### PR TITLE
feat: Add one-command deployment scripts for Linux and Windows

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,6 +26,29 @@ soroban network add --global testnet \
   --network-passphrase "Test SDF Network ; September 2015"
 ```
 
+## Automated Deployment (Recommended)
+
+For convenience, use the provided deployment scripts which handle building, optimizing, deploying, and initializing the contract in one step.
+
+**Linux/macOS:**
+```bash
+./deploy.sh [network]
+# Example: ./deploy.sh testnet
+```
+
+**Windows (PowerShell):**
+```powershell
+.\deploy.ps1 -Network [network]
+# Example: .\deploy.ps1 -Network testnet
+```
+
+These scripts will automatically:
+1. Build and optimize the contract
+2. Create/fund a deployer identity (if needed)
+3. Deploy the contract and a mock USDC token
+4. Initialize the contract
+5. Save contract IDs to `.env.local`
+
 ## Build the Contract
 
 1. Navigate to the project directory:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,36 @@ cargo test
 
 ## Quick Start
 
+### Automated Deployment (Recommended)
+
+Run the deployment script to build, deploy, and initialize everything automatically:
+
+**Linux/macOS:**
+```bash
+chmod +x deploy.sh
+./deploy.sh
+# To deploy to a specific network (default: testnet):
+./deploy.sh mainnet
+```
+
+**Windows (PowerShell):**
+```powershell
+.\deploy.ps1
+# To deploy to a specific network (default: testnet):
+.\deploy.ps1 -Network mainnet
+```
+
+This will:
+- Build and optimize the contract
+- Create/fund a `deployer` identity
+- Deploy the contract and a mock USDC token
+- Initialize the contract
+- Save contract IDs to `.env.local`
+
+### Manual Setup
+
+If you prefer to run steps manually:
+
 ### 1. Build the Contract
 
 ```bash

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,98 @@
+# SwiftRemit Deployment Script for Windows (PowerShell)
+
+param (
+    [string]$Network = "testnet"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Configuration
+$Deployer = "deployer"
+$WasmPath = "target/wasm32-unknown-unknown/release/swiftremit.optimized.wasm"
+
+Write-Host "🚀 SwiftRemit Deployment Script" -ForegroundColor Cyan
+Write-Host "Network: $Network" -ForegroundColor Gray
+Write-Host "Deployer Identity: $Deployer" -ForegroundColor Gray
+
+# Check prerequisites
+if (-not (Get-Command soroban -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ Soroban CLI not found. Please install it first." -ForegroundColor Red
+    exit 1
+}
+
+# Setup Identity
+Write-Host "Checking identity..." -ForegroundColor Yellow
+try {
+    $Address = soroban keys address $Deployer 2>$null
+    if (-not $Address) {
+        throw "Identity not found"
+    }
+    Write-Host "Identity '$Deployer' found: $Address" -ForegroundColor Green
+} catch {
+    Write-Host "Creating new identity '$Deployer'..." -ForegroundColor Yellow
+    soroban keys generate --global $Deployer --network $Network
+    $Address = soroban keys address $Deployer
+}
+
+# Fund Identity (attempt on testnet/standalone, skip on mainnet)
+if ($Network -ne "mainnet") {
+    Write-Host "Funding identity (this may take a moment)..." -ForegroundColor Yellow
+    try {
+        soroban keys fund $Deployer --network $Network
+    } catch {
+        Write-Host "Funding warning: Request may have failed or account already funded (or network doesn't support funding)." -ForegroundColor DarkYellow
+    }
+}
+
+# Build and Optimize
+Write-Host "🔨 Building and Optimizing Contract..." -ForegroundColor Yellow
+cargo build --target wasm32-unknown-unknown --release
+soroban contract optimize --wasm target/wasm32-unknown-unknown/release/swiftremit.wasm
+
+if (-not (Test-Path $WasmPath)) {
+    Write-Host "❌ Build failed. $WasmPath not found." -ForegroundColor Red
+    exit 1
+}
+
+# Deploy Contract
+Write-Host "📤 Deploying Contract..." -ForegroundColor Yellow
+$ContractId = soroban contract deploy `
+  --wasm $WasmPath `
+  --source $Deployer `
+  --network $Network
+
+Write-Host "✅ Contract Deployed: $ContractId" -ForegroundColor Green
+
+# Deploy Mock USDC Token
+Write-Host "💰 Deploying Mock USDC Token..." -ForegroundColor Yellow
+$UsdcId = soroban contract asset deploy `
+  --asset "USDC:$Address" `
+  --source $Deployer `
+  --network $Network
+
+Write-Host "✅ USDC Token Deployed: $UsdcId" -ForegroundColor Green
+
+# Initialize Contract
+Write-Host "⚙️ Initializing Contract..." -ForegroundColor Yellow
+soroban contract invoke `
+  --id $ContractId `
+  --source $Deployer `
+  --network $Network `
+  -- `
+  initialize `
+  --admin $Address `
+  --usdc_token $UsdcId `
+  --fee_bps 250
+
+Write-Host ""
+Write-Host "🎉 Deployment Complete!" -ForegroundColor Cyan
+Write-Host "----------------------------------------" -ForegroundColor Gray
+Write-Host "Contract ID: $ContractId"
+Write-Host "USDC Token ID: $UsdcId"
+Write-Host "Admin Address: $Address"
+Write-Host "----------------------------------------" -ForegroundColor Gray
+
+# Save to .env.local file for frontend use
+$EnvContent = "NEXT_PUBLIC_CONTRACT_ID=$ContractId`nNEXT_PUBLIC_USDC_TOKEN_ADDRESS=$UsdcId"
+Set-Content -Path ".env.local" -Value $EnvContent
+Write-Host "IDs saved to .env.local" -ForegroundColor Green

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+# Configuration
+NETWORK=${1:-testnet}
+DEPLOYER="deployer"
+WASM_PATH="target/wasm32-unknown-unknown/release/swiftremit.optimized.wasm"
+
+echo "🚀 SwiftRemit Deployment Script"
+echo "Network: $NETWORK"
+echo "Deployer Identity: $DEPLOYER"
+
+# Check prerequisites
+if ! command -v soroban &> /dev/null; then
+    echo "❌ Soroban CLI not found. Please install it first."
+    exit 1
+fi
+
+# Setup Identity
+echo "Checking identity..."
+if ! soroban keys address $DEPLOYER > /dev/null 2>&1; then
+    echo "Creating new identity '$DEPLOYER'..."
+    soroban keys generate --global $DEPLOYER --network $NETWORK
+else
+    echo "Identity '$DEPLOYER' found."
+fi
+
+ADDRESS=$(soroban keys address $DEPLOYER)
+echo "Address: $ADDRESS"
+
+# Fund Identity (attempt on testnet/standalone, skip on mainnet)
+if [ "$NETWORK" != "mainnet" ]; then
+    echo "Funding identity (this may take a moment)..."
+    soroban keys fund $DEPLOYER --network $NETWORK || echo "Funding warning: Request may have failed or account already funded (or network doesn't support funding)."
+fi
+
+# Build and Optimize
+echo "🔨 Building and Optimizing Contract..."
+cargo build --target wasm32-unknown-unknown --release
+soroban contract optimize --wasm target/wasm32-unknown-unknown/release/swiftremit.wasm
+
+if [ ! -f "$WASM_PATH" ]; then
+    echo "❌ Build failed. $WASM_PATH not found."
+    exit 1
+fi
+
+# Deploy Contract
+echo "📤 Deploying Contract..."
+CONTRACT_ID=$(soroban contract deploy \
+  --wasm $WASM_PATH \
+  --source $DEPLOYER \
+  --network $NETWORK)
+
+echo "✅ Contract Deployed: $CONTRACT_ID"
+
+# Deploy Mock USDC Token
+echo "💰 Deploying Mock USDC Token..."
+USDC_ID=$(soroban contract asset deploy \
+  --asset "USDC:$ADDRESS" \
+  --source $DEPLOYER \
+  --network $NETWORK)
+
+echo "✅ USDC Token Deployed: $USDC_ID"
+
+# Initialize Contract
+echo "⚙️ Initializing Contract..."
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $DEPLOYER \
+  --network $NETWORK \
+  -- \
+  initialize \
+  --admin $ADDRESS \
+  --usdc_token $USDC_ID \
+  --fee_bps 250
+
+echo ""
+echo "🎉 Deployment Complete!"
+echo "----------------------------------------"
+echo "Contract ID: $CONTRACT_ID"
+echo "USDC Token ID: $USDC_ID"
+echo "Admin Address: $ADDRESS"
+echo "----------------------------------------"
+
+# Save to .env file for frontend use
+echo "NEXT_PUBLIC_CONTRACT_ID=$CONTRACT_ID" > .env.local
+echo "NEXT_PUBLIC_USDC_TOKEN_ADDRESS=$USDC_ID" >> .env.local
+echo "IDs saved to .env.local"


### PR DESCRIPTION
Sloved issues #18 

- Added deploy.sh for Linux/macOS
- Added deploy.ps1 for Windows
- Updated README.md with usage instructions
- Added Automated Deployment section to DEPLOYMENT.md
- Scripts support network selection argument (default: testnet)
- Scripts handle build, optimize, deploy, initialize, and env setup