### PR TITLE
chore: remove duplicate pub use statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,6 @@ pub use transaction_controller::*;
 pub use transitions::*;
 pub use types::*;
 pub use validation::*;
-pub use transaction_controller::*;
-pub use types::*;
-pub use validation::*;
 
 /// Maximum number of remittances that can be settled in a single batch
 const MAX_BATCH_SIZE: u32 = 100;


### PR DESCRIPTION
Closes #214

## Summary
- remove the duplicate `pub use` re-exports for `transaction_controller`, `types`, and `validation` from `src/lib.rs`

## Verification
- confirmed each of the three `pub use` lines now appears exactly once in `src/lib.rs`
- `cargo build` is currently blocked by many pre-existing compile errors elsewhere in the repo (for example duplicate definitions in `src/errors.rs` and unresolved type issues in `src/abuse_protection.rs`), unrelated to this cleanup