### PR TITLE
Feature/store fx rate at transaction

### DIFF
--- a/backend/FX_RATE_STORAGE.md
+++ b/backend/FX_RATE_STORAGE.md
@@ -1,0 +1,179 @@
+# FX Rate Storage
+
+## Overview
+
+The FX rate storage feature captures and stores the exchange rate used at transaction time, ensuring immutability and auditability for all remittance transactions.
+
+## Features
+
+✅ **Rate Storage**: Save FX rate, provider, and timestamp at transaction time  
+✅ **Immutability**: Prevent recalculation during settlement using UNIQUE constraint  
+✅ **Auditability**: Full audit trail with timestamps and provider information  
+✅ **High Precision**: Support for up to 8 decimal places (DECIMAL(20, 8))
+
+## Database Schema
+
+```sql
+CREATE TABLE fx_rates (
+  id SERIAL PRIMARY KEY,
+  transaction_id VARCHAR(100) NOT NULL UNIQUE,
+  rate DECIMAL(20, 8) NOT NULL,
+  provider VARCHAR(100) NOT NULL,
+  timestamp TIMESTAMP NOT NULL,
+  from_currency VARCHAR(10) NOT NULL,
+  to_currency VARCHAR(10) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_fx_transaction ON fx_rates(transaction_id);
+CREATE INDEX idx_fx_timestamp ON fx_rates(timestamp);
+CREATE INDEX idx_fx_currencies ON fx_rates(from_currency, to_currency);
+```
+
+## API Endpoints
+
+### Store FX Rate
+
+**POST** `/api/fx-rate`
+
+Store the FX rate used for a transaction.
+
+**Request Body:**
+```json
+{
+  "transactionId": "tx_12345",
+  "rate": 1.25,
+  "provider": "CurrencyAPI",
+  "fromCurrency": "USD",
+  "toCurrency": "EUR"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "FX rate stored successfully"
+}
+```
+
+**Validation:**
+- `transactionId`: Required, string
+- `rate`: Required, positive number
+- `provider`: Required, string
+- `fromCurrency`: Required, string
+- `toCurrency`: Required, string
+
+### Get FX Rate
+
+**GET** `/api/fx-rate/:transactionId`
+
+Retrieve the FX rate for a specific transaction.
+
+**Response:**
+```json
+{
+  "id": 1,
+  "transaction_id": "tx_12345",
+  "rate": 1.25,
+  "provider": "CurrencyAPI",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "from_currency": "USD",
+  "to_currency": "EUR",
+  "created_at": "2024-01-15T10:30:05Z"
+}
+```
+
+**Error Response (404):**
+```json
+{
+  "error": "FX rate not found for this transaction"
+}
+```
+
+## Usage Example
+
+### Storing Rate at Transaction Time
+
+```typescript
+import { saveFxRate } from './database';
+
+// When creating a remittance transaction
+const transactionId = 'remittance_001';
+const currentRate = await fetchExchangeRate('USD', 'EUR');
+
+await saveFxRate({
+  transaction_id: transactionId,
+  rate: currentRate,
+  provider: 'CurrencyAPI',
+  timestamp: new Date(),
+  from_currency: 'USD',
+  to_currency: 'EUR',
+});
+```
+
+### Retrieving Rate During Settlement
+
+```typescript
+import { getFxRate } from './database';
+
+// During settlement, use stored rate (no recalculation)
+const storedRate = await getFxRate(transactionId);
+
+if (storedRate) {
+  const convertedAmount = amount * storedRate.rate;
+  // Use stored rate for settlement
+}
+```
+
+## Acceptance Criteria
+
+✅ **Save rate, provider, timestamp**: All three fields are stored atomically  
+✅ **Prevent recalculation during settlement**: UNIQUE constraint on transaction_id prevents updates  
+✅ **Ensure auditability**: Timestamps and provider information provide full audit trail
+
+## Immutability Guarantee
+
+The `UNIQUE(transaction_id)` constraint combined with `ON CONFLICT DO NOTHING` ensures that:
+
+1. Once an FX rate is stored for a transaction, it cannot be modified
+2. Subsequent attempts to store a rate for the same transaction are silently ignored
+3. Settlement always uses the original rate captured at transaction time
+
+## Testing
+
+Run tests with:
+
+```bash
+cd backend
+npm test fx-rate.test.ts
+```
+
+Tests cover:
+- Rate storage at transaction time
+- Immutability (prevention of recalculation)
+- Auditability (timestamp and provider tracking)
+- High precision rate handling
+- Error cases (non-existent transactions)
+
+## Security Considerations
+
+- **Input Validation**: All inputs are validated before storage
+- **Rate Limiting**: API endpoints are protected by rate limiting
+- **SQL Injection**: Parameterized queries prevent SQL injection
+- **Precision**: DECIMAL type prevents floating-point errors
+
+## Performance
+
+- **Indexes**: Optimized queries with indexes on transaction_id, timestamp, and currencies
+- **Single Write**: Atomic insert operation
+- **Fast Lookup**: O(1) lookup by transaction_id using primary index
+
+## Integration
+
+The FX rate storage integrates with:
+
+1. **Transaction Creation**: Store rate when remittance is created
+2. **Settlement**: Retrieve rate during payout confirmation
+3. **Audit Reports**: Query historical rates for compliance
+4. **Analytics**: Track rate trends over time

--- a/backend/src/__tests__/fx-rate.test.ts
+++ b/backend/src/__tests__/fx-rate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { saveFxRate, getFxRate, initDatabase, pool } from '../database';
+
+describe('FX Rate Storage', () => {
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should store FX rate at transaction time', async () => {
+    const fxRate = {
+      transaction_id: 'tx_test_001',
+      rate: 1.25,
+      provider: 'CurrencyAPI',
+      timestamp: new Date(),
+      from_currency: 'USD',
+      to_currency: 'EUR',
+    };
+
+    await saveFxRate(fxRate);
+
+    const stored = await getFxRate('tx_test_001');
+    expect(stored).not.toBeNull();
+    expect(stored?.rate).toBe(1.25);
+    expect(stored?.provider).toBe('CurrencyAPI');
+    expect(stored?.from_currency).toBe('USD');
+    expect(stored?.to_currency).toBe('EUR');
+  });
+
+  it('should prevent recalculation by storing immutable rate', async () => {
+    const fxRate = {
+      transaction_id: 'tx_test_002',
+      rate: 0.85,
+      provider: 'ExchangeRateAPI',
+      timestamp: new Date('2024-01-01T10:00:00Z'),
+      from_currency: 'EUR',
+      to_currency: 'GBP',
+    };
+
+    await saveFxRate(fxRate);
+
+    // Try to update with different rate (should be ignored due to UNIQUE constraint)
+    const updatedRate = {
+      ...fxRate,
+      rate: 0.90, // Different rate
+      timestamp: new Date('2024-01-02T10:00:00Z'), // Different timestamp
+    };
+
+    await saveFxRate(updatedRate);
+
+    // Verify original rate is preserved
+    const stored = await getFxRate('tx_test_002');
+    expect(stored?.rate).toBe(0.85); // Original rate preserved
+    expect(stored?.timestamp.toISOString()).toContain('2024-01-01'); // Original timestamp
+  });
+
+  it('should ensure auditability with timestamp and provider', async () => {
+    const timestamp = new Date('2024-06-15T14:30:00Z');
+    const fxRate = {
+      transaction_id: 'tx_test_003',
+      rate: 110.50,
+      provider: 'ForexAPI',
+      timestamp,
+      from_currency: 'USD',
+      to_currency: 'JPY',
+    };
+
+    await saveFxRate(fxRate);
+
+    const stored = await getFxRate('tx_test_003');
+    expect(stored).not.toBeNull();
+    expect(stored?.provider).toBe('ForexAPI');
+    expect(stored?.timestamp.toISOString()).toBe(timestamp.toISOString());
+    expect(stored?.created_at).toBeDefined(); // Audit trail
+  });
+
+  it('should return null for non-existent transaction', async () => {
+    const stored = await getFxRate('tx_nonexistent');
+    expect(stored).toBeNull();
+  });
+
+  it('should handle high precision rates', async () => {
+    const fxRate = {
+      transaction_id: 'tx_test_004',
+      rate: 1.23456789,
+      provider: 'PrecisionAPI',
+      timestamp: new Date(),
+      from_currency: 'BTC',
+      to_currency: 'USD',
+    };
+
+    await saveFxRate(fxRate);
+
+    const stored = await getFxRate('tx_test_004');
+    expect(stored?.rate).toBeCloseTo(1.23456789, 8);
+  });
+});

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -33,3 +33,23 @@ export interface VerificationResult {
   trustline_count: number;
   has_toml: boolean;
 }
+
+export interface FxRate {
+  transaction_id: string;
+  rate: number;
+  provider: string;
+  timestamp: Date;
+  from_currency: string;
+  to_currency: string;
+}
+
+export interface FxRateRecord {
+  id: number;
+  transaction_id: string;
+  rate: number;
+  provider: string;
+  timestamp: Date;
+  from_currency: string;
+  to_currency: string;
+  created_at: Date;
+}


### PR DESCRIPTION
Closes #78

---

feat: store FX rate at transaction time for auditability

- Save FX rate used during transaction
- Store rate provider and timestamp
- Prevent FX recalculation during settlement
- Ensure transaction auditability

#78 