### PR TITLE
fix: remove debug-log from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["debug-log"]
+default = []
 debug-log = []
 benchmarks = []
 legacy-tests = []

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -56,6 +56,7 @@ if ($Network -ne "mainnet") {
 
 # Build and Optimize
 Write-Host "🔨 Building and Optimizing Contract..." -ForegroundColor Yellow
+# Note: To enable debug logging for local testing, add: --features debug-log
 cargo build --target wasm32-unknown-unknown --release
 soroban contract optimize --wasm target/wasm32-unknown-unknown/release/swiftremit.wasm
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,6 +48,7 @@ fi
 
 # Build and Optimize
 echo "🔨 Building and Optimizing Contract..."
+# Note: To enable debug logging for local testing, add: --features debug-log
 cargo build --target wasm32-unknown-unknown --release
 soroban contract optimize --wasm target/wasm32-unknown-unknown/release/swiftremit.wasm
 


### PR DESCRIPTION
The debug-log feature was enabled by default in production builds, which increases contract size and may leak internal state via events.

Changes:
- Remove debug-log from default features in Cargo.toml
- Add documentation to deploy.sh and deploy.ps1 explaining how to enable debug logging for local testing

Closes #223 