### PR TITLE
feat: add optional memo field to remittance flow

### DIFF
--- a/backend/migrations/add_memo_to_remittances.sql
+++ b/backend/migrations/add_memo_to_remittances.sql
@@ -1,0 +1,9 @@
+-- Migration: add_memo_to_remittances.sql
+-- Adds an optional memo field to the transactions table for reconciliation purposes.
+-- Backward compatible: existing rows will have memo = NULL.
+
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS memo VARCHAR(100);
+
+COMMENT ON COLUMN transactions.memo IS
+  'Optional sender-supplied reference note (e.g. invoice number) for reconciliation. Max 100 chars, plain text only.';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,18 +15,26 @@
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.1.0",
+        "js-yaml": "^4.1.0",
         "node-cache": "^5.1.2",
         "node-cron": "^3.0.3",
         "pg": "^8.11.0",
-        "toml": "^3.0.0"
+        "swagger-ui-express": "^5.0.0",
+        "toml": "^3.0.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@apidevtools/swagger-cli": "^4.0.4",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.10.0",
+        "@types/node-cache": "^4.2.5",
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.10.9",
         "@types/supertest": "^7.2.0",
+        "@types/swagger-ui-express": "^4.1.6",
+        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
         "@typescript-eslint/parser": "^6.15.0",
         "eslint": "^8.56.0",
@@ -36,6 +44,143 @@
         "typescript": "^5.3.3",
         "vitest": "^1.0.4"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-cli": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
+      "integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
+      "deprecated": "This package has been abandoned. Please switch to using the actively maintained @redocly/cli",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^10.0.1",
+        "chalk": "^4.1.0",
+        "js-yaml": "^3.14.0",
+        "yargs": "^15.4.1"
+      },
+      "bin": {
+        "swagger-cli": "bin/swagger-cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-cli/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@apidevtools/swagger-cli/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -648,6 +793,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1059,6 +1211,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1182,6 +1341,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1211,6 +1377,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-cache": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node-cache/-/node-cache-4.2.5.tgz",
+      "integrity": "sha512-faK2Owokboz53g8ooq2dw3iDJ6/HMTCIa2RvMte5WMTiABy+wA558K+iuyRtlR67Un5q9gEKysSDtqZYbSa0Pg==",
+      "deprecated": "This is a stub types definition. node-cache provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-cache": "*"
       }
     },
     "node_modules/@types/node-cron": {
@@ -1309,6 +1486,24 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -1714,7 +1909,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -2023,10 +2217,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2080,6 +2291,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "node_modules/clone": {
@@ -2240,6 +2463,16 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -2382,6 +2615,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2626,6 +2866,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -2882,6 +3136,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3106,6 +3377,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
@@ -3514,6 +3795,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3599,7 +3890,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3927,6 +4217,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -4015,6 +4314,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4063,6 +4370,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parent-module": {
@@ -4527,6 +4844,33 @@
         "bare": ">=1.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4737,6 +5081,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -4934,6 +5285,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4956,6 +5314,21 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -5079,6 +5452,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/text-table": {
@@ -5322,9 +5719,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -5934,6 +6335,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -5982,6 +6390,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5996,6 +6419,106 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/backend/src/__tests__/memo.test.ts
+++ b/backend/src/__tests__/memo.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the optional memo field on remittance creation.
+ *
+ * Covers:
+ * - Remittance with memo saves and returns correctly
+ * - Remittance without memo works as before (backward compat)
+ * - Memo exceeding 100 chars is rejected with 400
+ * - Memo is sanitized before storage
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+// ── mock pool ──────────────────────────────────────────────────────────────
+const { mockPool, insertedRows } = vi.hoisted(() => {
+  const insertedRows: any[] = [];
+
+  const mockPool = {
+    query: vi.fn(async (sql: string, params: any[]) => {
+      const s = sql.toUpperCase();
+      if (s.includes('INSERT INTO TRANSACTIONS')) {
+        const row = {
+          transaction_id: params[0],
+          anchor_id: params[1],
+          amount_in: params[2],
+          memo: params[3],
+          status: 'pending_user_transfer_start',
+          created_at: new Date().toISOString(),
+        };
+        insertedRows.push(row);
+        return { rows: [row], rowCount: 1 };
+      }
+      if (s.includes('SELECT') && s.includes('FROM TRANSACTIONS')) {
+        const found = insertedRows.find((r) => r.transaction_id === params[0]);
+        return { rows: found ? [found] : [], rowCount: found ? 1 : 0 };
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  };
+
+  return { mockPool, insertedRows };
+});
+
+vi.mock('../database', () => ({
+  getPool: () => mockPool,
+  getAssetVerification: vi.fn(),
+  saveAssetVerification: vi.fn(),
+  reportSuspiciousAsset: vi.fn(),
+  getVerifiedAssets: vi.fn(),
+  saveFxRate: vi.fn(),
+  getFxRate: vi.fn(),
+  saveAnchorKycConfig: vi.fn(),
+  getUserKycStatus: vi.fn(),
+  saveUserKycStatus: vi.fn(),
+  saveAssetReport: vi.fn(),
+  getActiveWebhookSubscribers: vi.fn().mockResolvedValue([]),
+  getPendingWebhookDeliveries: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../stellar', () => ({
+  storeVerificationOnChain: vi.fn(),
+  simulateSettlement: vi.fn(),
+}));
+
+vi.mock('../metrics', () => ({
+  getMetricsService: () => ({ getMetrics: vi.fn().mockResolvedValue('') }),
+}));
+
+vi.mock('../fx-rate-cache', () => ({
+  getFxRateCache: () => ({ getCurrentRate: vi.fn() }),
+}));
+
+vi.mock('../kyc-upsert-service', () => ({
+  KycUpsertService: vi.fn().mockImplementation(() => ({
+    getStatusForUser: vi.fn(),
+  })),
+}));
+
+vi.mock('../transfer-guard', () => ({
+  createTransferGuard: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../sep24-service', () => ({
+  Sep24Service: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn(),
+    initiateFlow: vi.fn(),
+    getTransactionStatus: vi.fn(),
+  })),
+  Sep24ConfigError: class Sep24ConfigError extends Error {},
+  Sep24AnchorError: class Sep24AnchorError extends Error {},
+}));
+
+import app from '../api';
+
+const AUTH_HEADER = { 'x-user-id': 'user-test-1' };
+
+const BASE_BODY = {
+  sender: 'GSENDERADDRESS000000000000000000000000000000000000000000',
+  agent: 'anchor-test',
+  amount: '100.00',
+};
+
+beforeEach(() => {
+  insertedRows.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('POST /api/remittance — memo field', () => {
+  it('creates remittance with memo and returns it in the response', async () => {
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: 'Invoice #1234' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.remittance.memo).toBe('Invoice #1234');
+  });
+
+  it('creates remittance without memo (backward compat)', async () => {
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send(BASE_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.remittance.memo).toBeNull();
+  });
+
+  it('creates remittance with empty memo string (treated as no memo)', async () => {
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: '' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.remittance.memo).toBeNull();
+  });
+
+  it('rejects memo exceeding 100 characters with 400', async () => {
+    const longMemo = 'A'.repeat(101);
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: longMemo });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/100/);
+  });
+
+  it('accepts memo of exactly 100 characters', async () => {
+    const exactMemo = 'B'.repeat(100);
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: exactMemo });
+
+    expect(res.status).toBe(201);
+    expect(res.body.remittance.memo).toBe(exactMemo);
+  });
+
+  it('sanitizes memo before storage (strips HTML tags)', async () => {
+    const res = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: '<script>alert(1)</script>Invoice #99' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.remittance.memo).not.toContain('<script>');
+    expect(res.body.remittance.memo).toContain('Invoice #99');
+  });
+});
+
+describe('GET /api/remittance/:id — memo field', () => {
+  it('returns memo on the remittance detail response', async () => {
+    // Create first
+    const createRes = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send({ ...BASE_BODY, memo: 'REF-2024-001' });
+
+    const { remittance_id } = createRes.body.remittance;
+
+    const getRes = await request(app).get(`/api/remittance/${remittance_id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.memo).toBe('REF-2024-001');
+  });
+
+  it('returns null memo when none was set', async () => {
+    const createRes = await request(app)
+      .post('/api/remittance')
+      .set(AUTH_HEADER)
+      .send(BASE_BODY);
+
+    const { remittance_id } = createRes.body.remittance;
+
+    const getRes = await request(app).get(`/api/remittance/${remittance_id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.memo).toBeNull();
+  });
+});

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -24,6 +24,8 @@ import { createTransferGuard, AuthenticatedRequest } from './transfer-guard';
 import { getFxRateCache } from './fx-rate-cache';
 import { correlationIdMiddleware, createLogger } from './correlation-id';
 import { getMetricsService } from './metrics';
+import { sanitizeInput } from './sanitizer';
+import docsRouter from './routes/docs';
 
 const app = express();
 const fxRateCache = getFxRateCache();
@@ -40,7 +42,6 @@ app.use(express.json());
 // Correlation ID middleware
 app.use(correlationIdMiddleware);
 
-const pool = getPool();
 const kycUpsertService = new KycUpsertService(pool);
 const transferGuard = createTransferGuard(kycUpsertService);
 
@@ -572,6 +573,92 @@ app.get('/api/kyc/approved/:userId', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error checking KYC approval:', error);
     res.status(500).json({ error: 'Failed to check KYC approval' });
+  }
+});
+
+// Create remittance
+app.post('/api/remittance', authMiddleware, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { sender, agent, amount, fee, expiry, memo } = req.body;
+
+    if (!sender || typeof sender !== 'string') {
+      return res.status(400).json({ error: 'Invalid or missing sender' });
+    }
+    if (!agent || typeof agent !== 'string') {
+      return res.status(400).json({ error: 'Invalid or missing agent' });
+    }
+    if (!amount || typeof amount !== 'string' || isNaN(parseFloat(amount)) || parseFloat(amount) <= 0) {
+      return res.status(400).json({ error: 'Invalid or missing amount' });
+    }
+
+    // Validate memo — optional, max 100 chars, plain text only
+    let sanitizedMemo: string | undefined;
+    if (memo !== undefined && memo !== null && memo !== '') {
+      if (typeof memo !== 'string') {
+        return res.status(400).json({ error: 'memo must be a string' });
+      }
+      if (memo.length > 100) {
+        return res.status(400).json({ error: 'memo must not exceed 100 characters' });
+      }
+      sanitizedMemo = sanitizeInput(memo);
+    }
+
+    const remittanceId = `rem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    await pool.query(
+      `INSERT INTO transactions
+         (transaction_id, anchor_id, kind, status, amount_in, memo, created_at, updated_at)
+       VALUES ($1, $2, 'withdrawal', 'pending_user_transfer_start', $3, $4, NOW(), NOW())`,
+      [remittanceId, agent, amount, sanitizedMemo ?? null]
+    );
+
+    return res.status(201).json({
+      success: true,
+      remittance: {
+        remittance_id: remittanceId,
+        sender,
+        agent,
+        amount,
+        fee: fee ?? null,
+        expiry: expiry ?? null,
+        memo: sanitizedMemo ?? null,
+        status: 'pending_user_transfer_start',
+      },
+    });
+  } catch (error) {
+    logger.error('Error creating remittance', error);
+    return res.status(500).json({ error: 'Failed to create remittance' });
+  }
+});
+
+// Get remittance by ID
+app.get('/api/remittance/:remittanceId', async (req: Request, res: Response) => {
+  try {
+    const { remittanceId } = req.params;
+
+    const result = await pool.query(
+      `SELECT transaction_id, anchor_id, status, amount_in, memo, created_at, updated_at
+         FROM transactions WHERE transaction_id = $1`,
+      [remittanceId]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Remittance not found' });
+    }
+
+    const row = result.rows[0];
+    return res.json({
+      remittance_id: row.transaction_id,
+      agent: row.anchor_id,
+      status: row.status,
+      amount: row.amount_in,
+      memo: row.memo ?? null,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    });
+  } catch (error) {
+    logger.error('Error fetching remittance', error);
+    return res.status(500).json({ error: 'Failed to fetch remittance' });
   }
 });
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -111,6 +111,30 @@ export interface RemittanceCreatedWebhookPayload {
   amount: string;
   fee: string;
   expiry: string;
+  memo?: string;
+}
+
+/** Remittance creation request body */
+export interface CreateRemittanceRequest {
+  sender: string;
+  agent: string;
+  amount: string;
+  fee?: string;
+  expiry?: string;
+  memo?: string;
+}
+
+/** Remittance record as returned by the API */
+export interface RemittanceRecord {
+  remittance_id: string;
+  sender: string;
+  agent: string;
+  amount: string;
+  fee?: string;
+  expiry?: string;
+  memo?: string;
+  status: string;
+  created_at: string;
 }
 
 export interface WebhookSubscriber {

--- a/frontend/src/components/CreateRemittance.jsx
+++ b/frontend/src/components/CreateRemittance.jsx
@@ -5,6 +5,7 @@ import * as StellarSdk from '@stellar/stellar-sdk'
 export default function CreateRemittance({ walletAddress, contractId }) {
   const [agentAddress, setAgentAddress] = useState('')
   const [amount, setAmount] = useState('')
+  const [memo, setMemo] = useState('')
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState(null)
   const [error, setError] = useState(null)
@@ -30,12 +31,14 @@ export default function CreateRemittance({ walletAddress, contractId }) {
         message: 'Remittance created successfully!',
         id: Math.floor(Math.random() * 1000), // Mock ID
         amount: amount,
-        agent: agentAddress
+        agent: agentAddress,
+        memo: memo || null,
       })
 
       // Reset form
       setAgentAddress('')
       setAmount('')
+      setMemo('')
     } catch (err) {
       setError(err.message || 'Failed to create remittance')
     } finally {
@@ -71,6 +74,20 @@ export default function CreateRemittance({ walletAddress, contractId }) {
           />
         </div>
 
+        <div className="form-group">
+          <label>
+            Memo <span style={{ fontWeight: 'normal', color: '#888' }}>(optional)</span>:
+          </label>
+          <input
+            type="text"
+            value={memo}
+            onChange={(e) => setMemo(e.target.value.slice(0, 100))}
+            placeholder="e.g. Invoice #1234"
+            maxLength={100}
+          />
+          <small style={{ color: '#888' }}>{memo.length}/100</small>
+        </div>
+
         <button type="submit" disabled={loading} className="btn-primary">
           {loading ? 'Creating...' : 'Create Remittance'}
         </button>
@@ -80,6 +97,7 @@ export default function CreateRemittance({ walletAddress, contractId }) {
         <div className="success">
           <p>{result.message}</p>
           <p>Remittance ID: {result.id}</p>
+          {result.memo && <p>Memo: {result.memo}</p>}
         </div>
       )}
 

--- a/frontend/src/components/RemittanceList.jsx
+++ b/frontend/src/components/RemittanceList.jsx
@@ -15,7 +15,8 @@ export default function RemittanceList({ walletAddress, contractId }) {
           agent: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
           amount: 100.00,
           fee: 2.50,
-          status: 'Pending'
+          status: 'Pending',
+          memo: null,
         }
       ])
     }
@@ -54,6 +55,7 @@ export default function RemittanceList({ walletAddress, contractId }) {
                 <th>Amount</th>
                 <th>Fee</th>
                 <th>Status</th>
+                <th>Memo</th>
               </tr>
             </thead>
             <tbody>
@@ -71,6 +73,7 @@ export default function RemittanceList({ walletAddress, contractId }) {
                       {r.status}
                     </span>
                   </td>
+                  <td>{r.memo || <span style={{ color: '#aaa' }}>—</span>}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/components/SendMoneyFlow.tsx
+++ b/frontend/src/components/SendMoneyFlow.tsx
@@ -7,6 +7,7 @@ interface ConfirmPayload {
   amount: number;
   asset: string;
   recipient: string;
+  memo?: string;
 }
 
 interface SendMoneyFlowProps {
@@ -37,6 +38,7 @@ export const SendMoneyFlow: React.FC<SendMoneyFlowProps> = ({
   const [amount, setAmount] = useState('');
   const [asset, setAsset] = useState('');
   const [recipient, setRecipient] = useState('');
+  const [memo, setMemo] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
@@ -88,7 +90,12 @@ export const SendMoneyFlow: React.FC<SendMoneyFlowProps> = ({
     setIsSubmitting(true);
 
     try {
-      const payload = { amount: parsedAmount, asset, recipient: recipient.trim() };
+      const payload: ConfirmPayload = {
+        amount: parsedAmount,
+        asset,
+        recipient: recipient.trim(),
+        ...(memo.trim() ? { memo: memo.trim() } : {}),
+      };
 
       if (onConfirm) {
         await onConfirm(payload);
@@ -145,16 +152,33 @@ export const SendMoneyFlow: React.FC<SendMoneyFlowProps> = ({
 
     if (step === 3) {
       return (
-        <label className="flow-field" htmlFor="recipient">
-          <span>Recipient</span>
-          <input
-            id="recipient"
-            type="text"
-            value={recipient}
-            onChange={(event) => setRecipient(event.target.value)}
-            placeholder="G..."
-          />
-        </label>
+        <>
+          <label className="flow-field" htmlFor="recipient">
+            <span>Recipient</span>
+            <input
+              id="recipient"
+              type="text"
+              value={recipient}
+              onChange={(event) => setRecipient(event.target.value)}
+              placeholder="G..."
+            />
+          </label>
+          <label className="flow-field" htmlFor="memo">
+            <span>Memo <span className="flow-field-optional">(optional)</span></span>
+            <input
+              id="memo"
+              type="text"
+              value={memo}
+              onChange={(event) => setMemo(event.target.value.slice(0, 100))}
+              placeholder="e.g. Invoice #1234"
+              maxLength={100}
+              aria-describedby="memo-count"
+            />
+            <span id="memo-count" className="flow-char-count" aria-live="polite">
+              {memo.length}/100
+            </span>
+          </label>
+        </>
       );
     }
 
@@ -173,6 +197,12 @@ export const SendMoneyFlow: React.FC<SendMoneyFlowProps> = ({
             <dt>Recipient</dt>
             <dd>{recipient || '-'}</dd>
           </div>
+          {memo.trim() && (
+            <div>
+              <dt>Memo</dt>
+              <dd>{memo.trim()}</dd>
+            </div>
+          )}
         </dl>
       );
     }

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -11,6 +11,7 @@ export interface TransactionHistoryItem {
   recipient: string;
   status: TransactionProgressStatus;
   timestamp: string;
+  memo?: string;
   details?: Record<string, string | number>;
 }
 
@@ -188,6 +189,12 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                           <tr className="history-details-row">
                             <td colSpan={6}>
                               <dl className="history-details">
+                                {transaction.memo && (
+                                  <div key={`${transaction.id}-memo`}>
+                                    <dt>Memo</dt>
+                                    <dd>{transaction.memo}</dd>
+                                  </div>
+                                )}
                                 {Object.entries(transaction.details || {}).map(([key, value]) => (
                                   <div key={`${transaction.id}-${key}`}>
                                     <dt>{key}</dt>
@@ -242,6 +249,12 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                     </button>
                     {isExpanded && (
                       <dl className="history-details">
+                        {transaction.memo && (
+                          <div key={`${transaction.id}-memo`}>
+                            <dt>Memo</dt>
+                            <dd>{transaction.memo}</dd>
+                          </div>
+                        )}
                         {Object.entries(transaction.details || {}).map(([key, value]) => (
                           <div key={`${transaction.id}-${key}`}>
                             <dt>{key}</dt>

--- a/frontend/src/components/__tests__/SendMoneyFlowMemo.test.tsx
+++ b/frontend/src/components/__tests__/SendMoneyFlowMemo.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for the optional memo field in SendMoneyFlow.
+ *
+ * Covers:
+ * - Memo input renders on step 3 with correct placeholder
+ * - Character count updates as user types
+ * - Memo is included in onConfirm payload when provided
+ * - Memo is absent from payload when left empty
+ * - Memo is shown in review summary when provided
+ * - Memo is hidden from review summary when empty
+ * - Submission is not blocked when memo is empty
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { SendMoneyFlow } from '../SendMoneyFlow';
+
+const VALID_RECIPIENT = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** Advance to step 3 (recipient + memo step) */
+function advanceToStep3() {
+  render(<SendMoneyFlow />);
+  // Step 1 – amount
+  fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '50' } });
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+  // Step 2 – asset
+  fireEvent.change(screen.getByLabelText(/asset/i), { target: { value: 'USDC' } });
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+}
+
+/** Advance through all steps to confirmation, optionally setting a memo */
+async function submitFlow(memo?: string) {
+  const onConfirm = vi.fn().mockResolvedValueOnce(undefined);
+  render(<SendMoneyFlow onConfirm={onConfirm} />);
+
+  fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '100' } });
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+  fireEvent.change(screen.getByLabelText(/asset/i), { target: { value: 'USDC' } });
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+  fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: VALID_RECIPIENT } });
+  if (memo !== undefined) {
+    fireEvent.change(screen.getByLabelText(/memo/i), { target: { value: memo } });
+  }
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+  // Step 4 – review
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+  // Step 5 – confirm
+  fireEvent.click(screen.getByRole('button', { name: /confirm transaction/i }));
+
+  await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+  return onConfirm;
+}
+
+describe('SendMoneyFlow – memo field', () => {
+  it('renders memo input on step 3', () => {
+    advanceToStep3();
+    expect(screen.getByLabelText(/memo/i)).toBeInTheDocument();
+  });
+
+  it('memo input has correct placeholder', () => {
+    advanceToStep3();
+    expect(screen.getByPlaceholderText(/invoice #1234/i)).toBeInTheDocument();
+  });
+
+  it('shows character count starting at 0/100', () => {
+    advanceToStep3();
+    expect(screen.getByText('0/100')).toBeInTheDocument();
+  });
+
+  it('updates character count as user types', () => {
+    advanceToStep3();
+    fireEvent.change(screen.getByLabelText(/memo/i), { target: { value: 'Hello' } });
+    expect(screen.getByText('5/100')).toBeInTheDocument();
+  });
+
+  it('does not allow more than 100 characters', () => {
+    advanceToStep3();
+    const over = 'A'.repeat(110);
+    fireEvent.change(screen.getByLabelText(/memo/i), { target: { value: over } });
+    const input = screen.getByLabelText(/memo/i) as HTMLInputElement;
+    // The component slices to 100
+    expect(input.value.length).toBeLessThanOrEqual(100);
+  });
+
+  it('does not block submission when memo is empty', async () => {
+    const onConfirm = await submitFlow('');
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('includes memo in payload when provided', async () => {
+    const onConfirm = await submitFlow('Invoice #42');
+    const [payload] = onConfirm.mock.calls[0];
+    expect(payload.memo).toBe('Invoice #42');
+  });
+
+  it('omits memo from payload when left empty', async () => {
+    const onConfirm = await submitFlow('');
+    const [payload] = onConfirm.mock.calls[0];
+    expect(payload.memo).toBeUndefined();
+  });
+
+  it('shows memo in review summary when provided', () => {
+    render(<SendMoneyFlow />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '50' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    fireEvent.change(screen.getByLabelText(/asset/i), { target: { value: 'USDC' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: VALID_RECIPIENT } });
+    fireEvent.change(screen.getByLabelText(/memo/i), { target: { value: 'REF-001' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Now on step 4 (review)
+    expect(screen.getByText('REF-001')).toBeInTheDocument();
+  });
+
+  it('hides memo from review summary when empty', () => {
+    render(<SendMoneyFlow />);
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '50' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    fireEvent.change(screen.getByLabelText(/asset/i), { target: { value: 'USDC' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: VALID_RECIPIENT } });
+    // leave memo empty
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Step 4 – memo row should not appear
+    expect(screen.queryByText(/^memo$/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/TransactionHistoryMemo.test.tsx
+++ b/frontend/src/components/__tests__/TransactionHistoryMemo.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for memo display in TransactionHistory.
+ *
+ * Covers:
+ * - Memo appears in expanded table row when present
+ * - Memo appears in expanded card when present
+ * - Memo is hidden when not set
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TransactionHistory } from '../TransactionHistory';
+import type { TransactionHistoryItem } from '../TransactionHistory';
+
+afterEach(cleanup);
+
+const BASE_TX: TransactionHistoryItem = {
+  id: 'tx-1',
+  amount: 100,
+  asset: 'USDC',
+  recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA',
+  status: 'completed',
+  timestamp: '2024-01-01T00:00:00Z',
+};
+
+describe('TransactionHistory – memo display', () => {
+  it('shows memo in expanded table row when memo is present', () => {
+    const tx = { ...BASE_TX, memo: 'Invoice #1234' };
+    render(<TransactionHistory transactions={[tx]} defaultView="table" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+
+    expect(screen.getByText('Memo')).toBeInTheDocument();
+    expect(screen.getByText('Invoice #1234')).toBeInTheDocument();
+  });
+
+  it('does not show memo row in table when memo is absent', () => {
+    render(<TransactionHistory transactions={[BASE_TX]} defaultView="table" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+
+    expect(screen.queryByText('Memo')).not.toBeInTheDocument();
+  });
+
+  it('shows memo in expanded card when memo is present', () => {
+    const tx = { ...BASE_TX, memo: 'REF-2024-007' };
+    render(<TransactionHistory transactions={[tx]} defaultView="card" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand details/i }));
+
+    expect(screen.getByText('Memo')).toBeInTheDocument();
+    expect(screen.getByText('REF-2024-007')).toBeInTheDocument();
+  });
+
+  it('does not show memo row in card when memo is absent', () => {
+    render(<TransactionHistory transactions={[BASE_TX]} defaultView="card" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand details/i }));
+
+    expect(screen.queryByText('Memo')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Migration: add memo VARCHAR(100) to transactions (backward compatible)
- Backend: validate (max 100 chars), sanitize, store and return memo on POST /api/remittance and GET /api/remittance/:id
- Frontend: memo input with char count on SendMoneyFlow step 3, memo display in TransactionHistory, CreateRemittance, RemittanceList
- Tests: 8 backend + 9 frontend covering save, display, backward compat, 100-char rejection, and sanitization
- Fix: remove duplicate pool declaration, add missing docsRouter import





closes #373 