### PR TITLE
chore: add .env.example validation script to CI (#207)

### DIFF
--- a/.github/workflows/env-example-validation.yml
+++ b/.github/workflows/env-example-validation.yml
@@ -1,0 +1,29 @@
+name: Validate .env.example Files
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/.env.example'
+      - 'scripts/validate-env-examples.js'
+      - 'backend/src/**'
+      - 'api/src/**'
+      - 'frontend/src/**'
+      - 'examples/**/*.js'
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Check .env.example sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Run validation
+        run: node scripts/validate-env-examples.js

--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for complete deployment instructions.
 
 For production readiness assessment, see [PRODUCTION_READINESS_REPORT.md](PRODUCTION_READINESS_REPORT.md).
 
+## Environment Validation
+
+A script checks that every env variable consumed in source code is present in the corresponding `.env.example` file. CI fails automatically if any are missing.
+
+Run locally:
+
+```bash
+node scripts/validate-env-examples.js
+```
+
+Covers: root `.env.example`, `api/.env.example`, `backend/.env.example`, `frontend/.env.example`.
+
 ## Configuration
 
 SwiftRemit uses environment variables for configuration. This allows you to easily configure the system for different environments (local development, testnet, mainnet) without modifying code.

--- a/scripts/validate-env-examples.js
+++ b/scripts/validate-env-examples.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Validates that all env vars consumed in source code are present in the corresponding .env.example
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Map of [sourceGlob, envExamplePath, extractPattern]
+const CHECKS = [
+  {
+    name: 'root (examples/)',
+    sources: ['examples/**/*.js'],
+    envExample: '.env.example',
+    pattern: /process\.env\.([A-Z][A-Z0-9_]+)/g,
+    // Exclude dotenv internals and dynamic vars
+    ignore: new Set([
+      'DOTENV_CONFIG_DEBUG', 'DOTENV_CONFIG_DOTENV_KEY', 'DOTENV_CONFIG_ENCODING',
+      'DOTENV_CONFIG_OVERRIDE', 'DOTENV_CONFIG_PATH', 'DOTENV_CONFIG_QUIET',
+      'DOTENV_KEY', 'NODE_DEBUG', 'NODE_ENV', 'DEBUG', 'LOG_LEVEL',
+      'REQUEST_ID', 'NEW_CONTRACT_ID', 'OLD_CONTRACT_ID', 'CONTRACT_ID',
+    ]),
+  },
+  {
+    name: 'api/',
+    sources: ['api/src/**/*.ts'],
+    envExample: 'api/.env.example',
+    pattern: /process\.env\.([A-Z][A-Z0-9_]+)/g,
+    ignore: new Set(['NODE_ENV']),
+  },
+  {
+    name: 'backend/',
+    sources: ['backend/src/**/*.ts'],
+    envExample: 'backend/.env.example',
+    pattern: /process\.env\.([A-Z][A-Z0-9_]+)/g,
+    ignore: new Set(['NODE_ENV']),
+  },
+  {
+    name: 'frontend/',
+    sources: ['frontend/src/**/*.{ts,tsx,js,jsx}'],
+    envExample: 'frontend/.env.example',
+    pattern: /import\.meta\.env\.(VITE_[A-Z0-9_]+)/g,
+    ignore: new Set(),
+  },
+];
+
+function glob(pattern) {
+  const { execSync } = require('child_process');
+  try {
+    return execSync(`find ${ROOT} -type f -path "${ROOT}/${pattern.replace(/\*\*/g, '*').replace(/\*/g, '*')}" 2>/dev/null`, { encoding: 'utf8' })
+      .split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function findFiles(pattern) {
+  const { execSync } = require('child_process');
+  const cmd = `find ${ROOT}/${pattern.split('/')[0]} -type f -name "*.${pattern.split('.').pop()}" 2>/dev/null`;
+  // Use a proper glob approach
+  try {
+    const base = pattern.split('/**')[0];
+    const ext = pattern.match(/\{([^}]+)\}/) 
+      ? pattern.match(/\{([^}]+)\}/)[1].split(',').map(e => `-name "*.${e}"`).join(' -o ')
+      : `-name "*.${pattern.split('.').pop()}"`;
+    const result = execSync(
+      `find ${ROOT}/${base} -type f \\( ${ext} \\) 2>/dev/null`,
+      { encoding: 'utf8' }
+    );
+    return result.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function extractFromExample(envExamplePath) {
+  const fullPath = path.join(ROOT, envExamplePath);
+  if (!fs.existsSync(fullPath)) return new Set();
+  return new Set(
+    fs.readFileSync(fullPath, 'utf8')
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l && !l.startsWith('#'))
+      .map(l => l.split('=')[0].trim())
+  );
+}
+
+function extractFromSources(sources, pattern) {
+  const vars = new Set();
+  for (const src of sources) {
+    const files = findFiles(src);
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      let match;
+      const re = new RegExp(pattern.source, pattern.flags);
+      while ((match = re.exec(content)) !== null) {
+        vars.add(match[1]);
+      }
+    }
+  }
+  return vars;
+}
+
+let failed = false;
+
+for (const check of CHECKS) {
+  const defined = extractFromExample(check.envExample);
+  const used = extractFromSources(check.sources, check.pattern);
+
+  const missing = [...used].filter(v => !check.ignore.has(v) && !defined.has(v));
+
+  if (missing.length > 0) {
+    console.error(`\n❌ [${check.name}] Missing in ${check.envExample}:`);
+    missing.forEach(v => console.error(`   - ${v}`));
+    failed = true;
+  } else {
+    console.log(`✅ [${check.name}] ${check.envExample} is in sync`);
+  }
+}
+
+if (failed) {
+  console.error('\nValidation failed. Add missing variables to the corresponding .env.example files.');
+  process.exit(1);
+} else {
+  console.log('\nAll .env.example files are in sync with source code.');
+}


### PR DESCRIPTION
- Add scripts/validate-env-examples.js to detect env vars used in source but missing from the corresponding .env.example files
- Wire into CI via .github/workflows/env-example-validation.yml, runs on every PR targeting main
- README already documents local usage via `node scripts/validate-env-examples.js`

Closes #207