### PR TITLE
refactor(storage): group storage keys into enums with comments

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,15 +2,47 @@ use soroban_sdk::{contracttype, Address, Env};
 
 use crate::{ContractError, Remittance};
 
+/// Storage keys for the SwiftRemit contract.
+/// 
+/// Storage Layout:
+/// - Instance storage: Contract-level configuration and state (Admin, UsdcToken, PlatformFeeBps, 
+///   RemittanceCounter, AccumulatedFees)
+/// - Persistent storage: Per-entity data that needs long-term retention (Remittance records, 
+///   AgentRegistered status)
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
+    // === Contract Configuration ===
+    // Core contract settings stored in instance storage
+    
+    /// Contract administrator address with privileged access
     Admin,
+    
+    /// USDC token contract address used for all remittance transactions
     UsdcToken,
+    
+    /// Platform fee in basis points (1 bps = 0.01%)
     PlatformFeeBps,
+    
+    // === Remittance Management ===
+    // Keys for tracking and storing remittance transactions
+    
+    /// Global counter for generating unique remittance IDs
     RemittanceCounter,
+    
+    /// Individual remittance record indexed by ID (persistent storage)
     Remittance(u64),
+    
+    // === Agent Management ===
+    // Keys for tracking registered agents
+    
+    /// Agent registration status indexed by agent address (persistent storage)
     AgentRegistered(Address),
+    
+    // === Fee Tracking ===
+    // Keys for managing platform fees
+    
+    /// Total accumulated platform fees awaiting withdrawal
     AccumulatedFees,
 }
 


### PR DESCRIPTION
Refactors storage keys into clearly defined enums/structs with explanatory comments. 

No behavior changes; storage access remains fully compatible. Code is now easier to understand.

Close #17