### PR TITLE
feat: issues #416 #417 #418 #419 - governance cleanup, config query, …

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -161,7 +161,13 @@ The snapshot now includes **full agent records** (`AgentRecord` with `address`,
 ### Step 3 — Split into batches and import
 
 Split `MigrationSnapshot.persistent_data.remittances` into chunks of at most
-`MAX_MIGRATION_BATCH_SIZE` (100) items.  For each chunk:
+`MAX_MIGRATION_BATCH_SIZE` (100) items.  Batches **must** be submitted in strict
+sequential order starting from `batch_number = 0`.  Submitting a batch whose
+`batch_number` does not equal the next expected index returns
+`InvalidMigrationBatch` (32) and leaves the destination contract in its current
+state — no partial write occurs.
+
+For each chunk:
 
 ```bash
 soroban contract invoke \
@@ -173,6 +179,28 @@ soroban contract invoke \
 
 After the final batch the destination contract automatically clears the
 `MigrationInProgress` flag.
+
+### Step 3a — Abort a failed import (rollback)
+
+If an import fails mid-way (e.g. a batch hash mismatch, out-of-order batch, or
+off-chain tooling error), call `abort_migration` on the **destination** contract
+to reset the state machine back to Idle:
+
+```bash
+soroban contract invoke \
+  --id <DEST_CONTRACT_ID> \
+  -- abort_migration \
+  --caller <ADMIN_ADDRESS>
+```
+
+`abort_migration`:
+- Clears the `MigrationInProgress` flag (re-enables normal operations).
+- Resets the batch ordering counter so a fresh import can start from batch 0.
+- Emits a `migration_aborted` event for off-chain indexers.
+
+> **Note:** Any remittances already written by previous `import_migration_batch`
+> calls are **not** automatically removed.  If a clean slate is required,
+> re-initialize the destination contract before retrying the import.
 
 ### Step 4 — Verify
 
@@ -193,9 +221,9 @@ Update off-chain services to point to `<DEST_CONTRACT_ID>`.
 |-----------------------------|------|------------------------------------------------------------|
 | `MigrationInProgress`       | 31   | Export already called; or normal op blocked during migration |
 | `InvalidMigrationHash`      | 30   | Batch hash mismatch — data was tampered or corrupted       |
-| `InvalidMigrationBatch`     | 32   | `batch_number >= total_batches`                            |
+| `InvalidMigrationBatch`     | 32   | `batch_number != expected_next_batch` or `batch_number >= total_batches` |
 | `MigrationValidationFailed` | 56   | One or more agents unreadable after `migrate()`            |
-| `NotFound`                  | 57   | No rollback snapshot exists                                |
+| `NotFound`                  | 57   | No rollback snapshot exists; or `abort_migration` called when not in progress |
 | `Unauthorized`              | 20   | Caller does not have Admin role                            |
 
 ---

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -17,6 +17,7 @@ import type {
   HealthStatus,
   CreateRemittanceParams,
   BatchCreateEntry,
+  GovernanceConfig,
 } from "./types.js";
 import {
   parseRemittance,
@@ -531,5 +532,23 @@ export class SwiftRemitClient {
       u64ToScVal(remittanceId),
       i128ToScVal(amount),
     ]);
+  }
+
+  /**
+   * Returns the current governance configuration (quorum, timelock, proposal TTL).
+   * Read-only — no transaction required.
+   */
+  async getGovernanceConfig(sourceAddress: string): Promise<GovernanceConfig> {
+    const result = await this.simulateCall(
+      sourceAddress,
+      "query_governance_config",
+      []
+    );
+    const native = scValToNative(result);
+    return {
+      quorum: Number(native.quorum),
+      timelockSeconds: BigInt(native.timelock_seconds),
+      proposalTtlSeconds: BigInt(native.proposal_ttl_seconds),
+    };
   }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -13,6 +13,7 @@ export type {
   SettlementConfig,
   EscrowStatus,
   Role,
+  GovernanceConfig,
 } from "./types.js";
 export {
   parseRemittance,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -99,3 +99,12 @@ export interface SwiftRemitClientOptions {
   /** Base fee for transactions in stroops (default: 100) */
   fee?: string;
 }
+
+export interface GovernanceConfig {
+  /** Minimum number of admin approvals required to pass a proposal */
+  quorum: number;
+  /** Seconds that must elapse between approval and execution */
+  timelockSeconds: bigint;
+  /** Seconds after creation before a proposal expires */
+  proposalTtlSeconds: bigint;
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -750,3 +750,19 @@ pub fn emit_agent_management_proposed(env: &Env, proposal_id: u64, agent: Addres
         (SCHEMA_VERSION, proposal_id, agent, action),
     );
 }
+
+/// Emits when an expired or executed proposal is cleaned up from storage.
+pub fn emit_proposal_cleaned_up(env: &Env, proposal_id: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gov"), Symbol::new(env, "cleaned_up")),
+        (SCHEMA_VERSION, proposal_id),
+    );
+}
+
+/// Emits when a cross-contract migration is aborted and state is reset to Idle.
+pub fn emit_migration_aborted(env: &Env, caller: Address) {
+    env.events().publish(
+        (Symbol::new(env, "mig"), Symbol::new(env, "aborted")),
+        (SCHEMA_VERSION, env.ledger().sequence(), caller),
+    );
+}

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -12,11 +12,11 @@ use crate::{
     events::{
         emit_agent_management_proposed, emit_agent_registered, emit_agent_removed,
         emit_fee_update_proposed, emit_fee_updated, emit_governance_admin_added,
-        emit_governance_admin_removed, emit_proposal_approved, emit_proposal_created,
-        emit_proposal_executed, emit_proposal_expired, emit_proposal_voted,
+        emit_governance_admin_removed, emit_proposal_approved, emit_proposal_cleaned_up,
+        emit_proposal_created, emit_proposal_executed, emit_proposal_expired, emit_proposal_voted,
     },
     storage::{
-        self, add_admin_to_list, assign_role, get_active_fee_proposal,
+        self, add_admin_to_list, assign_role, delete_proposal, get_active_fee_proposal,
         get_governance_quorum, get_governance_timelock, get_proposal, get_proposal_ttl,
         has_governance_voted, is_agent_registered, is_governance_initialized,
         next_proposal_id, record_governance_vote, remove_admin_from_list, remove_role,
@@ -289,6 +289,37 @@ pub fn do_migrate(
     add_admin_to_list(env, &legacy_admin);
 
     set_governance_initialized(env);
+    Ok(())
+}
+
+/// Deletes expired or executed proposals from persistent storage to reclaim on-chain space.
+///
+/// Admin-only. For each supplied `proposal_id`:
+/// - If the proposal is in `Expired` or `Executed` state it is removed from storage
+///   and a `proposal_cleaned_up` event is emitted.
+/// - Proposals in `Pending` or `Approved` state are skipped (not an error).
+/// - Non-existent proposal IDs are silently skipped.
+///
+/// # Authorization
+/// Caller must hold `Role::Admin`.
+pub fn cleanup_expired_proposals(
+    env: &Env,
+    caller: &Address,
+    proposal_ids: soroban_sdk::Vec<u64>,
+) -> Result<(), ContractError> {
+    require_admin_role(env, caller)?;
+
+    for i in 0..proposal_ids.len() {
+        let id = proposal_ids.get_unchecked(i);
+        if let Ok(proposal) = get_proposal(env, id) {
+            if proposal.state == ProposalState::Expired
+                || proposal.state == ProposalState::Executed
+            {
+                delete_proposal(env, id);
+                emit_proposal_cleaned_up(env, id);
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2928,4 +2928,43 @@ impl SwiftRemitContract {
     pub fn get_timelock_seconds(env: Env) -> u64 {
         storage::get_governance_timelock(&env)
     }
+
+    /// Returns quorum, timelock, and proposal TTL in a single call.
+    ///
+    /// Allows integrators and frontends to display current governance parameters
+    /// without reading raw storage or making three separate queries.
+    pub fn query_governance_config(env: Env) -> GovernanceConfig {
+        GovernanceConfig {
+            quorum: storage::get_governance_quorum(&env),
+            timelock_seconds: storage::get_governance_timelock(&env),
+            proposal_ttl_seconds: storage::get_proposal_ttl(&env),
+        }
+    }
+
+    /// Deletes expired or executed proposals from persistent storage.
+    ///
+    /// Admin-only. Proposals in `Pending` or `Approved` state are skipped.
+    /// Emits a `proposal_cleaned_up` event for each deleted proposal.
+    pub fn cleanup_expired_proposals(
+        env: Env,
+        caller: Address,
+        proposal_ids: soroban_sdk::Vec<u64>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        governance::cleanup_expired_proposals(&env, &caller, proposal_ids)
+    }
+
+    /// Aborts an in-progress cross-contract migration and resets the state machine to Idle.
+    ///
+    /// Clears the `MigrationInProgress` flag and the batch ordering counter, then emits
+    /// a `migration_aborted` event. Admin only.
+    ///
+    /// # Errors
+    /// - `NotFound` — no migration is currently in progress.
+    /// - `Unauthorized` — caller is not an admin.
+    pub fn abort_migration(env: Env, caller: Address) -> Result<(), ContractError> {
+        get_admin(&env)?;
+        require_admin(&env, &caller)?;
+        migration::abort_migration(&env, &caller)
+    }
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -150,6 +150,8 @@ enum MigrationKey {
     SchemaVersion,
     /// Stores a `RollbackSnapshot` taken before the last `migrate()` run.
     RollbackSnapshot,
+    /// Tracks the next expected batch index during a cross-contract import.
+    ExpectedNextBatch,
 }
 
 fn get_schema_version(env: &Env) -> u32 {
@@ -181,6 +183,27 @@ fn clear_rollback_snapshot(env: &Env) {
     env.storage()
         .instance()
         .remove(&MigrationKey::RollbackSnapshot);
+}
+
+// ─── Batch ordering helpers ───────────────────────────────────────────────────
+
+fn get_expected_next_batch(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&MigrationKey::ExpectedNextBatch)
+        .unwrap_or(0u32)
+}
+
+fn set_expected_next_batch(env: &Env, next: u32) {
+    env.storage()
+        .instance()
+        .set(&MigrationKey::ExpectedNextBatch, &next);
+}
+
+fn clear_expected_next_batch(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&MigrationKey::ExpectedNextBatch);
 }
 
 // ─── Helper: status byte ─────────────────────────────────────────────────────
@@ -358,6 +381,38 @@ pub fn rollback_migration(env: &Env) -> Result<(), ContractError> {
     env.events().publish(
         soroban_sdk::symbol_short!("rolled_back"),
         snapshot.from_version,
+    );
+
+    Ok(())
+}
+
+/// Aborts an in-progress cross-contract migration and resets the state machine to Idle.
+///
+/// Clears the `MigrationInProgress` flag, resets the batch ordering counter, and
+/// emits a `migration_aborted` event so off-chain indexers can detect the rollback.
+/// Any partially imported data written by previous `import_migration_batch` calls
+/// is **not** automatically removed — the destination contract should be considered
+/// dirty and re-initialized if a clean slate is required.
+///
+/// # Authorization
+/// Caller must be an admin. Auth is enforced at the call site in `lib.rs`.
+///
+/// # Errors
+/// - `ContractError::NotFound` — no migration is currently in progress.
+pub fn abort_migration(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    if !crate::storage::is_migration_in_progress(env) {
+        return Err(ContractError::NotFound);
+    }
+
+    // Reset state machine to Idle.
+    crate::storage::set_migration_in_progress(env, false);
+
+    // Reset batch ordering counter.
+    clear_expected_next_batch(env);
+
+    env.events().publish(
+        (soroban_sdk::Symbol::new(env, "mig"), soroban_sdk::Symbol::new(env, "aborted")),
+        (crate::config::SCHEMA_VERSION, env.ledger().sequence(), caller.clone()),
     );
 
     Ok(())
@@ -553,9 +608,23 @@ pub fn import_batch(env: &Env, batch: MigrationBatch) -> Result<(), ContractErro
         return Err(ContractError::InvalidMigrationHash);
     }
 
+    // Enforce strict monotonic ordering: reject any batch whose index != expected_next_batch.
+    let expected = get_expected_next_batch(env);
+    if batch.batch_number != expected {
+        return Err(ContractError::InvalidMigrationBatch);
+    }
+
     for i in 0..batch.remittances.len() {
         let remittance = batch.remittances.get_unchecked(i);
         crate::storage::set_remittance(env, remittance.id, &remittance);
+    }
+
+    // Advance the counter for the next expected batch.
+    set_expected_next_batch(env, expected + 1);
+
+    // Clear the counter after the final batch so it doesn't linger.
+    if batch.batch_number == batch.total_batches.saturating_sub(1) {
+        clear_expected_next_batch(env);
     }
 
     Ok(())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1785,6 +1785,13 @@ pub fn set_proposal(env: &Env, proposal: &Proposal) {
         .set(&DataKey::GovernanceProposal(proposal.id), proposal);
 }
 
+/// Deletes a proposal record from persistent storage.
+pub fn delete_proposal(env: &Env, id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::GovernanceProposal(id));
+}
+
 /// Returns true if the given voter has already voted on the given proposal.
 pub fn has_governance_voted(env: &Env, proposal_id: u64, voter: &Address) -> bool {
     env.storage()

--- a/src/test_governance.rs
+++ b/src/test_governance.rs
@@ -520,3 +520,115 @@ fn test_get_admin_backward_compat_after_governance_init() {
     // Legacy get_admin should still return the original admin
     assert_eq!(client.get_admin().unwrap(), admin);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #416 — cleanup_expired_proposals
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_cleanup_expired_proposal_removes_from_storage() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &100u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+
+    // Expire the proposal
+    advance_time(&env, 101);
+    client.expire_proposal(&pid);
+
+    // Cleanup
+    let ids = soroban_sdk::vec![&env, pid];
+    client.cleanup_expired_proposals(&admin, &ids);
+
+    // get_proposal should now return ProposalNotFound
+    let result = client.try_get_proposal(&pid);
+    assert_eq!(result, Err(Ok(ContractError::ProposalNotFound)));
+}
+
+#[test]
+fn test_cleanup_executed_proposal_removes_from_storage() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    let ids = soroban_sdk::vec![&env, pid];
+    client.cleanup_expired_proposals(&admin, &ids);
+
+    let result = client.try_get_proposal(&pid);
+    assert_eq!(result, Err(Ok(ContractError::ProposalNotFound)));
+}
+
+#[test]
+fn test_cleanup_pending_proposal_is_skipped() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+
+    // Cleanup while still Pending — should be a no-op
+    let ids = soroban_sdk::vec![&env, pid];
+    client.cleanup_expired_proposals(&admin, &ids);
+
+    // Proposal should still exist
+    let proposal = client.get_proposal(&pid);
+    assert_eq!(proposal.state, ProposalState::Pending);
+}
+
+#[test]
+fn test_cleanup_non_admin_rejected() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    let pid = client.propose(&admin, &ProposalAction::UpdateFee(100u32));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    let ids = soroban_sdk::vec![&env, pid];
+    let result = client.try_cleanup_expired_proposals(&other, &ids);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #417 — query_governance_config
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_query_governance_config_returns_correct_values() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &3600u64, &86_400u64);
+
+    let config = client.query_governance_config();
+    assert_eq!(config.quorum, 1u32);
+    assert_eq!(config.timelock_seconds, 3600u64);
+    assert_eq!(config.proposal_ttl_seconds, 86_400u64);
+}
+
+#[test]
+fn test_query_governance_config_reflects_updates() {
+    let (env, client) = setup_env();
+    let admin = Address::generate(&env);
+    initialize(&env, &client, &admin);
+    client.migrate_to_governance(&admin, &1u32, &0u64, &604_800u64);
+
+    // Update timelock via proposal
+    let pid = client.propose(&admin, &ProposalAction::UpdateTimelock(7200u64));
+    client.vote(&admin, &pid);
+    client.execute(&admin, &pid);
+
+    let config = client.query_governance_config();
+    assert_eq!(config.timelock_seconds, 7200u64);
+}

--- a/src/test_migration.rs
+++ b/src/test_migration.rs
@@ -288,3 +288,239 @@ fn build_single_batch(env: &Env, snapshot: &MigrationSnapshot) -> MigrationBatch
         batch_hash,
     }
 }
+
+// ─── Issue #418 — strict monotonic batch ordering ────────────────────────────
+
+#[test]
+fn test_import_batch_rejects_out_of_order_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, token) = setup(&env);
+    let sender = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    token.mint(&sender, &100_000);
+    contract.register_agent(&agent, &None);
+
+    // Create 2 remittances so we have 2 batches
+    contract.create_remittance(&sender, &agent, &10_000, &None, &None, &None, &None, &None);
+    contract.create_remittance(&sender, &agent, &20_000, &None, &None, &None, &None, &None);
+
+    let snapshot = contract.export_migration_snapshot(&admin);
+
+    // Build batch 1 (out of order — should be rejected before batch 0)
+    let remittances = snapshot.persistent_data.remittances.clone();
+    let batch_1 = {
+        let mut data = soroban_sdk::Bytes::new(&env);
+        let batch_number: u32 = 1;
+        data.append(&soroban_sdk::Bytes::from_array(&env, &batch_number.to_be_bytes()));
+        for i in 0..remittances.len() {
+            let r = remittances.get_unchecked(i);
+            data.append(&soroban_sdk::Bytes::from_array(&env, &r.id.to_be_bytes()));
+            data.append(&r.sender.clone().to_xdr(&env));
+            data.append(&r.agent.clone().to_xdr(&env));
+            data.append(&soroban_sdk::Bytes::from_array(&env, &r.amount.to_be_bytes()));
+            data.append(&soroban_sdk::Bytes::from_array(&env, &r.fee.to_be_bytes()));
+            let status_byte: u8 = match r.status {
+                crate::RemittanceStatus::Pending => 0,
+                crate::RemittanceStatus::Completed => 1,
+                crate::RemittanceStatus::Cancelled => 2,
+                _ => 0,
+            };
+            data.append(&soroban_sdk::Bytes::from_array(&env, &[status_byte]));
+            if let Some(expiry) = r.expiry {
+                data.append(&soroban_sdk::Bytes::from_array(&env, &expiry.to_be_bytes()));
+            }
+        }
+        let hash_bytes = env.crypto().sha256(&data);
+        MigrationBatch {
+            batch_number: 1,
+            total_batches: 2,
+            remittances: remittances.clone(),
+            batch_hash: BytesN::from_array(&env, &hash_bytes.to_array()),
+        }
+    };
+
+    // Submitting batch 1 before batch 0 must fail
+    let result = contract.try_import_migration_batch(&admin, &batch_1);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::InvalidMigrationBatch
+    );
+}
+
+#[test]
+fn test_import_batch_rejects_duplicate_batch_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, _token) = setup(&env);
+    let snapshot = contract.export_migration_snapshot(&admin);
+
+    // Import batch 0 successfully
+    let batch0 = build_single_batch(&env, &snapshot);
+    contract.import_migration_batch(&admin, &batch0);
+
+    // Submitting batch 0 again must fail (duplicate)
+    // We need to rebuild it since the first import consumed it
+    // Re-export is blocked (MigrationInProgress cleared after final batch)
+    // Instead test with a fresh contract
+    let env2 = Env::default();
+    env2.mock_all_auths();
+    let (contract2, admin2, _token2) = setup(&env2);
+    let snapshot2 = contract2.export_migration_snapshot(&admin2);
+
+    // Build two-batch scenario by manually constructing batch 0 twice
+    let remittances = snapshot2.persistent_data.remittances.clone();
+    let batch_0a = build_single_batch(&env2, &snapshot2);
+
+    // Simulate a two-batch total so the lock isn't cleared after first import
+    let batch_0b = MigrationBatch {
+        batch_number: 0,
+        total_batches: 2, // pretend there are 2 batches
+        remittances: remittances.clone(),
+        batch_hash: {
+            let mut data = soroban_sdk::Bytes::new(&env2);
+            let bn: u32 = 0;
+            data.append(&soroban_sdk::Bytes::from_array(&env2, &bn.to_be_bytes()));
+            for i in 0..remittances.len() {
+                let r = remittances.get_unchecked(i);
+                data.append(&soroban_sdk::Bytes::from_array(&env2, &r.id.to_be_bytes()));
+                data.append(&r.sender.clone().to_xdr(&env2));
+                data.append(&r.agent.clone().to_xdr(&env2));
+                data.append(&soroban_sdk::Bytes::from_array(&env2, &r.amount.to_be_bytes()));
+                data.append(&soroban_sdk::Bytes::from_array(&env2, &r.fee.to_be_bytes()));
+                let status_byte: u8 = match r.status {
+                    crate::RemittanceStatus::Pending => 0,
+                    crate::RemittanceStatus::Completed => 1,
+                    crate::RemittanceStatus::Cancelled => 2,
+                    _ => 0,
+                };
+                data.append(&soroban_sdk::Bytes::from_array(&env2, &[status_byte]));
+                if let Some(expiry) = r.expiry {
+                    data.append(&soroban_sdk::Bytes::from_array(&env2, &expiry.to_be_bytes()));
+                }
+            }
+            let h = env2.crypto().sha256(&data);
+            BytesN::from_array(&env2, &h.to_array())
+        },
+    };
+
+    // Import batch 0 (total_batches=2, so lock stays)
+    contract2.import_migration_batch(&admin2, &batch_0b);
+
+    // Submitting batch 0 again must fail
+    let dup = MigrationBatch {
+        batch_number: 0,
+        total_batches: 2,
+        remittances: remittances.clone(),
+        batch_hash: batch_0b.batch_hash.clone(),
+    };
+    let result = contract2.try_import_migration_batch(&admin2, &dup);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::InvalidMigrationBatch
+    );
+}
+
+// ─── Issue #419 — abort_migration ────────────────────────────────────────────
+
+#[test]
+fn test_abort_migration_resets_state_to_idle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, _token) = setup(&env);
+
+    // Lock via export
+    contract.export_migration_snapshot(&admin);
+
+    // Abort
+    contract.abort_migration(&admin);
+
+    // Normal ops should be unblocked
+    assert!(!contract.is_paused());
+
+    // A second export should now succeed (state is Idle again)
+    contract.export_migration_snapshot(&admin);
+}
+
+#[test]
+fn test_abort_migration_when_not_in_progress_returns_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, _token) = setup(&env);
+
+    let result = contract.try_abort_migration(&admin);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::NotFound
+    );
+}
+
+#[test]
+fn test_abort_migration_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, _token) = setup(&env);
+    let other = Address::generate(&env);
+
+    contract.export_migration_snapshot(&admin);
+
+    let result = contract.try_abort_migration(&other);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_abort_migration_resets_batch_counter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract, admin, _token) = setup(&env);
+    let snapshot = contract.export_migration_snapshot(&admin);
+
+    // Build a two-batch scenario and import batch 0
+    let remittances = snapshot.persistent_data.remittances.clone();
+    let batch_0 = MigrationBatch {
+        batch_number: 0,
+        total_batches: 2,
+        remittances: remittances.clone(),
+        batch_hash: {
+            let mut data = soroban_sdk::Bytes::new(&env);
+            let bn: u32 = 0u32;
+            data.append(&soroban_sdk::Bytes::from_array(&env, &bn.to_be_bytes()));
+            for i in 0..remittances.len() {
+                let r = remittances.get_unchecked(i);
+                data.append(&soroban_sdk::Bytes::from_array(&env, &r.id.to_be_bytes()));
+                data.append(&r.sender.clone().to_xdr(&env));
+                data.append(&r.agent.clone().to_xdr(&env));
+                data.append(&soroban_sdk::Bytes::from_array(&env, &r.amount.to_be_bytes()));
+                data.append(&soroban_sdk::Bytes::from_array(&env, &r.fee.to_be_bytes()));
+                let status_byte: u8 = match r.status {
+                    crate::RemittanceStatus::Pending => 0,
+                    crate::RemittanceStatus::Completed => 1,
+                    crate::RemittanceStatus::Cancelled => 2,
+                    _ => 0,
+                };
+                data.append(&soroban_sdk::Bytes::from_array(&env, &[status_byte]));
+                if let Some(expiry) = r.expiry {
+                    data.append(&soroban_sdk::Bytes::from_array(&env, &expiry.to_be_bytes()));
+                }
+            }
+            let h = env.crypto().sha256(&data);
+            BytesN::from_array(&env, &h.to_array())
+        },
+    };
+    contract.import_migration_batch(&admin, &batch_0);
+
+    // Abort — resets batch counter
+    contract.abort_migration(&admin);
+
+    // Re-export and import from batch 0 again — should succeed
+    let snapshot2 = contract.export_migration_snapshot(&admin);
+    let batch_fresh = build_single_batch(&env, &snapshot2);
+    contract.import_migration_batch(&admin, &batch_fresh);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -354,6 +354,21 @@ pub enum ProposalState {
     Expired,
 }
 
+/// Governance configuration returned by `query_governance_config`.
+///
+/// Bundles quorum, timelock, and proposal TTL into a single queryable struct
+/// so integrators and frontends can inspect all governance parameters in one call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceConfig {
+    /// Minimum number of admin approvals required to pass a proposal.
+    pub quorum: u32,
+    /// Seconds that must elapse between approval and execution.
+    pub timelock_seconds: u64,
+    /// Seconds after creation before a proposal expires.
+    pub proposal_ttl_seconds: u64,
+}
+
 /// A governance proposal record stored on-chain.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION


**PR: feat/issues-416-417-418-419**

Closes #416
closes #417 
closes #418 
closes #419

**#416 — Governance proposal expiry cleanup**
- Added `cleanup_expired_proposals(caller, proposal_ids)` to `governance.rs` — admin-only, deletes `Expired`/`Executed` proposals from persistent storage, skips `Pending`/`Approved` ones
- Added `delete_proposal()` helper to `storage.rs`
- Added `emit_proposal_cleaned_up` event to `events.rs`
- Exposed as `cleanup_expired_proposals` entry point in `lib.rs`
- 4 unit tests covering cleanup, skip-pending, and unauthorized access

**#417 — Governance config query**
- Added `GovernanceConfig { quorum, timelock_seconds, proposal_ttl_seconds }` contracttype to `types.rs`
- Added `query_governance_config()` public entry point in `lib.rs`
- Added `getGovernanceConfig()` SDK method in `client.ts` and `GovernanceConfig` TS type in `types.ts`/`index.ts`
- 2 unit tests covering initial values and post-update reflection

**#418 — Strict monotonic batch ordering**
- Added `ExpectedNextBatch` key to `MigrationKey` enum in `migration.rs`
- `import_batch` now rejects any batch where `batch_number != expected_next_batch` with `InvalidMigrationBatch`
- Counter advances after each successful import and is cleared after the final batch
- 2 tests: out-of-order batch rejection and duplicate batch index rejection

**#419 — Migration abort/rollback**
- Added `abort_migration(caller)` to `migration.rs` — clears `MigrationInProgress` flag, resets batch counter, emits `migration_aborted` event
- Exposed as `abort_migration` entry point in `lib.rs` (admin-only)
- Updated `MIGRATION.md` with Step 3a rollback procedure and updated error reference table
- 4 tests: reset to idle, not-in-progress error, non-admin rejection, batch counter reset
