### PR TITLE
feat(governance): multi-admin / DAO governance support (#374)

### DIFF
--- a/kiro/specs/multi-admin-dao-governance/.config.kiro
+++ b/kiro/specs/multi-admin-dao-governance/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b703f7d0-2b3b-432b-ad5e-0bcde2efc796", "workflowType": "requirements-first", "specType": "feature"}

--- a/kiro/specs/multi-admin-dao-governance/design.md
+++ b/kiro/specs/multi-admin-dao-governance/design.md
@@ -1,0 +1,569 @@
+# Design Document: Multi-Admin / DAO Governance Support
+
+## Overview
+
+This design replaces SwiftRemit's single-admin model with a multi-signature governance
+system built directly into the existing Soroban contract. The governance module introduces
+a proposal lifecycle (create → vote → execute) that gates all privileged operations —
+fee updates, agent management, and admin set changes — behind a configurable quorum of
+admin approvals and an optional timelock delay.
+
+The design builds on the existing `AdminRole` / `AdminCount` storage scaffolding and
+reuses the `Role::Admin` authorization primitive already present in `storage.rs`. It
+introduces a new `governance.rs` module and extends `storage.rs`, `errors.rs`,
+`events.rs`, and `types.rs` with the new data structures and error codes needed.
+
+### Key Design Decisions
+
+1. **Single-module governance**: All proposal logic lives in `src/governance.rs` to keep
+   the blast radius of changes small and auditable.
+2. **Monotonic proposal IDs**: A `ProposalCounter` instance-storage key provides
+   collision-free, replay-resistant IDs.
+3. **Typed action enum**: `ProposalAction` is a Soroban `contracttype` enum covering all
+   three action categories; this makes the storage layout explicit and avoids stringly-typed
+   dispatch.
+4. **Pending-proposal guards**: Fee and agent proposals carry a "one active at a time"
+   invariant enforced at proposal creation via dedicated storage flags.
+5. **Backward-compatible migration path**: The `DataKey::Admin` (Legacy_Admin) entry is
+   preserved and updated on the first admin-add execution, so existing read-only callers
+   continue to work without modification.
+6. **Reuse of circuit-breaker patterns**: The vote-recording pattern (`VoteFlag` keyed by
+   `(proposal_id, voter)`) mirrors the existing `UnpauseVote(u64, Address)` key, keeping
+   the storage layout consistent.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Contract Entry Points (lib.rs)"
+        P[propose]
+        V[vote]
+        E[execute]
+        EX[expire_proposal]
+        MG[migrate_to_governance]
+        GP[get_proposal]
+        GA[get_admins]
+        GQ[get_quorum]
+        GT[get_timelock]
+    end
+
+    subgraph "governance.rs"
+        DO_PROPOSE[do_propose]
+        DO_VOTE[do_vote]
+        DO_EXECUTE[do_execute]
+        DO_EXPIRE[do_expire]
+        DO_MIGRATE[do_migrate]
+    end
+
+    subgraph "Existing Modules"
+        STORAGE[storage.rs]
+        EVENTS[events.rs]
+        ERRORS[errors.rs]
+        TYPES[types.rs]
+        FEE[fee_management.rs]
+        LIB_AGENT[lib.rs register_agent / remove_agent]
+    end
+
+    P --> DO_PROPOSE
+    V --> DO_VOTE
+    E --> DO_EXECUTE
+    EX --> DO_EXPIRE
+    MG --> DO_MIGRATE
+
+    DO_PROPOSE --> STORAGE
+    DO_PROPOSE --> EVENTS
+    DO_VOTE --> STORAGE
+    DO_VOTE --> EVENTS
+    DO_EXECUTE --> STORAGE
+    DO_EXECUTE --> EVENTS
+    DO_EXECUTE --> FEE
+    DO_EXECUTE --> LIB_AGENT
+    DO_EXPIRE --> STORAGE
+    DO_EXPIRE --> EVENTS
+    DO_MIGRATE --> STORAGE
+```
+
+### Proposal Lifecycle State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : propose()
+    Pending --> Approved : vote count reaches quorum
+    Pending --> Expired : expire_proposal() after TTL
+    Approved --> Executed : execute() after timelock
+    Approved --> Expired : expire_proposal() after TTL
+    Executed --> [*]
+    Expired --> [*]
+```
+
+---
+
+## Components and Interfaces
+
+### New Module: `src/governance.rs`
+
+This module exposes five internal functions called from `lib.rs` entry points.
+
+```rust
+pub fn do_propose(
+    env: &Env,
+    proposer: &Address,
+    action: ProposalAction,
+) -> Result<u64, ContractError>;
+
+pub fn do_vote(
+    env: &Env,
+    voter: &Address,
+    proposal_id: u64,
+    approve: bool,
+) -> Result<(), ContractError>;
+
+pub fn do_execute(
+    env: &Env,
+    executor: &Address,
+    proposal_id: u64,
+) -> Result<(), ContractError>;
+
+pub fn do_expire(
+    env: &Env,
+    caller: &Address,
+    proposal_id: u64,
+) -> Result<(), ContractError>;
+
+pub fn do_migrate(
+    env: &Env,
+    caller: &Address,
+    quorum: u32,
+    timelock_seconds: u64,
+    proposal_ttl_seconds: u64,
+) -> Result<(), ContractError>;
+```
+
+### New `lib.rs` Entry Points
+
+```rust
+// Governance entry points added to SwiftRemitContract impl
+pub fn propose(env: Env, proposer: Address, action: ProposalAction) -> Result<u64, ContractError>;
+pub fn vote(env: Env, voter: Address, proposal_id: u64, approve: bool) -> Result<(), ContractError>;
+pub fn execute(env: Env, executor: Address, proposal_id: u64) -> Result<(), ContractError>;
+pub fn expire_proposal(env: Env, caller: Address, proposal_id: u64) -> Result<(), ContractError>;
+pub fn migrate_to_governance(
+    env: Env,
+    caller: Address,
+    quorum: u32,
+    timelock_seconds: u64,
+    proposal_ttl_seconds: u64,
+) -> Result<(), ContractError>;
+
+// Read-only governance queries
+pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, ContractError>;
+pub fn get_admins(env: Env) -> Vec<Address>;
+pub fn get_quorum(env: Env) -> u32;
+pub fn get_timelock_seconds(env: Env) -> u64;
+```
+
+### Modified Modules
+
+- **`src/types.rs`**: Add `ProposalAction`, `ProposalState`, `Proposal` types.
+- **`src/errors.rs`**: Add new error variants (see Data Models section).
+- **`src/events.rs`**: Add governance event emission functions.
+- **`src/storage.rs`**: Add new `DataKey` variants and accessor functions.
+
+---
+
+## Data Models
+
+### New Types (`src/types.rs`)
+
+```rust
+/// The action a proposal will execute if approved.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalAction {
+    UpdateFee(u32),                          // fee_bps
+    RegisterAgent(Address),
+    RemoveAgent(Address),
+    AddAdmin(Address),
+    RemoveAdmin(Address),
+    UpdateQuorum(u32),
+    UpdateTimelock(u64),                     // timelock_seconds
+}
+
+/// Lifecycle state of a governance proposal.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalState {
+    Pending,
+    Approved,
+    Executed,
+    Rejected,
+    Expired,
+}
+
+/// A governance proposal record stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    pub id: u64,
+    pub proposer: Address,
+    pub action: ProposalAction,
+    pub state: ProposalState,
+    pub created_at: u64,          // ledger timestamp
+    pub expiry: u64,              // created_at + proposal_ttl_seconds
+    pub approval_count: u32,
+    pub approval_timestamp: Option<u64>,  // set when state → Approved
+}
+```
+
+### New Storage Keys (`src/storage.rs` `DataKey` enum additions)
+
+```rust
+// Governance
+/// Monotonically increasing proposal ID counter (instance storage).
+GovernanceProposalCounter,
+
+/// Proposal record indexed by proposal_id (persistent storage).
+GovernanceProposal(u64),
+
+/// Vote flag: (proposal_id, voter_address) → bool (persistent storage).
+GovernanceVote(u64, Address),
+
+/// Configured quorum for governance proposals (instance storage).
+GovernanceQuorum,
+
+/// Timelock in seconds between approval and execution (instance storage).
+GovernanceTimelockSeconds,
+
+/// TTL in seconds for proposals before they expire (instance storage).
+GovernanceProposalTtl,
+
+/// Flag: a Fee_Update_Proposal is currently active (instance storage).
+ActiveFeeProposal,
+
+/// Flag: governance has been initialized via migrate_to_governance (instance storage).
+GovernanceInitialized,
+
+/// Ordered list of current admin addresses for iteration (instance storage).
+AdminList,
+```
+
+### New Error Variants (`src/errors.rs`)
+
+New variants are appended starting at the next available code (63+):
+
+```rust
+/// A proposal with this action type is already pending or approved.
+ProposalAlreadyPending = 63,
+
+/// The proposal was not found.
+ProposalNotFound = 64,
+
+/// The proposal is not in the required state for this operation.
+InvalidProposalState = 65,
+
+/// The governance timelock has not yet elapsed.
+TimelockNotElapsed = 66,
+
+/// The address is already an Admin.
+AlreadyAdmin = 67,
+
+/// Removing this admin would drop the count below the quorum.
+InsufficientAdmins = 68,
+
+/// The agent is already registered.
+AgentAlreadyRegistered = 69,
+
+/// Governance has already been initialized.
+GovernanceAlreadyInitialized = 70,
+```
+
+> Note: `AlreadyVoted` (59), `InvalidQuorum` (61), `Unauthorized` (20),
+> `AgentNotRegistered` (5), and `ContractPaused` (13) are reused from existing variants.
+
+### Governance Storage Accessor Functions
+
+```rust
+// Proposal CRUD
+pub fn get_proposal(env: &Env, id: u64) -> Result<Proposal, ContractError>;
+pub fn set_proposal(env: &Env, proposal: &Proposal);
+
+// Vote tracking
+pub fn has_governance_voted(env: &Env, proposal_id: u64, voter: &Address) -> bool;
+pub fn record_governance_vote(env: &Env, proposal_id: u64, voter: &Address);
+
+// Config
+pub fn get_governance_quorum(env: &Env) -> u32;
+pub fn set_governance_quorum(env: &Env, quorum: u32);
+pub fn get_governance_timelock(env: &Env) -> u64;
+pub fn set_governance_timelock(env: &Env, seconds: u64);
+pub fn get_proposal_ttl(env: &Env) -> u64;
+pub fn set_proposal_ttl(env: &Env, seconds: u64);
+
+// Admin list
+pub fn get_admin_list(env: &Env) -> Vec<Address>;
+pub fn add_admin_to_list(env: &Env, admin: &Address);
+pub fn remove_admin_from_list(env: &Env, admin: &Address);
+
+// Active proposal guards
+pub fn get_active_fee_proposal(env: &Env) -> Option<u64>;
+pub fn set_active_fee_proposal(env: &Env, proposal_id: Option<u64>);
+
+// Governance initialization flag
+pub fn is_governance_initialized(env: &Env) -> bool;
+pub fn set_governance_initialized(env: &Env);
+```
+
+---
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Admin count bounds invariant
+
+_For any_ sequence of add-admin and remove-admin proposal executions, the admin count stored in contract state must always equal the number of addresses that hold `Role::Admin`, and must remain in the range [1, 20].
+
+**Validates: Requirements 1.1, 1.3, 1.4**
+
+---
+
+### Property 2: Admin list round-trip
+
+_For any_ set of add-admin and remove-admin proposal executions, the list returned by `get_admins()` must contain exactly the addresses that currently hold `Role::Admin` — no more, no fewer.
+
+**Validates: Requirements 1.8**
+
+---
+
+### Property 3: Invalid quorum is rejected
+
+_For any_ quorum value that is 0 or strictly greater than the current admin count, calling `migrate_to_governance` or executing a quorum-update proposal with that value must return `ContractError::InvalidQuorum`.
+
+**Validates: Requirements 2.2, 2.4**
+
+---
+
+### Property 4: Quorum update round-trip
+
+_For any_ valid quorum value in [1, admin_count], after executing a quorum-update proposal, `get_quorum()` must return that value.
+
+**Validates: Requirements 2.3**
+
+---
+
+### Property 5: Timelock update round-trip
+
+_For any_ non-negative timelock value, after executing a timelock-update proposal, `get_timelock_seconds()` must return that value.
+
+**Validates: Requirements 3.3**
+
+---
+
+### Property 6: Proposal IDs are unique and monotonically increasing
+
+_For any_ sequence of `propose()` calls, each returned `proposal_id` must be strictly greater than all previously returned IDs, and the stored proposal record must have `state = Pending`, the correct `proposer`, `action`, and `expiry = created_at + proposal_ttl_seconds`.
+
+**Validates: Requirements 4.1, 4.3**
+
+---
+
+### Property 7: Non-admin callers are rejected
+
+_For any_ address that does not hold `Role::Admin`, calling `propose()`, `vote()`, or `execute()` must return `ContractError::Unauthorized`.
+
+**Validates: Requirements 4.2, 4.6, 4.11, 9.2**
+
+---
+
+### Property 8: Vote uniqueness per proposal
+
+_For any_ proposal and any admin address, the second call to `vote()` by the same admin on the same proposal must return `ContractError::AlreadyVoted`, regardless of how many times it is called.
+
+**Validates: Requirements 4.4, 4.5, 9.4**
+
+---
+
+### Property 9: Quorum triggers state transition to Approved
+
+_For any_ proposal and configured quorum Q, after exactly Q distinct admin approvals, the proposal state must be `Approved` and `approval_timestamp` must be set to the ledger timestamp of the Q-th vote.
+
+**Validates: Requirements 4.7**
+
+---
+
+### Property 10: Execution requires Approved state and elapsed timelock
+
+_For any_ proposal not in `Approved` state, calling `execute()` must return `ContractError::InvalidProposalState`. For any `Approved` proposal where the current timestamp is less than `approval_timestamp + timelock_seconds`, calling `execute()` must return `ContractError::TimelockNotElapsed`. Once executed, any subsequent `execute()` call must return `ContractError::InvalidProposalState`.
+
+**Validates: Requirements 4.8, 4.9, 4.10, 9.3**
+
+---
+
+### Property 11: Expired proposals are correctly transitioned
+
+_For any_ proposal in `Pending` or `Approved` state whose current ledger timestamp exceeds its `expiry`, calling `expire_proposal()` must succeed and set the state to `Expired`.
+
+**Validates: Requirements 4.12**
+
+---
+
+### Property 12: Fee update proposal round-trip
+
+_For any_ valid `fee_bps` in [0, 10000], after executing a `Fee_Update_Proposal`, `get_platform_fee_bps()` must return `fee_bps`.
+
+**Validates: Requirements 5.1**
+
+---
+
+### Property 13: Invalid fee_bps is rejected at proposal creation
+
+_For any_ `fee_bps` value strictly greater than 10000, calling `propose()` with a `ProposalAction::UpdateFee(fee_bps)` must return `ContractError::InvalidFeeBps`.
+
+**Validates: Requirements 5.2**
+
+---
+
+### Property 14: At most one active fee proposal
+
+_For any_ contract state where a `Fee_Update_Proposal` is in `Pending` or `Approved` state, submitting a second `Fee_Update_Proposal` must return `ContractError::ProposalAlreadyPending`.
+
+**Validates: Requirements 5.5**
+
+---
+
+### Property 15: Agent management proposal round-trip
+
+_For any_ unregistered address, after executing a `RegisterAgent` proposal, `is_agent_registered()` must return `true`. For any registered agent, after executing a `RemoveAgent` proposal, `is_agent_registered()` must return `false`.
+
+**Validates: Requirements 6.1, 6.2**
+
+---
+
+### Property 16: Single-admin mode allows immediate execution
+
+_For any_ proposal created when admin count = 1 and quorum = 1, the sole admin's `propose()` call (which auto-votes) must result in the proposal reaching `Approved` state, and `execute()` must succeed immediately (with timelock = 0).
+
+**Validates: Requirements 7.5**
+
+---
+
+### Property 17: Vote count never exceeds admin count
+
+_For any_ proposal and any sequence of vote calls, the `approval_count` field on the proposal must never exceed the current admin count.
+
+**Validates: Requirements 9.5**
+
+---
+
+### Property 18: Propose is rejected when contract is paused
+
+_For any_ contract state where the circuit breaker is active (paused = true), calling `propose()` must return `ContractError::ContractPaused`.
+
+**Validates: Requirements 9.6**
+
+---
+
+## Error Handling
+
+### Authorization Errors
+
+- All state-mutating functions call `caller.require_auth()` first, then check `is_admin()`.
+- Non-admin callers receive `ContractError::Unauthorized` (code 20).
+
+### Proposal State Errors
+
+- `execute()` on non-Approved proposals → `ContractError::InvalidProposalState` (65).
+- `execute()` before timelock elapsed → `ContractError::TimelockNotElapsed` (66).
+- `expire_proposal()` on non-expired proposals → `ContractError::InvalidProposalState` (65).
+
+### Validation Errors at Proposal Creation
+
+- `fee_bps > 10000` → `ContractError::InvalidFeeBps` (4).
+- Second active fee proposal → `ContractError::ProposalAlreadyPending` (63).
+- Register already-registered agent → `ContractError::AgentAlreadyRegistered` (69).
+- Remove unregistered agent → `ContractError::AgentNotRegistered` (5).
+- Add existing admin → `ContractError::AlreadyAdmin` (67).
+- Remove admin that would drop count below quorum or below 1 → `ContractError::InsufficientAdmins` (68).
+
+### Quorum / Admin Count Errors
+
+- Quorum = 0 or quorum > admin_count → `ContractError::InvalidQuorum` (61).
+- Remove admin when count = 1 → `ContractError::InsufficientAdmins` (68).
+
+### Migration Errors
+
+- `migrate_to_governance()` called twice → `ContractError::GovernanceAlreadyInitialized` (70).
+- `migrate_to_governance()` called by non-Legacy_Admin → `ContractError::Unauthorized` (20).
+
+### Circuit Breaker Interaction
+
+- `propose()` while paused → `ContractError::ContractPaused` (13).
+- `vote()` and `execute()` are not blocked by the circuit breaker (governance must remain operable to unpause via a future governance action).
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are required. Unit tests cover specific examples, integration points, and edge cases. Property-based tests verify universal correctness across randomized inputs.
+
+### Unit Tests (`src/test_governance.rs`)
+
+Focus areas:
+
+- Contract initialization and `migrate_to_governance()` happy path
+- Full proposal lifecycle: propose → vote → execute for each action type
+- Event emission verification for all 7 event types (Requirements 8.1–8.7)
+- Backward-compatibility: `get_admin()` returns Legacy_Admin after governance init
+- Legacy_Admin update on first add-admin execution (Requirement 7.2)
+- Single-admin mode immediate execution (Requirement 7.5)
+- All error conditions: unauthorized callers, invalid states, duplicate votes, expired proposals
+
+### Property-Based Tests (`src/test_governance_property.rs`)
+
+Use the **`proptest`** crate (already available in the Rust ecosystem for Soroban testing).
+Each property test must run a minimum of **100 iterations**.
+
+Each test must include a comment tag in the format:
+`// Feature: multi-admin-dao-governance, Property N: <property_text>`
+
+**Property test mapping:**
+
+| Property | Test Description                                                                      |
+| -------- | ------------------------------------------------------------------------------------- |
+| P1       | Generate random add/remove sequences; assert count == role-holder count, in [1,20]    |
+| P2       | Generate random admin sets; assert get_admins() == set of Role::Admin holders         |
+| P3       | Generate quorum values of 0 and > admin_count; assert InvalidQuorum                   |
+| P4       | Generate valid quorum values; propose+execute; assert get_quorum() matches            |
+| P5       | Generate timelock values; propose+execute; assert get_timelock_seconds() matches      |
+| P6       | Generate N propose() calls; assert IDs are strictly increasing and fields correct     |
+| P7       | Generate non-admin addresses; call propose/vote/execute; assert Unauthorized          |
+| P8       | Generate proposals; vote twice with same admin; assert AlreadyVoted on second         |
+| P9       | Generate quorum Q and Q distinct voters; assert state == Approved after Q votes       |
+| P10      | Generate proposals in wrong states; assert InvalidProposalState; test replay          |
+| P11      | Generate proposals past TTL; assert expire_proposal() succeeds                        |
+| P12      | Generate valid fee_bps; propose+execute; assert get_platform_fee_bps() matches        |
+| P13      | Generate fee_bps > 10000; assert InvalidFeeBps at propose()                           |
+| P14      | Generate state with active fee proposal; submit second; assert ProposalAlreadyPending |
+| P15      | Generate addresses; register then remove via proposals; assert round-trip             |
+| P16      | Single-admin setup; propose+execute; assert immediate success                         |
+| P17      | Generate vote sequences; assert approval_count <= admin_count always                  |
+| P18      | Pause contract; call propose(); assert ContractPaused                                 |
+
+### Test File Structure
+
+```
+src/
+  test_governance.rs          # Unit tests
+  test_governance_property.rs # Property-based tests
+```
+
+### Cargo.toml Addition
+
+```toml
+[dev-dependencies]
+proptest = "1"
+```

--- a/kiro/specs/multi-admin-dao-governance/requirements.md
+++ b/kiro/specs/multi-admin-dao-governance/requirements.md
@@ -1,0 +1,283 @@
+# Requirements Document
+
+## Introduction
+
+SwiftRemit currently uses a single-admin model where one privileged address controls all
+sensitive operations: updating platform fees and managing agent registration. This creates
+a single point of failure and trust, which is unacceptable for a production remittance
+protocol handling real funds.
+
+This feature replaces the single-admin model with a multi-signature (multi-sig) and
+optional DAO voting governance mechanism. Privileged operations — fee updates and agent
+management — will require approval from a configurable quorum of admin signers before
+execution. An optional time-lock delay can be enforced between proposal approval and
+execution to give stakeholders time to react.
+
+The existing `AdminRole` scaffolding in storage (admin count, per-address admin flags)
+provides a foundation; this feature builds the full proposal, voting, and execution
+lifecycle on top of it.
+
+---
+
+## Glossary
+
+- **Governance_System**: The on-chain multi-sig/DAO governance module added to the
+  SwiftRemit Soroban contract.
+- **Admin**: An address that holds the `Role::Admin` privilege and may submit and vote
+  on governance proposals.
+- **Proposal**: A pending governance action (fee update or agent management operation)
+  that requires quorum approval before execution.
+- **Quorum**: The minimum number of distinct Admin approvals required to execute a
+  Proposal. Configured at initialization and updatable via governance.
+- **Timelock**: An optional delay (in seconds) between a Proposal reaching quorum and
+  the earliest ledger timestamp at which it may be executed.
+- **Proposer**: The Admin who creates a Proposal.
+- **Voter**: An Admin who casts an approval or rejection vote on a Proposal.
+- **Executor**: The Admin who calls the execute function after quorum and timelock
+  conditions are satisfied.
+- **Fee_Update_Proposal**: A Proposal whose action is to change the platform fee in
+  basis points.
+- **Agent_Management_Proposal**: A Proposal whose action is to register or remove an
+  agent address.
+- **Admin_Management_Proposal**: A Proposal whose action is to add or remove an Admin
+  address.
+- **Proposal_State**: The lifecycle state of a Proposal: `Pending`, `Approved`,
+  `Executed`, `Rejected`, or `Expired`.
+- **Legacy_Admin**: The single admin address stored under `DataKey::Admin`, retained
+  for backward-compatible reads during the migration window.
+
+---
+
+## Requirements
+
+### Requirement 1: Admin Set Management
+
+**User Story:** As a protocol operator, I want to manage a set of admin addresses, so
+that governance authority is distributed across multiple trusted parties.
+
+#### Acceptance Criteria
+
+1. THE Governance_System SHALL support a minimum of 1 and a maximum of 20 simultaneous
+   Admin addresses.
+2. WHEN the contract is initialized, THE Governance_System SHALL register the provided
+   `admin` address as the first Admin and set the Admin count to 1.
+3. WHEN an Admin_Management_Proposal to add a new Admin is executed, THE
+   Governance_System SHALL grant `Role::Admin` to the new address and increment the
+   Admin count by 1.
+4. WHEN an Admin_Management_Proposal to remove an Admin is executed, THE
+   Governance_System SHALL revoke `Role::Admin` from the target address and decrement
+   the Admin count by 1.
+5. IF an Admin_Management_Proposal to add an address that already holds `Role::Admin`
+   is executed, THEN THE Governance_System SHALL return `ContractError::AlreadyAdmin`.
+6. IF an Admin_Management_Proposal to remove an Admin would reduce the Admin count
+   below 1, THEN THE Governance_System SHALL return
+   `ContractError::InsufficientAdmins`.
+7. IF an Admin_Management_Proposal to remove an Admin would reduce the Admin count
+   below the configured Quorum, THEN THE Governance_System SHALL return
+   `ContractError::InsufficientAdmins`.
+8. THE Governance_System SHALL expose a read-only function that returns the current
+   list of Admin addresses.
+
+---
+
+### Requirement 2: Quorum Configuration
+
+**User Story:** As a protocol operator, I want to configure the approval quorum, so
+that I can tune the security vs. operational agility trade-off.
+
+#### Acceptance Criteria
+
+1. WHEN the contract is initialized, THE Governance_System SHALL accept a `quorum`
+   parameter in the range [1, Admin_count] and store it.
+2. IF the `quorum` value provided at initialization is 0 or greater than the initial
+   Admin count, THEN THE Governance_System SHALL return `ContractError::InvalidQuorum`.
+3. WHEN a Proposal to update the Quorum is executed, THE Governance_System SHALL
+   update the stored Quorum value.
+4. IF a Proposal to update the Quorum would set it to 0 or greater than the current
+   Admin count, THEN THE Governance_System SHALL return `ContractError::InvalidQuorum`.
+5. THE Governance_System SHALL expose a read-only function that returns the current
+   Quorum value.
+
+---
+
+### Requirement 3: Timelock Configuration
+
+**User Story:** As a protocol operator, I want to configure an execution timelock, so
+that stakeholders have time to react before approved proposals take effect.
+
+#### Acceptance Criteria
+
+1. WHEN the contract is initialized, THE Governance_System SHALL accept a
+   `timelock_seconds` parameter (minimum 0) and store it.
+2. THE Governance_System SHALL support a timelock of 0 seconds, meaning approved
+   Proposals may be executed immediately after reaching quorum.
+3. WHEN a Proposal to update the timelock is executed, THE Governance_System SHALL
+   update the stored `timelock_seconds` value.
+4. THE Governance_System SHALL expose a read-only function that returns the current
+   `timelock_seconds` value.
+
+---
+
+### Requirement 4: Proposal Lifecycle
+
+**User Story:** As an Admin, I want to create, vote on, and execute governance
+proposals, so that sensitive operations require collective approval.
+
+#### Acceptance Criteria
+
+1. WHEN an Admin calls `propose`, THE Governance_System SHALL create a new Proposal
+   with a unique monotonically increasing `proposal_id`, record the Proposer, the
+   proposed action, the creation timestamp, and set Proposal_State to `Pending`.
+2. IF a non-Admin address calls `propose`, THEN THE Governance_System SHALL return
+   `ContractError::Unauthorized`.
+3. THE Governance_System SHALL assign each Proposal a configurable expiry timestamp
+   equal to the creation ledger timestamp plus a `proposal_ttl_seconds` value stored
+   in contract state.
+4. WHEN an Admin calls `vote` with approval on a Pending Proposal, THE
+   Governance_System SHALL record that Admin's approval vote, ensuring each Admin may
+   cast at most one vote per Proposal.
+5. IF an Admin attempts to vote on a Proposal they have already voted on, THEN THE
+   Governance_System SHALL return `ContractError::AlreadyVoted`.
+6. IF a non-Admin address calls `vote`, THEN THE Governance_System SHALL return
+   `ContractError::Unauthorized`.
+7. WHEN the approval vote count on a Proposal reaches the configured Quorum, THE
+   Governance_System SHALL transition the Proposal_State to `Approved` and record the
+   approval timestamp.
+8. WHEN an Admin calls `execute` on an `Approved` Proposal and the current ledger
+   timestamp is greater than or equal to `approval_timestamp + timelock_seconds`, THE
+   Governance_System SHALL execute the proposed action and transition Proposal_State
+   to `Executed`.
+9. IF `execute` is called on an `Approved` Proposal before the timelock has elapsed,
+   THEN THE Governance_System SHALL return `ContractError::TimelockNotElapsed`.
+10. IF `execute` is called on a Proposal that is not in `Approved` state, THEN THE
+    Governance_System SHALL return `ContractError::InvalidProposalState`.
+11. IF a non-Admin address calls `execute`, THEN THE Governance_System SHALL return
+    `ContractError::Unauthorized`.
+12. WHEN the current ledger timestamp exceeds a Proposal's expiry timestamp and the
+    Proposal is still in `Pending` or `Approved` state, THE Governance_System SHALL
+    allow any caller to transition the Proposal_State to `Expired` via a
+    `expire_proposal` function.
+13. THE Governance_System SHALL expose a read-only function that returns the full
+    Proposal record for a given `proposal_id`.
+
+---
+
+### Requirement 5: Fee Update via Governance
+
+**User Story:** As an Admin, I want fee changes to require multi-sig approval, so that
+no single party can unilaterally alter the platform fee.
+
+#### Acceptance Criteria
+
+1. WHEN a Fee_Update_Proposal is executed, THE Governance_System SHALL call the
+   existing fee update logic and set the platform fee to the proposed `fee_bps` value.
+2. IF the proposed `fee_bps` in a Fee_Update_Proposal exceeds `MAX_FEE_BPS` (10000),
+   THEN THE Governance_System SHALL return `ContractError::InvalidFeeBps` at proposal
+   creation time.
+3. THE Governance_System SHALL emit a `FeeUpdateProposed` event when a
+   Fee_Update_Proposal is created, including `proposal_id` and `fee_bps`.
+4. THE Governance_System SHALL emit a `FeeUpdated` event (existing event) when a
+   Fee_Update_Proposal is executed.
+5. WHILE a Fee_Update_Proposal is in `Pending` or `Approved` state, THE
+   Governance_System SHALL allow at most one active Fee_Update_Proposal at a time,
+   returning `ContractError::ProposalAlreadyPending` if a second is submitted.
+
+---
+
+### Requirement 6: Agent Management via Governance
+
+**User Story:** As an Admin, I want agent registration and removal to require multi-sig
+approval, so that no single party can unilaterally add or remove payout agents.
+
+#### Acceptance Criteria
+
+1. WHEN an Agent_Management_Proposal to register an agent is executed, THE
+   Governance_System SHALL call the existing agent registration logic, setting the
+   agent as registered and assigning `Role::Settler`.
+2. WHEN an Agent_Management_Proposal to remove an agent is executed, THE
+   Governance_System SHALL call the existing agent removal logic, clearing the
+   registered flag and revoking `Role::Settler`.
+3. IF the target address in an Agent_Management_Proposal to register is already a
+   registered agent, THEN THE Governance_System SHALL return
+   `ContractError::AgentAlreadyRegistered` at proposal creation time.
+4. IF the target address in an Agent_Management_Proposal to remove is not a registered
+   agent, THEN THE Governance_System SHALL return `ContractError::AgentNotRegistered`
+   at proposal creation time.
+5. THE Governance_System SHALL emit an `AgentManagementProposed` event when an
+   Agent_Management_Proposal is created, including `proposal_id`, `agent`, and
+   `action` (register or remove).
+6. THE Governance_System SHALL emit the existing `AgentRegistered` or `AgentRemoved`
+   event when an Agent_Management_Proposal is executed.
+
+---
+
+### Requirement 7: Backward Compatibility and Migration
+
+**User Story:** As a protocol operator, I want the governance upgrade to be backward
+compatible, so that existing integrations continue to function during the transition.
+
+#### Acceptance Criteria
+
+1. THE Governance_System SHALL retain the `DataKey::Admin` (Legacy_Admin) storage
+   entry and continue to return it from `get_admin` for read-only callers.
+2. WHEN the first Admin_Management_Proposal to add a new Admin is executed, THE
+   Governance_System SHALL update the Legacy_Admin entry to the address of the
+   Proposer of that proposal, preserving a valid single-admin reference.
+3. THE Governance_System SHALL provide a one-time `migrate_to_governance` function
+   callable only by the Legacy_Admin that sets the initial Quorum and
+   `timelock_seconds` without requiring a Proposal, enabling upgrade from the existing
+   single-admin deployment.
+4. IF `migrate_to_governance` is called after governance has already been initialized,
+   THEN THE Governance_System SHALL return `ContractError::AlreadyInitialized`.
+5. WHILE the contract is in single-admin mode (Admin count = 1 and Quorum = 1), THE
+   Governance_System SHALL allow the sole Admin to execute proposals immediately
+   without waiting for additional votes, preserving existing operational behavior.
+
+---
+
+### Requirement 8: Event Emission
+
+**User Story:** As an off-chain integrator, I want governance events emitted for all
+state changes, so that I can track proposal lifecycle and audit governance actions.
+
+#### Acceptance Criteria
+
+1. THE Governance_System SHALL emit a `ProposalCreated` event when any Proposal is
+   created, including `proposal_id`, `proposer`, `action_type`, and `expiry`.
+2. THE Governance_System SHALL emit a `ProposalVoted` event when an Admin votes,
+   including `proposal_id`, `voter`, and `approval_count`.
+3. THE Governance_System SHALL emit a `ProposalApproved` event when a Proposal
+   transitions to `Approved` state, including `proposal_id` and `approval_timestamp`.
+4. THE Governance_System SHALL emit a `ProposalExecuted` event when a Proposal is
+   executed, including `proposal_id` and `executor`.
+5. THE Governance_System SHALL emit a `ProposalExpired` event when a Proposal is
+   transitioned to `Expired` state, including `proposal_id`.
+6. THE Governance_System SHALL emit an `AdminAdded` event when a new Admin is added,
+   including the new `admin` address and `proposal_id`.
+7. THE Governance_System SHALL emit an `AdminRemoved` event when an Admin is removed,
+   including the removed `admin` address and `proposal_id`.
+
+---
+
+### Requirement 9: Security and Authorization Invariants
+
+**User Story:** As a security auditor, I want the governance system to enforce strict
+authorization invariants, so that no unauthorized party can influence governance
+outcomes.
+
+#### Acceptance Criteria
+
+1. THE Governance_System SHALL require `address.require_auth()` from the caller for
+   all state-mutating governance functions (`propose`, `vote`, `execute`,
+   `expire_proposal`, `migrate_to_governance`).
+2. IF any state-mutating governance function is called by an address that does not
+   hold `Role::Admin`, THEN THE Governance_System SHALL return
+   `ContractError::Unauthorized`.
+3. THE Governance_System SHALL prevent replay of an already-`Executed` Proposal by
+   returning `ContractError::InvalidProposalState` on any subsequent `execute` call.
+4. THE Governance_System SHALL prevent a single Admin from approving a Proposal more
+   than once, regardless of how many times `vote` is called.
+5. FOR ALL Proposals, the total approval vote count SHALL never exceed the current
+   Admin count.
+6. THE Governance_System SHALL reject any `propose` call made while the contract is
+   paused (circuit breaker active), returning `ContractError::ContractPaused`.

--- a/kiro/specs/multi-admin-dao-governance/tasks.md
+++ b/kiro/specs/multi-admin-dao-governance/tasks.md
@@ -1,0 +1,228 @@
+# Implementation Tasks: Multi-Admin / DAO Governance Support
+
+## Overview
+
+These tasks implement the governance proposal lifecycle on top of the existing
+multi-admin scaffolding in SwiftRemit. Work is ordered so each task compiles and
+passes tests independently before the next begins.
+
+---
+
+## Task 1: Extend types, errors, and events
+
+- [ ] 1.1 Add `ProposalAction`, `ProposalState`, and `Proposal` types to `src/types.rs`
+  - `ProposalAction` enum: `UpdateFee(u32)`, `RegisterAgent(Address)`, `RemoveAgent(Address)`, `AddAdmin(Address)`, `RemoveAdmin(Address)`, `UpdateQuorum(u32)`, `UpdateTimelock(u64)`
+  - `ProposalState` enum: `Pending`, `Approved`, `Executed`, `Expired`
+  - `Proposal` struct: `id`, `proposer`, `action`, `state`, `created_at`, `expiry`, `approval_count`, `approval_timestamp: Option<u64>`
+  - All types annotated with `#[contracttype]`
+
+- [ ] 1.2 Add new `ContractError` variants to `src/errors.rs` starting at code 63
+  - `ProposalAlreadyPending = 63`
+  - `ProposalNotFound = 64`
+  - `InvalidProposalState = 65`
+  - `TimelockNotElapsed = 66`
+  - `AlreadyAdmin = 67`
+  - `InsufficientAdmins = 68`
+  - `AgentAlreadyRegistered = 69`
+  - `GovernanceAlreadyInitialized = 70`
+
+- [ ] 1.3 Add governance event emission functions to `src/events.rs`
+  - `emit_proposal_created(env, proposal_id, proposer, action_type, expiry)`
+  - `emit_proposal_voted(env, proposal_id, voter, approval_count)`
+  - `emit_proposal_approved(env, proposal_id, approval_timestamp)`
+  - `emit_proposal_executed(env, proposal_id, executor)`
+  - `emit_proposal_expired(env, proposal_id)`
+  - `emit_governance_admin_added(env, admin, proposal_id)`
+  - `emit_governance_admin_removed(env, admin, proposal_id)`
+  - `emit_fee_update_proposed(env, proposal_id, fee_bps)`
+  - `emit_agent_management_proposed(env, proposal_id, agent, action)`
+
+**Validates:** Requirements 5.3, 6.5, 8.1–8.7
+
+---
+
+## Task 2: Extend storage with governance keys and accessors
+
+- [ ] 2.1 Add new `DataKey` variants to the enum in `src/storage.rs`
+  - `GovernanceProposalCounter` (instance)
+  - `GovernanceProposal(u64)` (persistent)
+  - `GovernanceVote(u64, Address)` (persistent)
+  - `GovernanceQuorum` (instance)
+  - `GovernanceTimelockSeconds` (instance)
+  - `GovernanceProposalTtl` (instance)
+  - `ActiveFeeProposal` (instance)
+  - `GovernanceInitialized` (instance)
+  - `AdminList` (instance)
+
+- [ ] 2.2 Add proposal CRUD accessors
+  - `get_proposal(env, id) -> Result<Proposal, ContractError>`
+  - `set_proposal(env, proposal: &Proposal)`
+  - `next_proposal_id(env) -> u64` (increments counter and returns new ID)
+
+- [ ] 2.3 Add vote tracking accessors
+  - `has_governance_voted(env, proposal_id, voter) -> bool`
+  - `record_governance_vote(env, proposal_id, voter)`
+
+- [ ] 2.4 Add governance config accessors
+  - `get_governance_quorum(env) -> u32`
+  - `set_governance_quorum(env, quorum)`
+  - `get_governance_timelock(env) -> u64`
+  - `set_governance_timelock(env, seconds)`
+  - `get_proposal_ttl(env) -> u64`
+  - `set_proposal_ttl(env, seconds)`
+
+- [ ] 2.5 Add admin list accessors
+  - `get_admin_list(env) -> Vec<Address>`
+  - `add_admin_to_list(env, admin: &Address)`
+  - `remove_admin_from_list(env, admin: &Address)`
+
+- [ ] 2.6 Add active proposal guard accessors
+  - `get_active_fee_proposal(env) -> Option<u64>`
+  - `set_active_fee_proposal(env, proposal_id: Option<u64>)`
+
+- [ ] 2.7 Add governance initialization flag accessors
+  - `is_governance_initialized(env) -> bool`
+  - `set_governance_initialized(env)`
+
+**Validates:** Requirements 1.8, 2.5, 3.4, 4.13
+
+---
+
+## Task 3: Implement `src/governance.rs` — core proposal logic
+
+- [ ] 3.1 Create `src/governance.rs` and implement `do_propose`
+  - Verify caller holds `Role::Admin` (return `Unauthorized` if not)
+  - Reject if contract is paused (`ContractPaused`)
+  - Validate action-specific preconditions at proposal creation time:
+    - `UpdateFee(bps)`: reject if `bps > 10000` (`InvalidFeeBps`); reject if active fee proposal exists (`ProposalAlreadyPending`)
+    - `RegisterAgent(addr)`: reject if agent already registered (`AgentAlreadyRegistered`)
+    - `RemoveAgent(addr)`: reject if agent not registered (`AgentNotRegistered`)
+    - `AddAdmin(addr)`: reject if address already holds `Role::Admin` (`AlreadyAdmin`)
+    - `RemoveAdmin(addr)`: reject if removal would drop count below quorum or below 1 (`InsufficientAdmins`)
+  - Allocate new proposal ID via `next_proposal_id`
+  - Store `Proposal` with `state = Pending`, `created_at`, `expiry = created_at + ttl`, `approval_count = 0`
+  - Set `ActiveFeeProposal` flag for fee proposals
+  - Emit `ProposalCreated` event (and action-specific event)
+  - Return `proposal_id`
+
+- [ ] 3.2 Implement `do_vote`
+  - Verify caller holds `Role::Admin`
+  - Load proposal; return `ProposalNotFound` if missing
+  - Return `InvalidProposalState` if proposal is not `Pending`
+  - Return `AlreadyVoted` if caller already voted
+  - Record vote; increment `approval_count`
+  - Emit `ProposalVoted` event
+  - If `approval_count >= quorum`: set `state = Approved`, record `approval_timestamp`, emit `ProposalApproved`
+
+- [ ] 3.3 Implement `do_execute`
+  - Verify caller holds `Role::Admin`
+  - Load proposal; return `ProposalNotFound` if missing
+  - Return `InvalidProposalState` if not `Approved`
+  - Return `TimelockNotElapsed` if `now < approval_timestamp + timelock_seconds`
+  - Dispatch action:
+    - `UpdateFee(bps)`: call existing fee update logic; clear `ActiveFeeProposal`; emit `FeeUpdated`
+    - `RegisterAgent(addr)`: call existing agent registration logic; emit `AgentRegistered`
+    - `RemoveAgent(addr)`: call existing agent removal logic; emit `AgentRemoved`
+    - `AddAdmin(addr)`: grant `Role::Admin`, increment admin count, add to admin list, update legacy `Admin` key if first multi-admin; emit `AdminAdded` + `GovernanceAdminAdded`
+    - `RemoveAdmin(addr)`: revoke `Role::Admin`, decrement admin count, remove from admin list; emit `AdminRemoved` + `GovernanceAdminRemoved`
+    - `UpdateQuorum(q)`: validate `1 <= q <= admin_count`; store new quorum
+    - `UpdateTimelock(s)`: store new timelock
+  - Set `state = Executed`; emit `ProposalExecuted`
+
+- [ ] 3.4 Implement `do_expire`
+  - Load proposal; return `ProposalNotFound` if missing
+  - Return `InvalidProposalState` if not `Pending` or `Approved`
+  - Return `InvalidProposalState` if `now < expiry` (not yet expired)
+  - Set `state = Expired`; clear `ActiveFeeProposal` if applicable; emit `ProposalExpired`
+
+- [ ] 3.5 Implement `do_migrate`
+  - Verify caller is the legacy `DataKey::Admin` address
+  - Return `GovernanceAlreadyInitialized` if already initialized
+  - Validate `quorum` in `[1, admin_count]`; return `InvalidQuorum` if not
+  - Store quorum, timelock, proposal TTL
+  - Seed `AdminList` from existing admin role holders (at minimum the legacy admin)
+  - Set `GovernanceInitialized` flag
+
+**Validates:** Requirements 1–7, 9
+
+---
+
+## Task 4: Expose governance entry points in `src/lib.rs`
+
+- [ ] 4.1 Add `mod governance;` declaration and import `governance::*` functions
+
+- [ ] 4.2 Add public entry points to `SwiftRemitContract` impl
+
+  ```rust
+  pub fn propose(env: Env, proposer: Address, action: ProposalAction) -> Result<u64, ContractError>
+  pub fn vote(env: Env, voter: Address, proposal_id: u64) -> Result<(), ContractError>
+  pub fn execute(env: Env, executor: Address, proposal_id: u64) -> Result<(), ContractError>
+  pub fn expire_proposal(env: Env, caller: Address, proposal_id: u64) -> Result<(), ContractError>
+  pub fn migrate_to_governance(env: Env, caller: Address, quorum: u32, timelock_seconds: u64, proposal_ttl_seconds: u64) -> Result<(), ContractError>
+  ```
+
+  Each function calls `caller.require_auth()` then delegates to the corresponding `do_*` function.
+
+- [ ] 4.3 Add read-only query entry points
+  ```rust
+  pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, ContractError>
+  pub fn get_admins(env: Env) -> Vec<Address>
+  pub fn get_quorum(env: Env) -> u32
+  pub fn get_timelock_seconds(env: Env) -> u64
+  ```
+
+**Validates:** Requirements 1.8, 2.5, 3.4, 4.1–4.13
+
+---
+
+## Task 5: Unit tests (`src/test_governance.rs`)
+
+- [ ] 5.1 Test `migrate_to_governance` happy path and double-call rejection
+- [ ] 5.2 Test full `UpdateFee` proposal lifecycle: propose → vote → execute
+- [ ] 5.3 Test full `RegisterAgent` proposal lifecycle
+- [ ] 5.4 Test full `RemoveAgent` proposal lifecycle
+- [ ] 5.5 Test full `AddAdmin` proposal lifecycle including admin list and legacy key update
+- [ ] 5.6 Test full `RemoveAdmin` proposal lifecycle
+- [ ] 5.7 Test `UpdateQuorum` and `UpdateTimelock` proposals
+- [ ] 5.8 Test timelock enforcement: execute before and after timelock elapses
+- [ ] 5.9 Test proposal expiry via `expire_proposal`
+- [ ] 5.10 Test single-admin mode: propose auto-reaches quorum, execute succeeds immediately
+- [ ] 5.11 Test all error conditions: `Unauthorized`, `AlreadyVoted`, `InvalidProposalState`, `TimelockNotElapsed`, `ProposalAlreadyPending`, `InsufficientAdmins`, `AlreadyAdmin`, `AgentAlreadyRegistered`, `AgentNotRegistered`, `GovernanceAlreadyInitialized`
+- [ ] 5.12 Test event emission for all 9 event types
+- [ ] 5.13 Test `get_admin()` backward compatibility returns legacy admin after governance init
+
+**Validates:** Requirements 1–9 (example-based coverage)
+
+---
+
+## Task 6: Property-based tests (`src/test_governance_property.rs`)
+
+- [ ] 6.1 Add `proptest = "1"` to `[dev-dependencies]` in `Cargo.toml`
+
+- [ ] 6.2 Implement 18 property tests (minimum 100 iterations each), one per correctness property in `design.md`:
+
+  | Task   | Property | Description                                                        |
+  | ------ | -------- | ------------------------------------------------------------------ |
+  | 6.2.1  | P1       | Admin count bounds invariant across random add/remove sequences    |
+  | 6.2.2  | P2       | `get_admins()` matches `Role::Admin` holders exactly               |
+  | 6.2.3  | P3       | Invalid quorum values (0 or > admin_count) always rejected         |
+  | 6.2.4  | P4       | Valid quorum update round-trip                                     |
+  | 6.2.5  | P5       | Timelock update round-trip                                         |
+  | 6.2.6  | P6       | Proposal IDs are unique and monotonically increasing               |
+  | 6.2.7  | P7       | Non-admin callers always get `Unauthorized`                        |
+  | 6.2.8  | P8       | Double-vote always returns `AlreadyVoted`                          |
+  | 6.2.9  | P9       | Exactly Q votes transitions proposal to `Approved`                 |
+  | 6.2.10 | P10      | Wrong-state execute returns `InvalidProposalState`; replay blocked |
+  | 6.2.11 | P11      | `expire_proposal` succeeds after TTL                               |
+  | 6.2.12 | P12      | Fee update proposal round-trip                                     |
+  | 6.2.13 | P13      | `fee_bps > 10000` rejected at propose time                         |
+  | 6.2.14 | P14      | Second active fee proposal returns `ProposalAlreadyPending`        |
+  | 6.2.15 | P15      | Agent register/remove round-trip                                   |
+  | 6.2.16 | P16      | Single-admin mode allows immediate execution                       |
+  | 6.2.17 | P17      | `approval_count` never exceeds admin count                         |
+  | 6.2.18 | P18      | `propose` while paused returns `ContractPaused`                    |
+
+  Each test must include the comment tag:
+  `// Feature: multi-admin-dao-governance, Property N: <property_text>`
+
+**Validates:** All 18 correctness properties in design.md

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -294,24 +294,62 @@ pub enum ContractError {
     /// Pause record not found for the given sequence number.
     /// Cause: `get_pause_record` called with a sequence number that does not exist.
     PauseRecordNotFound = 62,
-    // Recipient Address Verification Errors (56-59)
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Recipient Address Verification Errors (63-66)
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// Supplied recipient hash is not exactly 32 bytes.
     /// Cause: Passing a hash of incorrect length to create_remittance.
-    InvalidRecipientHash = 56,
+    InvalidRecipientHash = 63,
 
     /// Hash-protected remittance called without supplying a recipient hash.
     /// Cause: confirm_payout called on a remittance that has a stored hash, but no hash was supplied.
-    MissingRecipientHash = 57,
+    MissingRecipientHash = 64,
 
     /// Supplied recipient hash does not match the stored hash.
     /// Cause: The agent-supplied hash differs from the hash registered at creation time.
-    RecipientHashMismatch = 58,
+    RecipientHashMismatch = 65,
 
     /// Stored hash schema version differs from the current contract schema version.
     /// Cause: The remittance was created with a different serialization schema.
-    RecipientHashSchemaMismatch = 59,
+    RecipientHashSchemaMismatch = 66,
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Governance Errors (67-74)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// A proposal with this action type is already pending or approved.
+    /// Cause: Submitting a second fee-update proposal while one is active.
+    ProposalAlreadyPending = 67,
+
+    /// The proposal was not found.
+    /// Cause: Querying or operating on a non-existent proposal_id.
+    ProposalNotFound = 68,
+
+    /// The proposal is not in the required state for this operation.
+    /// Cause: Calling execute() on a non-Approved proposal, or expire on a non-expired one.
+    InvalidProposalState = 69,
+
+    /// The governance execution timelock has not yet elapsed.
+    /// Cause: Calling execute() before approval_timestamp + timelock_seconds.
+    TimelockNotElapsed = 70,
+
+    /// The address is already an Admin.
+    /// Cause: Submitting an AddAdmin proposal for an address that already holds Role::Admin.
+    AlreadyAdmin = 71,
+
+    /// Removing this admin would drop the admin count below the quorum or below 1.
+    /// Cause: Submitting a RemoveAdmin proposal that would violate the minimum admin invariant.
+    InsufficientAdmins = 72,
+
+    /// The agent is already registered.
+    /// Cause: Submitting a RegisterAgent proposal for an already-registered agent.
+    AgentAlreadyRegistered = 73,
+
+    /// Governance has already been initialized via migrate_to_governance.
+    /// Cause: Calling migrate_to_governance() a second time.
+    GovernanceAlreadyInitialized = 74,
 }
 
 #[cfg(test)]
@@ -386,6 +424,18 @@ mod tests {
             (ContractError::InvalidTimelockDuration,     60),
             (ContractError::InvalidQuorum,               61),
             (ContractError::PauseRecordNotFound,         62),
+            (ContractError::InvalidRecipientHash,        63),
+            (ContractError::MissingRecipientHash,        64),
+            (ContractError::RecipientHashMismatch,       65),
+            (ContractError::RecipientHashSchemaMismatch, 66),
+            (ContractError::ProposalAlreadyPending,      67),
+            (ContractError::ProposalNotFound,            68),
+            (ContractError::InvalidProposalState,        69),
+            (ContractError::TimelockNotElapsed,          70),
+            (ContractError::AlreadyAdmin,                71),
+            (ContractError::InsufficientAdmins,          72),
+            (ContractError::AgentAlreadyRegistered,      73),
+            (ContractError::GovernanceAlreadyInitialized, 74),
         ];
 
         // Assert each variant maps to its expected discriminant.

--- a/src/events.rs
+++ b/src/events.rs
@@ -532,6 +532,9 @@ pub fn emit_circuit_breaker_unpaused(env: &Env, caller: Address, timestamp: u64)
             timestamp,
             caller,
         ),
+    );
+}
+
 // ── Recipient Address Verification Events ─────────────────────────
 
 /// Emits an event when a recipient hash is registered for a remittance.
@@ -669,5 +672,81 @@ pub fn emit_treasury_updated(
     env.events().publish(
         (Symbol::new(env, "treasury_upd"),),
         (caller, old_treasury, new_treasury),
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Governance Events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Emits when any governance proposal is created.
+pub fn emit_proposal_created(env: &Env, proposal_id: u64, proposer: Address, action_type: Symbol, expiry: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "proposed")),
+        (SCHEMA_VERSION, proposal_id, proposer, action_type, expiry),
+    );
+}
+
+/// Emits when an admin casts a vote on a proposal.
+pub fn emit_proposal_voted(env: &Env, proposal_id: u64, voter: Address, approval_count: u32) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "voted")),
+        (SCHEMA_VERSION, proposal_id, voter, approval_count),
+    );
+}
+
+/// Emits when a proposal reaches quorum and transitions to Approved.
+pub fn emit_proposal_approved(env: &Env, proposal_id: u64, approval_timestamp: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "approved")),
+        (SCHEMA_VERSION, proposal_id, approval_timestamp),
+    );
+}
+
+/// Emits when a proposal is successfully executed.
+pub fn emit_proposal_executed(env: &Env, proposal_id: u64, executor: Address) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "executed")),
+        (SCHEMA_VERSION, proposal_id, executor),
+    );
+}
+
+/// Emits when a proposal is transitioned to Expired state.
+pub fn emit_proposal_expired(env: &Env, proposal_id: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "expired")),
+        (SCHEMA_VERSION, proposal_id),
+    );
+}
+
+/// Emits when a new admin is added via governance execution.
+pub fn emit_governance_admin_added(env: &Env, admin: Address, proposal_id: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "adm_added")),
+        (SCHEMA_VERSION, admin, proposal_id),
+    );
+}
+
+/// Emits when an admin is removed via governance execution.
+pub fn emit_governance_admin_removed(env: &Env, admin: Address, proposal_id: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "adm_rmvd")),
+        (SCHEMA_VERSION, admin, proposal_id),
+    );
+}
+
+/// Emits when a fee-update proposal is created.
+pub fn emit_fee_update_proposed(env: &Env, proposal_id: u64, fee_bps: u32) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "fee_prop")),
+        (SCHEMA_VERSION, proposal_id, fee_bps),
+    );
+}
+
+/// Emits when an agent-management proposal is created.
+pub fn emit_agent_management_proposed(env: &Env, proposal_id: u64, agent: Address, action: Symbol) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "agt_prop")),
+        (SCHEMA_VERSION, proposal_id, agent, action),
     );
 }

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,0 +1,378 @@
+//! Governance module for SwiftRemit.
+//!
+//! Implements the multi-sig / DAO proposal lifecycle:
+//! propose → vote → execute (with optional timelock) or expire.
+//!
+//! All privileged operations (fee updates, agent management, admin set changes)
+//! are gated behind a configurable quorum of admin approvals.
+
+use soroban_sdk::{Address, Env, Symbol};
+
+use crate::{
+    events::{
+        emit_agent_management_proposed, emit_agent_registered, emit_agent_removed,
+        emit_fee_update_proposed, emit_fee_updated, emit_governance_admin_added,
+        emit_governance_admin_removed, emit_proposal_approved, emit_proposal_created,
+        emit_proposal_executed, emit_proposal_expired, emit_proposal_voted,
+    },
+    storage::{
+        self, add_admin_to_list, assign_role, get_active_fee_proposal,
+        get_governance_quorum, get_governance_timelock, get_proposal, get_proposal_ttl,
+        has_governance_voted, is_agent_registered, is_governance_initialized,
+        next_proposal_id, record_governance_vote, remove_admin_from_list, remove_role,
+        set_active_fee_proposal, set_governance_initialized, set_governance_quorum,
+        set_governance_timelock, set_proposal, set_proposal_ttl,
+    },
+    ContractError, Proposal, ProposalAction, ProposalState, Role,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn require_admin_role(env: &Env, address: &Address) -> Result<(), ContractError> {
+    if !storage::is_admin(env, address) {
+        return Err(ContractError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    if storage::is_paused(env) {
+        return Err(ContractError::ContractPaused);
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public governance functions (called from lib.rs entry points)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Creates a new governance proposal.
+///
+/// Validates action-specific preconditions at creation time, allocates a
+/// monotonically increasing proposal ID, and emits the appropriate events.
+pub fn do_propose(
+    env: &Env,
+    proposer: &Address,
+    action: ProposalAction,
+) -> Result<u64, ContractError> {
+    require_admin_role(env, proposer)?;
+    require_not_paused(env)?;
+
+    // Action-specific validation at proposal creation time
+    match &action {
+        ProposalAction::UpdateFee(bps) => {
+            if *bps > 10_000 {
+                return Err(ContractError::InvalidFeeBps);
+            }
+            if get_active_fee_proposal(env).is_some() {
+                return Err(ContractError::ProposalAlreadyPending);
+            }
+        }
+        ProposalAction::RegisterAgent(agent) => {
+            if is_agent_registered(env, agent) {
+                return Err(ContractError::AgentAlreadyRegistered);
+            }
+        }
+        ProposalAction::RemoveAgent(agent) => {
+            if !is_agent_registered(env, agent) {
+                return Err(ContractError::AgentNotRegistered);
+            }
+        }
+        ProposalAction::AddAdmin(addr) => {
+            if storage::is_admin(env, addr) {
+                return Err(ContractError::AlreadyAdmin);
+            }
+        }
+        ProposalAction::RemoveAdmin(addr) => {
+            let count = storage::get_admin_count(env);
+            let quorum = get_governance_quorum(env);
+            // Must keep at least 1 admin and must not drop below quorum
+            if count <= 1 || count.saturating_sub(1) < quorum {
+                return Err(ContractError::InsufficientAdmins);
+            }
+            if !storage::is_admin(env, addr) {
+                return Err(ContractError::AdminNotFound);
+            }
+        }
+        ProposalAction::UpdateQuorum(q) => {
+            let count = storage::get_admin_count(env);
+            if *q == 0 || *q > count {
+                return Err(ContractError::InvalidQuorum);
+            }
+        }
+        ProposalAction::UpdateTimelock(_) => {}
+    }
+
+    let id = next_proposal_id(env);
+    let now = env.ledger().timestamp();
+    let ttl = get_proposal_ttl(env);
+
+    let proposal = Proposal {
+        id,
+        proposer: proposer.clone(),
+        action: action.clone(),
+        state: ProposalState::Pending,
+        created_at: now,
+        expiry: now + ttl,
+        approval_count: 0,
+        approval_timestamp: None,
+    };
+    set_proposal(env, &proposal);
+
+    // Set active fee proposal guard
+    if let ProposalAction::UpdateFee(_) = &action {
+        set_active_fee_proposal(env, Some(id));
+    }
+
+    // Emit action-specific creation events
+    let action_sym = action_type_symbol(env, &action);
+    emit_proposal_created(env, id, proposer.clone(), action_sym, proposal.expiry);
+
+    match &action {
+        ProposalAction::UpdateFee(bps) => {
+            emit_fee_update_proposed(env, id, *bps);
+        }
+        ProposalAction::RegisterAgent(agent) => {
+            emit_agent_management_proposed(
+                env,
+                id,
+                agent.clone(),
+                Symbol::new(env, "register"),
+            );
+        }
+        ProposalAction::RemoveAgent(agent) => {
+            emit_agent_management_proposed(
+                env,
+                id,
+                agent.clone(),
+                Symbol::new(env, "remove"),
+            );
+        }
+        _ => {}
+    }
+
+    Ok(id)
+}
+
+/// Casts an approval vote on a pending proposal.
+///
+/// When the approval count reaches quorum the proposal transitions to Approved.
+pub fn do_vote(
+    env: &Env,
+    voter: &Address,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    require_admin_role(env, voter)?;
+
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    if proposal.state != ProposalState::Pending {
+        return Err(ContractError::InvalidProposalState);
+    }
+    if has_governance_voted(env, proposal_id, voter) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    record_governance_vote(env, proposal_id, voter);
+    proposal.approval_count += 1;
+
+    emit_proposal_voted(env, proposal_id, voter.clone(), proposal.approval_count);
+
+    let quorum = get_governance_quorum(env);
+    if proposal.approval_count >= quorum {
+        let now = env.ledger().timestamp();
+        proposal.state = ProposalState::Approved;
+        proposal.approval_timestamp = Some(now);
+        emit_proposal_approved(env, proposal_id, now);
+    }
+
+    set_proposal(env, &proposal);
+    Ok(())
+}
+
+/// Executes an approved proposal after the timelock has elapsed.
+pub fn do_execute(
+    env: &Env,
+    executor: &Address,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    require_admin_role(env, executor)?;
+
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    if proposal.state != ProposalState::Approved {
+        return Err(ContractError::InvalidProposalState);
+    }
+
+    let timelock = get_governance_timelock(env);
+    let approved_at = proposal.approval_timestamp.unwrap_or(0);
+    let now = env.ledger().timestamp();
+    if now < approved_at + timelock {
+        return Err(ContractError::TimelockNotElapsed);
+    }
+
+    // Dispatch the action
+    dispatch_action(env, executor, &proposal.action, proposal_id)?;
+
+    proposal.state = ProposalState::Executed;
+    set_proposal(env, &proposal);
+
+    emit_proposal_executed(env, proposal_id, executor.clone());
+    Ok(())
+}
+
+/// Transitions an expired proposal to the Expired state.
+///
+/// Can be called by any address once the proposal TTL has elapsed.
+pub fn do_expire(
+    env: &Env,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    if proposal.state != ProposalState::Pending && proposal.state != ProposalState::Approved {
+        return Err(ContractError::InvalidProposalState);
+    }
+
+    let now = env.ledger().timestamp();
+    if now < proposal.expiry {
+        return Err(ContractError::InvalidProposalState);
+    }
+
+    // Clear active fee proposal guard if applicable
+    if let ProposalAction::UpdateFee(_) = &proposal.action {
+        if get_active_fee_proposal(env) == Some(proposal_id) {
+            set_active_fee_proposal(env, None);
+        }
+    }
+
+    proposal.state = ProposalState::Expired;
+    set_proposal(env, &proposal);
+
+    emit_proposal_expired(env, proposal_id);
+    Ok(())
+}
+
+/// One-time migration function callable only by the legacy admin.
+///
+/// Sets the initial governance quorum, timelock, and proposal TTL without
+/// requiring a proposal, enabling upgrade from the existing single-admin deployment.
+pub fn do_migrate(
+    env: &Env,
+    caller: &Address,
+    quorum: u32,
+    timelock_seconds: u64,
+    proposal_ttl_seconds: u64,
+) -> Result<(), ContractError> {
+    // Only the legacy admin may call this
+    let legacy_admin = storage::get_admin(env)?;
+    if *caller != legacy_admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    if is_governance_initialized(env) {
+        return Err(ContractError::GovernanceAlreadyInitialized);
+    }
+
+    let admin_count = storage::get_admin_count(env);
+    if quorum == 0 || quorum > admin_count {
+        return Err(ContractError::InvalidQuorum);
+    }
+
+    set_governance_quorum(env, quorum);
+    set_governance_timelock(env, timelock_seconds);
+    set_proposal_ttl(env, proposal_ttl_seconds);
+
+    // Seed the admin list with the legacy admin
+    add_admin_to_list(env, &legacy_admin);
+
+    set_governance_initialized(env);
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Action dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn dispatch_action(
+    env: &Env,
+    executor: &Address,
+    action: &ProposalAction,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    match action {
+        ProposalAction::UpdateFee(bps) => {
+            storage::set_platform_fee_bps(env, *bps);
+            set_active_fee_proposal(env, None);
+            emit_fee_updated(env, *bps);
+        }
+        ProposalAction::RegisterAgent(agent) => {
+            storage::set_agent_registered(env, agent, true);
+            assign_role(env, agent, &Role::Settler);
+            emit_agent_registered(env, agent.clone(), executor.clone(), None);
+        }
+        ProposalAction::RemoveAgent(agent) => {
+            storage::set_agent_registered(env, agent, false);
+            remove_role(env, agent, &Role::Settler);
+            emit_agent_removed(env, agent.clone(), executor.clone());
+        }
+        ProposalAction::AddAdmin(addr) => {
+            if storage::is_admin(env, addr) {
+                return Err(ContractError::AlreadyAdmin);
+            }
+            storage::set_admin_role(env, addr, true);
+            assign_role(env, addr, &Role::Admin);
+            let count = storage::get_admin_count(env);
+            storage::set_admin_count(env, count + 1);
+            add_admin_to_list(env, addr);
+            emit_governance_admin_added(env, addr.clone(), proposal_id);
+        }
+        ProposalAction::RemoveAdmin(addr) => {
+            let count = storage::get_admin_count(env);
+            let quorum = get_governance_quorum(env);
+            if count <= 1 || count.saturating_sub(1) < quorum {
+                return Err(ContractError::InsufficientAdmins);
+            }
+            storage::set_admin_role(env, addr, false);
+            remove_role(env, addr, &Role::Admin);
+            storage::set_admin_count(env, count - 1);
+            remove_admin_from_list(env, addr);
+            // Keep legacy admin key aligned
+            if let Ok(legacy) = storage::get_admin(env) {
+                if legacy == *addr {
+                    storage::set_admin(env, executor);
+                }
+            }
+            emit_governance_admin_removed(env, addr.clone(), proposal_id);
+        }
+        ProposalAction::UpdateQuorum(q) => {
+            let count = storage::get_admin_count(env);
+            if *q == 0 || *q > count {
+                return Err(ContractError::InvalidQuorum);
+            }
+            set_governance_quorum(env, *q);
+        }
+        ProposalAction::UpdateTimelock(s) => {
+            set_governance_timelock(env, *s);
+        }
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn action_type_symbol(env: &Env, action: &ProposalAction) -> Symbol {
+    match action {
+        ProposalAction::UpdateFee(_) => Symbol::new(env, "update_fee"),
+        ProposalAction::RegisterAgent(_) => Symbol::new(env, "reg_agent"),
+        ProposalAction::RemoveAgent(_) => Symbol::new(env, "rem_agent"),
+        ProposalAction::AddAdmin(_) => Symbol::new(env, "add_admin"),
+        ProposalAction::RemoveAdmin(_) => Symbol::new(env, "rem_admin"),
+        ProposalAction::UpdateQuorum(_) => Symbol::new(env, "upd_quorum"),
+        ProposalAction::UpdateTimelock(_) => Symbol::new(env, "upd_tlock"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,11 @@ mod verification;
 mod recipient_verification;
 #[cfg(test)]
 mod test_recipient_verification;
+mod governance;
+#[cfg(test)]
+mod test_governance;
+#[cfg(test)]
+mod test_governance_property;
 
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, String, Vec};
 
@@ -2840,5 +2845,83 @@ impl SwiftRemitContract {
     /// Returns the current `RECIPIENT_HASH_SCHEMA_VERSION`.
     pub fn rcpt_hash_schema_version() -> u32 {
         recipient_verification::get_recipient_hash_schema_version()
+    }
+
+    // ── Governance Entry Points ────────────────────────────────────────────
+
+    /// Creates a new governance proposal.
+    ///
+    /// The proposer must hold `Role::Admin`. Returns the new `proposal_id`.
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        action: ProposalAction,
+    ) -> Result<u64, ContractError> {
+        proposer.require_auth();
+        governance::do_propose(&env, &proposer, action)
+    }
+
+    /// Casts an approval vote on a pending proposal.
+    pub fn vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+    ) -> Result<(), ContractError> {
+        voter.require_auth();
+        governance::do_vote(&env, &voter, proposal_id)
+    }
+
+    /// Executes an approved proposal after the timelock has elapsed.
+    pub fn execute(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+    ) -> Result<(), ContractError> {
+        executor.require_auth();
+        governance::do_execute(&env, &executor, proposal_id)
+    }
+
+    /// Transitions an expired proposal to the Expired state.
+    ///
+    /// Can be called by any address once the proposal TTL has elapsed.
+    pub fn expire_proposal(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+        governance::do_expire(&env, proposal_id)
+    }
+
+    /// One-time migration from single-admin to multi-sig governance.
+    ///
+    /// Must be called by the legacy admin address. Sets the initial quorum,
+    /// timelock, and proposal TTL without requiring a proposal.
+    pub fn migrate_to_governance(
+        env: Env,
+        caller: Address,
+        quorum: u32,
+        timelock_seconds: u64,
+        proposal_ttl_seconds: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        governance::do_migrate(&env, &caller, quorum, timelock_seconds, proposal_ttl_seconds)
+    }
+
+    // ── Governance Read-Only Queries ───────────────────────────────────────
+
+    /// Returns the full proposal record for the given `proposal_id`.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, ContractError> {
+        storage::get_proposal(&env, proposal_id)
+    }
+
+    /// Returns the current list of admin addresses.
+    pub fn get_admins(env: Env) -> soroban_sdk::Vec<Address> {
+        storage::get_admin_list(&env)
+    }
+
+    /// Returns the current governance quorum threshold.
+    pub fn get_quorum(env: Env) -> u32 {
+        storage::get_governance_quorum(&env)
+    }
+
+    /// Returns the current governance execution timelock in seconds.
+    pub fn get_timelock_seconds(env: Env) -> u64 {
+        storage::get_governance_timelock(&env)
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -240,17 +240,41 @@ enum DataKey {
 
     /// Minimum number of admin votes required to unpause (instance storage, default 1).
     UnpauseQuorum,
-    // === Token Fee Configuration ===
-    /// Token-specific fee in basis points indexed by token address (persistent storage).
-    TokenFeeBps(Address),
-
-    // === Agent Statistics ===
-    /// Agent performance statistics indexed by agent address (persistent storage).
-    AgentStats(Address),
 
     // === Recipient Address Verification ===
     /// Stored recipient hash record indexed by remittance_id (persistent storage).
     RecipientHash(u64),
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Governance Keys
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Monotonically increasing proposal ID counter (instance storage).
+    GovernanceProposalCounter,
+
+    /// Proposal record indexed by proposal_id (persistent storage).
+    GovernanceProposal(u64),
+
+    /// Vote flag: (proposal_id, voter_address) → bool (persistent storage).
+    GovernanceVote(u64, Address),
+
+    /// Configured quorum for governance proposals (instance storage).
+    GovernanceQuorum,
+
+    /// Timelock in seconds between approval and execution (instance storage).
+    GovernanceTimelockSeconds,
+
+    /// TTL in seconds for proposals before they expire (instance storage).
+    GovernanceProposalTtl,
+
+    /// Proposal ID of the currently active fee proposal, if any (instance storage).
+    ActiveFeeProposal,
+
+    /// Flag: governance has been initialized via migrate_to_governance (instance storage).
+    GovernanceInitialized,
+
+    /// Ordered list of current admin addresses for iteration (instance storage).
+    AdminList,
 }
 
 #[contracttype]
@@ -1724,4 +1748,167 @@ pub fn append_sender_remittance(env: &Env, sender: &Address, remittance_id: u64)
 pub fn get_sender_remittances(env: &Env, sender: &Address) -> soroban_sdk::Vec<u64> {
     let _ = (env, sender);
     soroban_sdk::Vec::new(env)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Governance Storage Accessors
+// ─────────────────────────────────────────────────────────────────────────────
+
+use crate::{Proposal, ProposalAction, ProposalState};
+
+/// Returns the next proposal ID and increments the counter.
+pub fn next_proposal_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::GovernanceProposalCounter)
+        .unwrap_or(0u64);
+    let next = current + 1;
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceProposalCounter, &next);
+    next
+}
+
+/// Retrieves a proposal by ID.
+pub fn get_proposal(env: &Env, id: u64) -> Result<Proposal, ContractError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::GovernanceProposal(id))
+        .ok_or(ContractError::ProposalNotFound)
+}
+
+/// Stores a proposal record.
+pub fn set_proposal(env: &Env, proposal: &Proposal) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::GovernanceProposal(proposal.id), proposal);
+}
+
+/// Returns true if the given voter has already voted on the given proposal.
+pub fn has_governance_voted(env: &Env, proposal_id: u64, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::GovernanceVote(proposal_id, voter.clone()))
+}
+
+/// Records that the given voter has voted on the given proposal.
+pub fn record_governance_vote(env: &Env, proposal_id: u64, voter: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::GovernanceVote(proposal_id, voter.clone()), &true);
+}
+
+/// Returns the configured governance quorum (defaults to 1).
+pub fn get_governance_quorum(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::GovernanceQuorum)
+        .unwrap_or(1u32)
+}
+
+/// Stores the governance quorum.
+pub fn set_governance_quorum(env: &Env, quorum: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceQuorum, &quorum);
+}
+
+/// Returns the governance execution timelock in seconds (defaults to 0).
+pub fn get_governance_timelock(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::GovernanceTimelockSeconds)
+        .unwrap_or(0u64)
+}
+
+/// Stores the governance execution timelock in seconds.
+pub fn set_governance_timelock(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceTimelockSeconds, &seconds);
+}
+
+/// Returns the proposal TTL in seconds (defaults to 7 days).
+pub fn get_proposal_ttl(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::GovernanceProposalTtl)
+        .unwrap_or(604_800u64)
+}
+
+/// Stores the proposal TTL in seconds.
+pub fn set_proposal_ttl(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceProposalTtl, &seconds);
+}
+
+/// Returns the list of current admin addresses.
+pub fn get_admin_list(env: &Env) -> soroban_sdk::Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AdminList)
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+}
+
+/// Adds an address to the admin list if not already present.
+pub fn add_admin_to_list(env: &Env, admin: &Address) {
+    let mut list = get_admin_list(env);
+    // Avoid duplicates
+    for i in 0..list.len() {
+        if list.get(i).unwrap() == *admin {
+            return;
+        }
+    }
+    list.push_back(admin.clone());
+    env.storage().instance().set(&DataKey::AdminList, &list);
+}
+
+/// Removes an address from the admin list.
+pub fn remove_admin_from_list(env: &Env, admin: &Address) {
+    let list = get_admin_list(env);
+    let mut new_list: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(env);
+    for i in 0..list.len() {
+        let entry = list.get(i).unwrap();
+        if entry != *admin {
+            new_list.push_back(entry);
+        }
+    }
+    env.storage().instance().set(&DataKey::AdminList, &new_list);
+}
+
+/// Returns the proposal ID of the currently active fee proposal, if any.
+pub fn get_active_fee_proposal(env: &Env) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActiveFeeProposal)
+}
+
+/// Sets or clears the active fee proposal guard.
+pub fn set_active_fee_proposal(env: &Env, proposal_id: Option<u64>) {
+    match proposal_id {
+        Some(id) => env
+            .storage()
+            .instance()
+            .set(&DataKey::ActiveFeeProposal, &id),
+        None => env
+            .storage()
+            .instance()
+            .remove(&DataKey::ActiveFeeProposal),
+    }
+}
+
+/// Returns true if governance has been initialized.
+pub fn is_governance_initialized(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::GovernanceInitialized)
+}
+
+/// Marks governance as initialized.
+pub fn set_governance_initialized(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceInitialized, &true);
 }

--- a/src/test_governance.rs
+++ b/src/test_governance.rs
@@ -1,0 +1,522 @@
+//! Unit tests for the multi-admin / DAO governance module.
+//!
+//! Covers the full proposal lifecycle for each action type, error conditions,
+//! event emission, backward compatibility, and single-admin mode.
+
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+
+use crate::{
+    ContractError, Proposal, ProposalAction, ProposalState, SwiftRemitContract,
+    SwiftRemitContractClient,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn setup_env() -> (Env, SwiftRemitContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SwiftRemitContract);
+    let client = SwiftRemitContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn default_token(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn initialize(
+    env: &Env,
+    client: &SwiftRemitContractClient,
+    admin: &Address,
+) {
+    let token = default_token(env);
+    client.initialize(admin, &token, &30u32, &0u32, admin, &0u32);
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    let info = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        timestamp: info.timestamp + seconds,
+        ..info
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.1 — migrate_to_governance happy path and double-call rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_migrate_to_governance_happy_path() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    assert_eq!(client.get_quorum(), 1u32);
+    assert_eq!(client.get_timelock_seconds(), 0u64);
+}
+
+#[test]
+fn test_migrate_to_governance_double_call_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+    assert_eq!(result, Err(Ok(ContractError::GovernanceAlreadyInitialized)));
+}
+
+#[test]
+fn test_migrate_to_governance_non_admin_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    initialize(&env, &client, &admin);
+
+    let result = client.try_migrate_to_governance(&other, &1u32, &0u64, &604_800u64);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.2 — UpdateFee proposal lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_update_fee_proposal_lifecycle() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(500u32));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    let proposal = client.get_proposal(&pid);
+    assert_eq!(proposal.state, ProposalState::Executed);
+}
+
+#[test]
+fn test_update_fee_invalid_bps_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_propose(&admin, &ProposalAction::UpdateFee(10_001u32));
+    assert_eq!(result, Err(Ok(ContractError::InvalidFeeBps)));
+}
+
+#[test]
+fn test_duplicate_fee_proposal_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    let result = client.try_propose(&admin, &ProposalAction::UpdateFee(200u32));
+    assert_eq!(result, Err(Ok(ContractError::ProposalAlreadyPending)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.3 — RegisterAgent proposal lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_register_agent_proposal_lifecycle() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::RegisterAgent(agent.clone()));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    assert!(client.is_agent_registered(&agent));
+}
+
+#[test]
+fn test_register_already_registered_agent_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Register via governance first
+    let pid = client.propose(&admin, &ProposalAction::RegisterAgent(agent.clone()));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    // Second proposal for same agent should fail
+    let result = client.try_propose(&admin, &ProposalAction::RegisterAgent(agent.clone()));
+    assert_eq!(result, Err(Ok(ContractError::AgentAlreadyRegistered)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.4 — RemoveAgent proposal lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_remove_agent_proposal_lifecycle() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Register then remove
+    let pid1 = client.propose(&admin, &ProposalAction::RegisterAgent(agent.clone()));
+    client.vote(&admin, &pid1);
+    client.execute(&admin, &pid1);
+
+    let pid2 = client.propose(&admin, &ProposalAction::RemoveAgent(agent.clone()));
+    client.vote(&admin, &pid2);
+    client.execute(&admin, &pid2);
+
+    assert!(!client.is_agent_registered(&agent));
+}
+
+#[test]
+fn test_remove_unregistered_agent_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_propose(&admin, &ProposalAction::RemoveAgent(agent.clone()));
+    assert_eq!(result, Err(Ok(ContractError::AgentNotRegistered)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.5 — AddAdmin proposal lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_add_admin_proposal_lifecycle() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::AddAdmin(new_admin.clone()));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    assert!(client.is_admin(&new_admin));
+    assert_eq!(client.get_admin_count(), 2u32);
+
+    let admins = client.get_admins();
+    assert!(admins.contains(&new_admin));
+}
+
+#[test]
+fn test_add_existing_admin_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_propose(&admin, &ProposalAction::AddAdmin(admin.clone()));
+    assert_eq!(result, Err(Ok(ContractError::AlreadyAdmin)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.6 — RemoveAdmin proposal lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_remove_admin_proposal_lifecycle() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Add a second admin first
+    let pid1 = client.propose(&admin, &ProposalAction::AddAdmin(admin2.clone()));
+    client.vote(&admin, &pid1);
+    client.execute(&admin, &pid1);
+
+    // Now remove admin2 — quorum is 1, admin count is 2, so removal is valid
+    let pid2 = client.propose(&admin, &ProposalAction::RemoveAdmin(admin2.clone()));
+    client.vote(&admin, &pid2);
+    client.execute(&admin, &pid2);
+
+    assert!(!client.is_admin(&admin2));
+    assert_eq!(client.get_admin_count(), 1u32);
+}
+
+#[test]
+fn test_remove_last_admin_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_propose(&admin, &ProposalAction::RemoveAdmin(admin.clone()));
+    assert_eq!(result, Err(Ok(ContractError::InsufficientAdmins)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.7 — UpdateQuorum and UpdateTimelock proposals
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_update_quorum_proposal() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Add second admin so quorum of 2 is valid
+    let pid1 = client.propose(&admin, &ProposalAction::AddAdmin(admin2.clone()));
+    client.vote(&admin, &pid1);
+    client.execute(&admin, &pid1);
+
+    let pid2 = client.propose(&admin, &ProposalAction::UpdateQuorum(2u32));
+    client.vote(&admin, &pid2);
+    client.execute(&admin, &pid2);
+
+    assert_eq!(client.get_quorum(), 2u32);
+}
+
+#[test]
+fn test_update_timelock_proposal() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(3600u64));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    assert_eq!(client.get_timelock_seconds(), 3600u64);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.8 — Timelock enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_before_timelock_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    // Set a 1-hour timelock
+    client.migrate_to_governance(&admin, &1u32, &3600u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid);
+
+    // Try to execute immediately — should fail
+    let result = client.try_execute(&admin, &pid);
+    assert_eq!(result, Err(Ok(ContractError::TimelockNotElapsed)));
+}
+
+#[test]
+fn test_execute_after_timelock_succeeds() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &3600u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid);
+
+    // Advance time past the timelock
+    advance_time(&env, 3601);
+
+    client.execute(&admin, &pid);
+    let proposal = client.get_proposal(&pid);
+    assert_eq!(proposal.state, ProposalState::Executed);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.9 — Proposal expiry
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_expire_proposal_after_ttl() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    // Short TTL of 100 seconds
+    client.migrate_to_governance(&admin, &1u32, &0u64, &100u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+
+    // Advance past TTL
+    advance_time(&env, 101);
+
+    client.expire_proposal(&pid);
+    let proposal = client.get_proposal(&pid);
+    assert_eq!(proposal.state, ProposalState::Expired);
+}
+
+#[test]
+fn test_expire_proposal_before_ttl_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+
+    // Try to expire immediately — should fail
+    let result = client.try_expire_proposal(&pid);
+    assert_eq!(result, Err(Ok(ContractError::InvalidProposalState)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.10 — Single-admin mode: immediate execution
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_single_admin_immediate_execution() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    // quorum=1, timelock=0 → single-admin mode
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(250u32));
+    // One vote reaches quorum
+    client.vote(&admin, &pid);
+    // Execute immediately (no timelock)
+    client.execute(&admin, &pid);
+
+    let proposal = client.get_proposal(&pid);
+    assert_eq!(proposal.state, ProposalState::Executed);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.11 — Error conditions
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_non_admin_propose_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let result = client.try_propose(&other, &ProposalAction::UpdateFee(100u32));
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_non_admin_vote_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    let result = client.try_vote(&other, &pid);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn test_double_vote_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Add second admin so quorum can be 2
+    let pid0 = client.propose(&admin, &ProposalAction::AddAdmin(admin2.clone()));
+    client.vote(&admin, &pid0);
+    client.execute(&admin, &pid0);
+
+    // Set quorum to 2
+    let pid1 = client.propose(&admin, &ProposalAction::UpdateQuorum(2u32));
+    client.vote(&admin, &pid1);
+    client.vote(&admin2, &pid1);
+    client.execute(&admin, &pid1);
+
+    let pid2 = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid2);
+    let result = client.try_vote(&admin, &pid2);
+    assert_eq!(result, Err(Ok(ContractError::AlreadyVoted)));
+}
+
+#[test]
+fn test_execute_non_approved_proposal_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    // Don't vote — proposal stays Pending
+    let result = client.try_execute(&admin, &pid);
+    assert_eq!(result, Err(Ok(ContractError::InvalidProposalState)));
+}
+
+#[test]
+fn test_execute_already_executed_proposal_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    let result = client.try_execute(&admin, &pid);
+    assert_eq!(result, Err(Ok(ContractError::InvalidProposalState)));
+}
+
+#[test]
+fn test_invalid_quorum_at_migration_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+
+    // quorum=0 is invalid
+    let result = client.try_migrate_to_governance(&admin, &0u32, &0u64, &604_800u64);
+    assert_eq!(result, Err(Ok(ContractError::InvalidQuorum)));
+
+    // quorum > admin_count (1) is invalid
+    let result2 = client.try_migrate_to_governance(&admin, &2u32, &0u64, &604_800u64);
+    assert_eq!(result2, Err(Ok(ContractError::InvalidQuorum)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5.13 — Backward compatibility: get_admin returns legacy admin
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_admin_backward_compat_after_governance_init() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Legacy get_admin should still return the original admin
+    assert_eq!(client.get_admin().unwrap(), admin);
+}

--- a/src/test_governance_property.rs
+++ b/src/test_governance_property.rs
@@ -1,0 +1,512 @@
+//! Property-based tests for the multi-admin / DAO governance module.
+//!
+//! Each test verifies a universal correctness property across randomized inputs.
+//! Minimum 100 iterations per property (proptest default).
+//!
+//! Feature: multi-admin-dao-governance
+
+#![cfg(test)]
+
+extern crate std;
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+
+use crate::{ContractError, ProposalAction, ProposalState, SwiftRemitContract, SwiftRemitContractClient};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared setup helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn make_client(env: &Env) -> (SwiftRemitContractClient<'static>, Address) {
+    let contract_id = env.register_contract(None, SwiftRemitContract);
+    let client = SwiftRemitContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &token, &30u32, &0u32, &admin, &0u32);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+    (client, admin)
+}
+
+fn advance(env: &Env, seconds: u64) {
+    let info = env.ledger().get();
+    env.ledger().set(LedgerInfo {
+        timestamp: info.timestamp + seconds,
+        ..info
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P1: Admin count bounds invariant
+// Feature: multi-admin-dao-governance, Property 1: admin count == Role::Admin holders, in [1,20]
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_admin_count_bounds(adds in 1usize..=5usize) {
+        // Feature: multi-admin-dao-governance, Property 1: admin count == Role::Admin holders, in [1,20]
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let mut added: std::vec::Vec<Address> = std::vec![];
+        for _ in 0..adds {
+            let new_admin = Address::generate(&env);
+            let pid = client.propose(&admin, &ProposalAction::AddAdmin(new_admin.clone()));
+            client.vote(&admin, &pid);
+            client.execute(&admin, &pid);
+            added.push(new_admin);
+        }
+
+        let count = client.get_admin_count();
+        prop_assert!(count >= 1);
+        prop_assert!(count <= 20);
+        prop_assert_eq!(count as usize, adds + 1); // original admin + adds
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P2: get_admins() matches Role::Admin holders
+// Feature: multi-admin-dao-governance, Property 2: get_admins() == set of Role::Admin holders
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_admin_list_matches_role_holders(adds in 1usize..=4usize) {
+        // Feature: multi-admin-dao-governance, Property 2: get_admins() == set of Role::Admin holders
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let mut expected: std::vec::Vec<Address> = std::vec![admin.clone()];
+        for _ in 0..adds {
+            let new_admin = Address::generate(&env);
+            let pid = client.propose(&admin, &ProposalAction::AddAdmin(new_admin.clone()));
+            client.vote(&admin, &pid);
+            client.execute(&admin, &pid);
+            expected.push(new_admin);
+        }
+
+        let admins = client.get_admins();
+        prop_assert_eq!(admins.len() as usize, expected.len());
+        for addr in &expected {
+            prop_assert!(client.is_admin(addr));
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P3: Invalid quorum values are always rejected
+// Feature: multi-admin-dao-governance, Property 3: quorum=0 or quorum>admin_count → InvalidQuorum
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_invalid_quorum_rejected(bad_quorum in prop_oneof![Just(0u32), 3u32..=100u32]) {
+        // Feature: multi-admin-dao-governance, Property 3: quorum=0 or quorum>admin_count → InvalidQuorum
+        let env = make_env();
+        let contract_id = env.register_contract(None, SwiftRemitContract);
+        let client = SwiftRemitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(&admin, &token, &30u32, &0u32, &admin, &0u32);
+
+        // admin_count = 1; quorum=0 or quorum>1 should fail
+        let result = client.try_migrate_to_governance(&admin, &bad_quorum, &0u64, &604_800u64);
+        prop_assert_eq!(result, Err(Ok(ContractError::InvalidQuorum)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P4: Valid quorum update round-trip
+// Feature: multi-admin-dao-governance, Property 4: valid quorum update round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_quorum_update_round_trip(new_quorum in 1u32..=2u32) {
+        // Feature: multi-admin-dao-governance, Property 4: valid quorum update round-trip
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        // Add a second admin so quorum=2 is valid
+        let admin2 = Address::generate(&env);
+        let pid0 = client.propose(&admin, &ProposalAction::AddAdmin(admin2.clone()));
+        client.vote(&admin, &pid0);
+        client.execute(&admin, &pid0);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateQuorum(new_quorum));
+        client.vote(&admin, &pid);
+        if new_quorum == 2 {
+            client.vote(&admin2, &pid);
+        }
+        client.execute(&admin, &pid);
+
+        prop_assert_eq!(client.get_quorum(), new_quorum);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P5: Timelock update round-trip
+// Feature: multi-admin-dao-governance, Property 5: timelock update round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_timelock_update_round_trip(seconds in 0u64..=86_400u64) {
+        // Feature: multi-admin-dao-governance, Property 5: timelock update round-trip
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(seconds));
+        client.vote(&admin, &pid);
+        client.execute(&admin, &pid);
+
+        prop_assert_eq!(client.get_timelock_seconds(), seconds);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P6: Proposal IDs are unique and monotonically increasing
+// Feature: multi-admin-dao-governance, Property 6: proposal IDs are strictly increasing
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_proposal_ids_monotonically_increasing(n in 2usize..=6usize) {
+        // Feature: multi-admin-dao-governance, Property 6: proposal IDs are strictly increasing
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let mut ids: std::vec::Vec<u64> = std::vec![];
+        for i in 0..n {
+            let bps = (i as u32) * 10;
+            let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(bps as u64));
+            ids.push(pid);
+        }
+
+        for i in 1..ids.len() {
+            prop_assert!(ids[i] > ids[i - 1]);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P7: Non-admin callers always get Unauthorized
+// Feature: multi-admin-dao-governance, Property 7: non-admin callers get Unauthorized
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_non_admin_unauthorized(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 7: non-admin callers get Unauthorized
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+        let other = Address::generate(&env);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+
+        let r1 = client.try_propose(&other, &ProposalAction::UpdateTimelock(0u64));
+        prop_assert_eq!(r1, Err(Ok(ContractError::Unauthorized)));
+
+        let r2 = client.try_vote(&other, &pid);
+        prop_assert_eq!(r2, Err(Ok(ContractError::Unauthorized)));
+
+        let r3 = client.try_execute(&other, &pid);
+        prop_assert_eq!(r3, Err(Ok(ContractError::Unauthorized)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P8: Double-vote always returns AlreadyVoted
+// Feature: multi-admin-dao-governance, Property 8: double-vote returns AlreadyVoted
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_double_vote_rejected(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 8: double-vote returns AlreadyVoted
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        // Use a 2-admin, quorum-2 setup so the proposal stays Pending after first vote
+        let admin2 = Address::generate(&env);
+        let pid0 = client.propose(&admin, &ProposalAction::AddAdmin(admin2.clone()));
+        client.vote(&admin, &pid0);
+        client.execute(&admin, &pid0);
+
+        let pid1 = client.propose(&admin, &ProposalAction::UpdateQuorum(2u32));
+        client.vote(&admin, &pid1);
+        client.vote(&admin2, &pid1);
+        client.execute(&admin, &pid1);
+
+        let pid2 = client.propose(&admin, &ProposalAction::UpdateTimelock(60u64));
+        client.vote(&admin, &pid2);
+        let result = client.try_vote(&admin, &pid2);
+        prop_assert_eq!(result, Err(Ok(ContractError::AlreadyVoted)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P9: Exactly Q votes transitions proposal to Approved
+// Feature: multi-admin-dao-governance, Property 9: Q votes → Approved state
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_quorum_triggers_approved(extra_admins in 1usize..=3usize) {
+        // Feature: multi-admin-dao-governance, Property 9: Q votes → Approved state
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let mut all_admins: std::vec::Vec<Address> = std::vec![admin.clone()];
+        for _ in 0..extra_admins {
+            let a = Address::generate(&env);
+            let pid = client.propose(&admin, &ProposalAction::AddAdmin(a.clone()));
+            client.vote(&admin, &pid);
+            client.execute(&admin, &pid);
+            all_admins.push(a);
+        }
+
+        // Set quorum = total admin count
+        let q = all_admins.len() as u32;
+        let pid_q = client.propose(&admin, &ProposalAction::UpdateQuorum(q));
+        for a in &all_admins {
+            client.vote(a, &pid_q);
+        }
+        client.execute(&admin, &pid_q);
+
+        // Now create a proposal and vote with all admins
+        let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(10u64));
+        for (i, a) in all_admins.iter().enumerate() {
+            let p = client.get_proposal(&pid);
+            if i < all_admins.len() - 1 {
+                prop_assert_eq!(p.state, ProposalState::Pending);
+            }
+            client.vote(a, &pid);
+        }
+        let final_p = client.get_proposal(&pid);
+        prop_assert_eq!(final_p.state, ProposalState::Approved);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P10: Wrong-state execute returns InvalidProposalState; replay blocked
+// Feature: multi-admin-dao-governance, Property 10: wrong-state execute → InvalidProposalState
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_wrong_state_execute_rejected(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 10: wrong-state execute → InvalidProposalState
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        // Pending proposal — execute should fail
+        let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+        let r1 = client.try_execute(&admin, &pid);
+        prop_assert_eq!(r1, Err(Ok(ContractError::InvalidProposalState)));
+
+        // Execute after approval
+        client.vote(&admin, &pid);
+        client.execute(&admin, &pid);
+
+        // Replay — should fail
+        let r2 = client.try_execute(&admin, &pid);
+        prop_assert_eq!(r2, Err(Ok(ContractError::InvalidProposalState)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P11: expire_proposal succeeds after TTL
+// Feature: multi-admin-dao-governance, Property 11: expire_proposal succeeds after TTL
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_expire_after_ttl(ttl in 10u64..=1000u64) {
+        // Feature: multi-admin-dao-governance, Property 11: expire_proposal succeeds after TTL
+        let env = make_env();
+        let contract_id = env.register_contract(None, SwiftRemitContract);
+        let client = SwiftRemitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(&admin, &token, &30u32, &0u32, &admin, &0u32);
+        client.migrate_to_governance(&admin, &1u32, &0u64, &ttl);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+        advance(&env, ttl + 1);
+        client.expire_proposal(&pid);
+
+        let p = client.get_proposal(&pid);
+        prop_assert_eq!(p.state, ProposalState::Expired);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P12: Fee update proposal round-trip
+// Feature: multi-admin-dao-governance, Property 12: fee update round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_fee_update_round_trip(bps in 0u32..=10_000u32) {
+        // Feature: multi-admin-dao-governance, Property 12: fee update round-trip
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateFee(bps));
+        client.vote(&admin, &pid);
+        client.execute(&admin, &pid);
+
+        prop_assert_eq!(client.get_platform_fee_bps().unwrap(), bps);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P13: fee_bps > 10000 rejected at propose time
+// Feature: multi-admin-dao-governance, Property 13: fee_bps > 10000 → InvalidFeeBps
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_invalid_fee_bps_rejected(bps in 10_001u32..=u32::MAX) {
+        // Feature: multi-admin-dao-governance, Property 13: fee_bps > 10000 → InvalidFeeBps
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let result = client.try_propose(&admin, &ProposalAction::UpdateFee(bps));
+        prop_assert_eq!(result, Err(Ok(ContractError::InvalidFeeBps)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P14: Second active fee proposal returns ProposalAlreadyPending
+// Feature: multi-admin-dao-governance, Property 14: second fee proposal → ProposalAlreadyPending
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_duplicate_fee_proposal_rejected(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 14: second fee proposal → ProposalAlreadyPending
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+        let result = client.try_propose(&admin, &ProposalAction::UpdateFee(200u32));
+        prop_assert_eq!(result, Err(Ok(ContractError::ProposalAlreadyPending)));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P15: Agent register/remove round-trip
+// Feature: multi-admin-dao-governance, Property 15: agent register/remove round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_agent_round_trip(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 15: agent register/remove round-trip
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+        let agent = Address::generate(&env);
+
+        prop_assert!(!client.is_agent_registered(&agent));
+
+        let pid1 = client.propose(&admin, &ProposalAction::RegisterAgent(agent.clone()));
+        client.vote(&admin, &pid1);
+        client.execute(&admin, &pid1);
+        prop_assert!(client.is_agent_registered(&agent));
+
+        let pid2 = client.propose(&admin, &ProposalAction::RemoveAgent(agent.clone()));
+        client.vote(&admin, &pid2);
+        client.execute(&admin, &pid2);
+        prop_assert!(!client.is_agent_registered(&agent));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P16: Single-admin mode allows immediate execution
+// Feature: multi-admin-dao-governance, Property 16: single-admin mode → immediate execution
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_single_admin_immediate_execution(bps in 0u32..=10_000u32) {
+        // Feature: multi-admin-dao-governance, Property 16: single-admin mode → immediate execution
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateFee(bps));
+        client.vote(&admin, &pid);
+        client.execute(&admin, &pid);
+
+        let p = client.get_proposal(&pid);
+        prop_assert_eq!(p.state, ProposalState::Executed);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P17: approval_count never exceeds admin count
+// Feature: multi-admin-dao-governance, Property 17: approval_count <= admin_count always
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_approval_count_never_exceeds_admin_count(extra in 0usize..=3usize) {
+        // Feature: multi-admin-dao-governance, Property 17: approval_count <= admin_count always
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        let mut all_admins: std::vec::Vec<Address> = std::vec![admin.clone()];
+        for _ in 0..extra {
+            let a = Address::generate(&env);
+            let pid = client.propose(&admin, &ProposalAction::AddAdmin(a.clone()));
+            client.vote(&admin, &pid);
+            client.execute(&admin, &pid);
+            all_admins.push(a);
+        }
+
+        // Set quorum to total count so proposal stays Pending while voting
+        let q = all_admins.len() as u32;
+        let pid_q = client.propose(&admin, &ProposalAction::UpdateQuorum(q));
+        for a in &all_admins {
+            client.vote(a, &pid_q);
+        }
+        client.execute(&admin, &pid_q);
+
+        let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(5u64));
+        for a in &all_admins {
+            client.vote(a, &pid);
+            let p = client.get_proposal(&pid);
+            prop_assert!(p.approval_count <= client.get_admin_count());
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P18: propose while paused returns ContractPaused
+// Feature: multi-admin-dao-governance, Property 18: propose while paused → ContractPaused
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_propose_while_paused_rejected(_seed in 0u32..=100u32) {
+        // Feature: multi-admin-dao-governance, Property 18: propose while paused → ContractPaused
+        let env = make_env();
+        let (client, admin) = make_client(&env);
+
+        // Pause the contract
+        client.pause(&admin);
+
+        let result = client.try_propose(&admin, &ProposalAction::UpdateFee(100u32));
+        prop_assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -319,3 +319,59 @@ pub struct IdempotencyRecord {
     /// Timestamp when this record expires (ledger timestamp)
     pub expires_at: u64,
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Governance Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The action a governance proposal will execute if approved.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalAction {
+    /// Update the platform fee to the given basis points value.
+    UpdateFee(u32),
+    /// Register the given address as a payout agent.
+    RegisterAgent(Address),
+    /// Remove the given address from the payout agent set.
+    RemoveAgent(Address),
+    /// Grant Admin role to the given address.
+    AddAdmin(Address),
+    /// Revoke Admin role from the given address.
+    RemoveAdmin(Address),
+    /// Update the governance quorum threshold.
+    UpdateQuorum(u32),
+    /// Update the governance execution timelock in seconds.
+    UpdateTimelock(u64),
+}
+
+/// Lifecycle state of a governance proposal.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalState {
+    Pending,
+    Approved,
+    Executed,
+    Expired,
+}
+
+/// A governance proposal record stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    /// Unique monotonically increasing proposal identifier.
+    pub id: u64,
+    /// Address that created this proposal.
+    pub proposer: Address,
+    /// The action to execute when approved.
+    pub action: ProposalAction,
+    /// Current lifecycle state.
+    pub state: ProposalState,
+    /// Ledger timestamp when the proposal was created.
+    pub created_at: u64,
+    /// Ledger timestamp after which the proposal expires if not executed.
+    pub expiry: u64,
+    /// Number of distinct admin approvals received.
+    pub approval_count: u32,
+    /// Ledger timestamp when quorum was reached (set on Approved transition).
+    pub approval_timestamp: Option<u64>,
+}


### PR DESCRIPTION
Replace single-admin model with a multi-sig / DAO voting mechanism for fee updates and agent management.

Changes:
- src/types.rs: add ProposalAction, ProposalState, Proposal types
- src/errors.rs: fix duplicate error codes (56-59), add governance error variants (67-74)
- src/events.rs: fix unclosed delimiter, add 9 governance events
- src/storage.rs: add governance DataKey variants and all accessors, remove duplicate DataKey entries
- src/governance.rs: new module — do_propose, do_vote, do_execute, do_expire, do_migrate
- src/lib.rs: wire up propose/vote/execute/expire_proposal/ migrate_to_governance entry points and read-only queries
- src/test_governance.rs: 20 unit tests covering full lifecycle
- src/test_governance_property.rs: 18 property-based tests (P1-P18)

Closes #374