### PR TITLE
feat: add webhook delivery dead-letter queue (#435)

### DIFF
--- a/backend/migrations/add_webhook_dead_letters.sql
+++ b/backend/migrations/add_webhook_dead_letters.sql
@@ -1,0 +1,15 @@
+-- Dead-letter queue for permanently failed webhook deliveries
+CREATE TABLE IF NOT EXISTS webhook_dead_letters (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  delivery_id UUID NOT NULL,
+  webhook_id UUID NOT NULL,
+  event_type VARCHAR(80) NOT NULL,
+  payload JSONB NOT NULL,
+  last_error TEXT,
+  attempts INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  replayed_at TIMESTAMP
+);
+
+CREATE INDEX idx_webhook_dead_letters_webhook ON webhook_dead_letters(webhook_id);
+CREATE INDEX idx_webhook_dead_letters_created ON webhook_dead_letters(created_at DESC);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -685,4 +685,49 @@ app.post('/api/simulate-settlement', async (req: Request, res: Response) => {
   }
 });
 
+// Admin: list dead-letter queue entries
+app.get('/api/webhooks/dead-letters', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { createWebhookStore } = await import('./webhooks/store');
+    const store = createWebhookStore(pool);
+    const limit = Math.min(parseInt((req.query.limit as string) || '50', 10), 200);
+    const offset = parseInt((req.query.offset as string) || '0', 10);
+    const entries = await store.listDeadLetters(limit, offset);
+    res.json({ entries, limit, offset });
+  } catch (error) {
+    logger.error('Error listing dead letters', error);
+    res.status(500).json({ error: 'Failed to list dead-letter queue' });
+  }
+});
+
+// Admin: replay a dead-letter entry
+app.post('/api/webhooks/dead-letters/:id/replay', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    if (!id || typeof id !== 'string') {
+      return res.status(400).json({ error: 'Invalid dead-letter id' });
+    }
+
+    const { createWebhookStore } = await import('./webhooks/store');
+    const { WebhookDispatcher } = await import('./webhooks/dispatcher');
+    const store = createWebhookStore(pool);
+    const entries = await store.listDeadLetters(200, 0);
+    const entry = entries.find(e => e.id === id);
+
+    if (!entry) {
+      return res.status(404).json({ error: 'Dead-letter entry not found' });
+    }
+
+    const metrics = getMetricsService(pool);
+    const dispatcher = new WebhookDispatcher(store, logger, {}, () => metrics.incrementDeadLetterCount());
+    await dispatcher.dispatch(entry.eventType, entry.payload);
+    await store.markDeadLetterReplayed(id);
+
+    res.json({ success: true, id });
+  } catch (error) {
+    logger.error('Error replaying dead letter', error);
+    res.status(500).json({ error: 'Failed to replay dead-letter entry' });
+  }
+});
+
 export default app;

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -11,6 +11,7 @@ export class MetricsService {
     swiftremit_webhook_deliveries_total: {} as Record<string, number>,
     swiftremit_active_remittances: 0,
     swiftremit_accumulated_fees: 0,
+    swiftremit_webhook_dead_letter_count: 0,
   };
 
   constructor(pool: Pool) {
@@ -109,6 +110,13 @@ export class MetricsService {
   }
 
   /**
+   * Increment dead-letter counter (called by dispatcher on each DLQ insertion)
+   */
+  incrementDeadLetterCount(): void {
+    this.metrics.swiftremit_webhook_dead_letter_count++;
+  }
+
+  /**
    * Update all metrics
    */
   async updateAllMetrics(): Promise<void> {
@@ -149,6 +157,11 @@ export class MetricsService {
     lines.push('# HELP swiftremit_accumulated_fees Total accumulated fees from completed transactions');
     lines.push('# TYPE swiftremit_accumulated_fees gauge');
     lines.push(`swiftremit_accumulated_fees ${this.metrics.swiftremit_accumulated_fees}`);
+
+    // Dead-letter counter
+    lines.push('# HELP swiftremit_webhook_dead_letter_count Total webhook deliveries moved to dead-letter queue');
+    lines.push('# TYPE swiftremit_webhook_dead_letter_count counter');
+    lines.push(`swiftremit_webhook_dead_letter_count ${this.metrics.swiftremit_webhook_dead_letter_count}`);
 
     return lines.join('\n') + '\n';
   }

--- a/backend/src/webhooks/dispatcher.ts
+++ b/backend/src/webhooks/dispatcher.ts
@@ -25,7 +25,8 @@ export class WebhookDispatcher {
   constructor(
     private store: IWebhookStore,
     private logger?: Console | any,
-    private options: WebhookDeliveryOptions = {}
+    private options: WebhookDeliveryOptions = {},
+    private onDeadLetter?: () => void
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.logger = logger || console;
@@ -88,16 +89,20 @@ export class WebhookDispatcher {
 
       for (const subscriber of subscribers) {
         try {
-          const deliveryId = await this.store.recordDelivery({
+          const deliveryRecord: Partial<WebhookDeliveryRecord> = {
             webhookId: subscriber.id,
             eventType: event,
             payload,
+            maxRetries: this.options.maxRetries!,
+          };
+
+          const deliveryId = await this.store.recordDelivery({
+            ...deliveryRecord,
             status: 'pending',
             attempt: 0,
-            maxRetries: this.options.maxRetries!,
-          });
+          } as WebhookDeliveryRecord);
 
-          const success = await this.attemptDelivery(deliveryId, subscriber.url, subscriber.secret, payload);
+          const success = await this.attemptDelivery(deliveryId, subscriber.url, subscriber.secret, payload, 1, deliveryRecord);
 
           if (success) {
             successCount++;
@@ -126,7 +131,8 @@ export class WebhookDispatcher {
     url: string,
     secret: string,
     payload: WebhookPayload,
-    attempt: number = 1
+    attempt: number = 1,
+    deliveryRecord?: Partial<WebhookDeliveryRecord>
   ): Promise<boolean> {
     try {
       const payloadJson = JSON.stringify(payload);
@@ -161,10 +167,24 @@ export class WebhookDispatcher {
         await this.store.updateDeliveryStatus(deliveryId, 'pending', attempt, errorMessage);
         await new Promise(resolve => setTimeout(resolve, delay));
 
-        return this.attemptDelivery(deliveryId, url, secret, payload, attempt + 1);
+        return this.attemptDelivery(deliveryId, url, secret, payload, attempt + 1, deliveryRecord);
       } else {
         await this.store.updateDeliveryStatus(deliveryId, 'failed', attempt, errorMessage);
         this.logger.error(`Delivery ${deliveryId} failed after ${attempt} attempts: ${errorMessage}`);
+
+        // Send to dead-letter queue
+        if (deliveryRecord) {
+          await this.store.sendToDeadLetter({
+            ...deliveryRecord,
+            id: deliveryId,
+            status: 'failed',
+            attempt,
+            error: errorMessage,
+          } as WebhookDeliveryRecord);
+          this.onDeadLetter?.();
+          this.logger.warn(`Delivery ${deliveryId} moved to dead-letter queue`);
+        }
+
         return false;
       }
     }
@@ -198,7 +218,8 @@ export class WebhookDispatcher {
           subscriber.url,
           subscriber.secret,
           delivery.payload,
-          delivery.attempt + 1
+          delivery.attempt + 1,
+          delivery
         );
       }
     } catch (error) {

--- a/backend/src/webhooks/store.ts
+++ b/backend/src/webhooks/store.ts
@@ -9,7 +9,7 @@
  */
 
 import { Pool, QueryResult } from 'pg';
-import { EventType, WebhookSubscriber, WebhookDeliveryRecord } from './types';
+import { EventType, WebhookSubscriber, WebhookDeliveryRecord, DeadLetterRecord } from './types';
 
 export interface IWebhookStore {
   // Webhook Registration
@@ -25,6 +25,11 @@ export interface IWebhookStore {
   recordDelivery(delivery: WebhookDeliveryRecord): Promise<string>;
   updateDeliveryStatus(deliveryId: string, status: 'pending' | 'success' | 'failed', attempt: number, error?: string): Promise<void>;
   getPendingDeliveries(limit?: number): Promise<WebhookDeliveryRecord[]>;
+
+  // Dead-Letter Queue
+  sendToDeadLetter(delivery: WebhookDeliveryRecord): Promise<void>;
+  listDeadLetters(limit?: number, offset?: number): Promise<DeadLetterRecord[]>;
+  markDeadLetterReplayed(id: string): Promise<void>;
 }
 
 /**
@@ -35,6 +40,7 @@ export interface IWebhookStore {
 export class InMemoryWebhookStore implements IWebhookStore {
   private webhooks: Map<string, WebhookSubscriber> = new Map();
   private deliveries: Map<string, WebhookDeliveryRecord> = new Map();
+  private deadLetters: Map<string, DeadLetterRecord> = new Map();
 
   async registerWebhook(url: string, events: EventType[], secret?: string): Promise<WebhookSubscriber> {
     // Validate URL
@@ -113,6 +119,31 @@ export class InMemoryWebhookStore implements IWebhookStore {
       .filter(d => d.status === 'pending' || (d.status === 'failed' && d.attempt < d.maxRetries))
       .sort((a, b) => (a.createdAt?.getTime() || 0) - (b.createdAt?.getTime() || 0))
       .slice(0, limit);
+  }
+
+  async sendToDeadLetter(delivery: WebhookDeliveryRecord): Promise<void> {
+    const id = `dl_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    this.deadLetters.set(id, {
+      id,
+      deliveryId: delivery.id!,
+      webhookId: delivery.webhookId,
+      eventType: delivery.eventType,
+      payload: delivery.payload,
+      lastError: delivery.error,
+      attempts: delivery.attempt,
+      createdAt: new Date(),
+    });
+  }
+
+  async listDeadLetters(limit: number = 50, offset: number = 0): Promise<DeadLetterRecord[]> {
+    return Array.from(this.deadLetters.values())
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(offset, offset + limit);
+  }
+
+  async markDeadLetterReplayed(id: string): Promise<void> {
+    const record = this.deadLetters.get(id);
+    if (record) record.replayedAt = new Date();
   }
 }
 
@@ -282,6 +313,42 @@ export class PostgresWebhookStore implements IWebhookStore {
       updatedAt: row.updated_at,
       error: row.error,
     }));
+  }
+
+  async sendToDeadLetter(delivery: WebhookDeliveryRecord): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO webhook_dead_letters (delivery_id, webhook_id, event_type, payload, last_error, attempts)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [delivery.id, delivery.webhookId, delivery.eventType, JSON.stringify(delivery.payload), delivery.error || null, delivery.attempt]
+    );
+  }
+
+  async listDeadLetters(limit: number = 50, offset: number = 0): Promise<DeadLetterRecord[]> {
+    const result = await this.pool.query(
+      `SELECT id, delivery_id, webhook_id, event_type, payload, last_error, attempts, created_at, replayed_at
+       FROM webhook_dead_letters
+       ORDER BY created_at DESC
+       LIMIT $1 OFFSET $2`,
+      [limit, offset]
+    );
+    return result.rows.map(row => ({
+      id: row.id,
+      deliveryId: row.delivery_id,
+      webhookId: row.webhook_id,
+      eventType: row.event_type,
+      payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
+      lastError: row.last_error,
+      attempts: row.attempts,
+      createdAt: row.created_at,
+      replayedAt: row.replayed_at,
+    }));
+  }
+
+  async markDeadLetterReplayed(id: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE webhook_dead_letters SET replayed_at = NOW() WHERE id = $1`,
+      [id]
+    );
   }
 }
 

--- a/backend/src/webhooks/types.ts
+++ b/backend/src/webhooks/types.ts
@@ -72,3 +72,15 @@ export interface WebhookSignatureHeaders {
   'x-webhook-timestamp': string;
   'x-webhook-id': string;
 }
+
+export interface DeadLetterRecord {
+  id: string;
+  deliveryId: string;
+  webhookId: string;
+  eventType: EventType;
+  payload: any;
+  lastError?: string;
+  attempts: number;
+  createdAt: Date;
+  replayedAt?: Date;
+}


### PR DESCRIPTION
Closes #435 Failed webhook deliveries were silently dropped after max retries with no way
  to inspect or replay them. This PR adds a dead-letter queue (DLQ) to capture
  permanently failed deliveries.
  
  Changes
  
  - Migration — adds webhook_dead_letters table to persist failed deliveries
  after max retries
  - Store — extends IWebhookStore (and both InMemory + Postgres implementations)
  with sendToDeadLetter, listDeadLetters, and markDeadLetterReplayed
  - Dispatcher — on final retry failure, moves the delivery to the DLQ instead of
  silently dropping it
  - Metrics — adds swiftremit_webhook_dead_letter_count Prometheus counter,
  incremented on each DLQ insertion
  - API — two new admin endpoints:
    - GET /api/webhooks/dead-letters — list DLQ entries (supports limit / offset)
    - POST /api/webhooks/dead-letters/:id/replay — replay a specific entry and
  mark it as replayed
  
  Acceptance Criteria
  
  - [x] Failed deliveries after max retries go to DLQ table
  - [x] Admin endpoint lists and replays DLQ entries
  - [x] swiftremit_webhook_dead_letter_count counter metric added
  - [x] Migration SQL added
  
  Testing
  
  No new type errors introduced. Existing tests unaffected. Both store
  implementations (in-memory and Postgres) support the new DLQ methods.

