### PR TITLE
feat: db indexes, admin audit log, repository pattern, OpenTelemetry

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,10 @@ MIN_REPUTATION_SCORE=50
 # SEP24_WEBHOOK_ANCHOR_1=https://your-server.com/webhooks/anchor
 # SEP24_POLL_INTERVAL_ANCHOR_1=5
 # SEP24_TIMEOUT_ANCHOR_1=30
+
+# OpenTelemetry / Distributed Tracing
+# Set OTEL_ENABLED=false to disable tracing entirely (e.g. in unit-test environments)
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=swiftremit-backend
+# OTLP HTTP endpoint — point at a local Jaeger all-in-one or any OTLP-compatible collector
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/backend/README.md
+++ b/backend/README.md
@@ -330,3 +330,47 @@ See `.env.example` for all configuration options.
 ## License
 
 MIT
+
+## Distributed Tracing (OpenTelemetry)
+
+The backend emits OTLP traces for all major operations: HTTP requests, database queries, FX rate fetches, and webhook deliveries. Trace context is propagated to outbound anchor API calls via W3C `traceparent` headers.
+
+### Local Jaeger setup
+
+Run a Jaeger all-in-one container that accepts OTLP over HTTP:
+
+```bash
+docker run -d --name jaeger \
+  -p 4318:4318 \   # OTLP HTTP receiver
+  -p 16686:16686 \ # Jaeger UI
+  jaegertracing/all-in-one:latest
+```
+
+Then start the backend with tracing enabled (the default):
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 npm run dev
+```
+
+Open the Jaeger UI at **http://localhost:16686** and select the `swiftremit-backend` service.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_ENABLED` | `true` | Set to `false` to disable tracing (e.g. in CI) |
+| `OTEL_SERVICE_NAME` | `swiftremit-backend` | Service name shown in traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP HTTP collector endpoint |
+
+### Manual spans
+
+Use the `withSpan` helper for custom instrumentation:
+
+```typescript
+import { withSpan } from './tracing';
+
+const result = await withSpan('fx-rate.fetch', async (span) => {
+  span.setAttribute('currency.pair', `${from}/${to}`);
+  return fetchRate(from, to);
+});
+```

--- a/backend/migrations/add_transaction_indexes.sql
+++ b/backend/migrations/add_transaction_indexes.sql
@@ -1,0 +1,18 @@
+-- Migration: add_transaction_indexes
+-- Adds performance indexes to the transactions table for common query patterns.
+-- Idempotent: uses CREATE INDEX IF NOT EXISTS throughout.
+
+-- Add sender_address column if it doesn't exist (transactions table may predate this column)
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS sender_address VARCHAR(56);
+
+-- Index for user transaction history lookups
+CREATE INDEX IF NOT EXISTS idx_transactions_sender
+  ON transactions(sender_address);
+
+-- Composite index for paginated history queries (sender + newest first)
+CREATE INDEX IF NOT EXISTS idx_transactions_sender_created
+  ON transactions(sender_address, created_at DESC);
+
+-- Index for pending transaction polling
+CREATE INDEX IF NOT EXISTS idx_transactions_status_created
+  ON transactions(status, created_at);

--- a/backend/migrations/admin_audit_log.sql
+++ b/backend/migrations/admin_audit_log.sql
@@ -1,0 +1,21 @@
+-- Migration: admin_audit_log
+-- Creates the admin_audit_log table for off-chain compliance audit trail.
+-- Idempotent: uses CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS admin_audit_log (
+  id          BIGSERIAL PRIMARY KEY,
+  admin_address VARCHAR(56)  NOT NULL,
+  action        VARCHAR(100) NOT NULL,
+  target        VARCHAR(255),
+  params_json   JSONB,
+  tx_hash       VARCHAR(64),
+  created_at    TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_admin_address ON admin_audit_log(admin_address);
+CREATE INDEX IF NOT EXISTS idx_audit_action        ON admin_audit_log(action);
+CREATE INDEX IF NOT EXISTS idx_audit_created_at    ON admin_audit_log(created_at DESC);
+
+-- Retention: rows older than AUDIT_RETENTION_DAYS (default 90) can be purged by a scheduled job.
+-- Example purge query (run via cron or pg_cron):
+-- DELETE FROM admin_audit_log WHERE created_at < NOW() - INTERVAL '90 days';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,14 @@
       "name": "swiftremit-verification-service",
       "version": "1.0.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+        "@opentelemetry/instrumentation-express": "^0.63.0",
+        "@opentelemetry/instrumentation-http": "^0.215.0",
+        "@opentelemetry/instrumentation-pg": "^0.67.0",
+        "@opentelemetry/resources": "^2.7.0",
+        "@opentelemetry/sdk-node": "^0.215.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "@stellar/stellar-sdk": "^12.0.0",
         "axios": "^1.8.2",
         "cors": "^2.8.5",
@@ -710,6 +718,128 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -779,6 +909,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -837,6 +977,601 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.215.0.tgz",
+      "integrity": "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.215.0.tgz",
+      "integrity": "sha512-FSWvDryxjinHROfzEVbJGBw10FqGzLEm2C1LPX6Lot6hvxq3lFJzNLlue8vm64C5yIbqSQVjWsPhYu56ThQS4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.0.tgz",
+      "integrity": "sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.215.0.tgz",
+      "integrity": "sha512-MVq+9ma/63XRXc0AcnS+XyWSD6VBYn39OucsvpzjqxTpzTOiGXNxTwsbV3zbnvgUexb5hc2ZjJlZUK2W/19UUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/sdk-logs": "0.215.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.215.0.tgz",
+      "integrity": "sha512-U7Qb+TVX2GZH5RSC+Gx9aE5zChKP1kPg87X3PlI/41lWVPJdBIzmgMmuE28MmQlrK84nLHCIqUOOben8YkSzBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/sdk-logs": "0.215.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.215.0.tgz",
+      "integrity": "sha512-vs2xKKTdt/vKWMuBzw+LZYYCKqulodCRoonWWiyToIQfa6JgbyWjTu/iy6qpBLhLi+t6fNc1bwJGwu3vkot2Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-logs": "0.215.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.215.0.tgz",
+      "integrity": "sha512-1TAMliHQvzc+v1OtnLMHSk5sU8BSkJbxIKrWzuCWcQjajWrvem/r5ugLK6agI0PjPz/ADfZju5AVYedlNyeO9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.215.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-metrics": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.215.0.tgz",
+      "integrity": "sha512-FRydO5j7MWnXK9ghfykKxiSM8I5UeiicK/UNl3/mv86xoEKkb+LKz1I3WXgkuYVOQf22VNqbPO58s2W1mVWtEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-metrics": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.215.0.tgz",
+      "integrity": "sha512-d8/Sys9MtxLbn0S+RE1pUNcuoI9ZyI4SPfOO+yskSEQiPFoKCTMwwthB8MTY4S8qxCBAWyM+P7QMX+vEIT7PZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.215.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-metrics": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.215.0.tgz",
+      "integrity": "sha512-7ghCl1G84jccmxG3B8UwUMZ1OlequBzB1jt5tZ4DDiAyVKeA4Roz5D6VK8SQ0ZyBQffVyX/rtXrpVXKVzRCGfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-metrics": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.215.0.tgz",
+      "integrity": "sha512-+SuWfPFVjPTvHJhlzTCBetLsPVu86xSFPR3fv8TN+H7lpe5aZzF96TUsfMHDR0lwpIwlJpG57CJnGalIfrpXkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.215.0.tgz",
+      "integrity": "sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.215.0.tgz",
+      "integrity": "sha512-+QclHuJmlp/I3Z2fNn+j1dAajMjJqJ4Sgo8ajwiK6Tzmg5SNwBGmBX66AZvTLe/3/bc3L7bo90m9gsaJBrzEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.0.tgz",
+      "integrity": "sha512-tbzcYDmZWtX4hgJn15qP7/iYFVd1yzbUloBuSYsQtn0XQTxJsG7vgwkPKEBellriH0XJmlZJxYtWkHpwzHBhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.215.0.tgz",
+      "integrity": "sha512-SyJONuqypQ2xWdYMy99vF7JhZ2kDTGx4oRmM/jZV+kRtZ96JTnJmEINbIJgHz7Gnhtw0bimHwbPy/pguA5wpPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.63.0.tgz",
+      "integrity": "sha512-zr4T1akyXEW08K+9g5NSLXxC6WMOKm47ZmLWU1q45jGsfVaXYYbBwNuLyFWTh5RavXYgh4pJswEvHkQXzNumHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.215.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.215.0.tgz",
+      "integrity": "sha512-ip9iNoRRVxDyP8LVfdqqI6OwbOwzxTl4SaP1WDKJq0sDsgpOr7rIOFj7gV8yKl4F5PdDOUYy8VqdgIOWZRlGBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/instrumentation": "0.215.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.67.0.tgz",
+      "integrity": "sha512-1b1o/9nelDwoE3+EucZ9eHZsdUgji799C94lX1ZPy6O0EVjdTj3HczLL6z3GqPGZHmV4OpmJjGz8kuLtuPjCGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.215.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.215.0.tgz",
+      "integrity": "sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-transformer": "0.215.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.215.0.tgz",
+      "integrity": "sha512-WkuHkUrhwNxTKrm7Xuf6S+HmLNbk2T8S2YiZhN606RfgetSQb9xLp4NizWLwXvw63uxGsBaK262dirFO2yht2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/otlp-transformer": "0.215.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.215.0.tgz",
+      "integrity": "sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-logs": "0.215.0",
+        "@opentelemetry/sdk-metrics": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0",
+        "protobufjs": "^8.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.7.0.tgz",
+      "integrity": "sha512-HNm+tdXY5i8dzAo4YankchNWdZ4Z1Boop7lhbb3wltWT0MwEMo0QADRJwrF83pXEeDT+5Bmq4J8sStFaUywE3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.0.tgz",
+      "integrity": "sha512-lKMAjekRkFYWrjmPTaxUJt+V8Mr1iB94sP3HDZZCmdZ/LUV/wtqAGqXhgnkIbdlnWxxvEs9MGEIMdJC+xObMFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.215.0.tgz",
+      "integrity": "sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.0.tgz",
+      "integrity": "sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.215.0.tgz",
+      "integrity": "sha512-YunKvZOMhYNMBJ66YRjbGShuoV/w1y21U7MGPRx0iPJenPszOddtYEQFJv8piAEOn94BUFIfJHtHjptrHsGiIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.215.0",
+        "@opentelemetry/configuration": "0.215.0",
+        "@opentelemetry/context-async-hooks": "2.7.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.215.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.215.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.215.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.215.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.215.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.215.0",
+        "@opentelemetry/exporter-prometheus": "0.215.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.215.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.215.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.215.0",
+        "@opentelemetry/exporter-zipkin": "2.7.0",
+        "@opentelemetry/instrumentation": "0.215.0",
+        "@opentelemetry/otlp-exporter-base": "0.215.0",
+        "@opentelemetry/propagator-b3": "2.7.0",
+        "@opentelemetry/propagator-jaeger": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/sdk-logs": "0.215.0",
+        "@opentelemetry/sdk-metrics": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0",
+        "@opentelemetry/sdk-trace-node": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.0.tgz",
+      "integrity": "sha512-RrFHOXw0IYp/OThew6QORdybnnLitUAUMCJKcQNBYS0hDkCYarO2vTkVxfrGxCIqd5XHSMvbCpBd/T8ZMw8oSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.7.0",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/sdk-trace-base": "2.7.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -846,6 +1581,70 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1370,7 +2169,6 @@
       "version": "20.19.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.34.tgz",
       "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1391,12 +2189,20 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1813,13 +2619,21 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -1853,7 +2667,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1863,7 +2676,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2258,6 +3070,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2283,7 +3101,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2296,7 +3113,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2407,7 +3223,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2566,7 +3381,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2670,6 +3484,15 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3277,6 +4100,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -3321,7 +4150,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3641,6 +4469,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3704,7 +4547,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3851,12 +4693,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3983,6 +4837,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4438,6 +5298,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4572,7 +5456,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4586,6 +5469,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/require-main-filename": {
@@ -5030,7 +5926,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5045,7 +5940,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5427,7 +6321,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6293,6 +7186,21 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,14 @@
     "validate:openapi": "swagger-cli validate openapi.yaml"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/instrumentation-express": "^0.63.0",
+    "@opentelemetry/instrumentation-http": "^0.215.0",
+    "@opentelemetry/instrumentation-pg": "^0.67.0",
+    "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-node": "^0.215.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "axios": "^1.8.2",
     "cors": "^2.8.5",
@@ -22,26 +30,27 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
+    "js-yaml": "^4.1.0",
     "node-cache": "^5.1.2",
     "node-cron": "^4.2.1",
     "pg": "^8.11.0",
-    "toml": "^3.0.0",
     "swagger-ui-express": "^5.0.0",
-    "js-yaml": "^4.1.0",
+    "toml": "^3.0.0",
     "uuid": "^14.0.0"
   },
   "overrides": {
     "uuid": "^14.0.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-cli": "^4.0.4",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.0",
     "@types/node-cache": "^4.2.5",
     "@types/pg": "^8.10.9",
     "@types/supertest": "^7.2.0",
     "@types/swagger-ui-express": "^4.1.6",
-    "@types/js-yaml": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.56.0",
@@ -50,7 +59,6 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vite": "^6.4.2",
-    "vitest": "^3.1.1",
-    "@apidevtools/swagger-cli": "^4.0.4"
+    "vitest": "^3.1.1"
   }
 }

--- a/backend/src/__tests__/repositories.test.ts
+++ b/backend/src/__tests__/repositories.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RemittanceRepository } from '../repositories/RemittanceRepository';
+import { KycRepository } from '../repositories/KycRepository';
+import { FxRateRepository } from '../repositories/FxRateRepository';
+import { WebhookRepository } from '../repositories/WebhookRepository';
+
+function mockPool(rows: unknown[] = []) {
+  return { query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }) } as any;
+}
+
+// ── RemittanceRepository ──────────────────────────────────────────────────────
+
+describe('RemittanceRepository', () => {
+  it('findById returns null when no rows', async () => {
+    const repo = new RemittanceRepository(mockPool([]));
+    expect(await repo.findById('tx-1')).toBeNull();
+  });
+
+  it('findById returns first row', async () => {
+    const row = { transaction_id: 'tx-1', status: 'pending' };
+    const repo = new RemittanceRepository(mockPool([row]));
+    expect(await repo.findById('tx-1')).toEqual(row);
+  });
+
+  it('findBySender passes correct params', async () => {
+    const pool = mockPool([]);
+    const repo = new RemittanceRepository(pool);
+    await repo.findBySender('GABC', 10, 0);
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('sender_address'), ['GABC', 10, 0]);
+  });
+
+  it('upsert calls pool.query', async () => {
+    const pool = mockPool([]);
+    const repo = new RemittanceRepository(pool);
+    await repo.upsert({ transaction_id: 'tx-1' });
+    expect(pool.query).toHaveBeenCalledOnce();
+  });
+});
+
+// ── KycRepository ─────────────────────────────────────────────────────────────
+
+describe('KycRepository', () => {
+  it('getUserStatus returns null when no rows', async () => {
+    const repo = new KycRepository(mockPool([]));
+    expect(await repo.getUserStatus('user-1', 'anchor-1')).toBeNull();
+  });
+
+  it('getConfigs maps rows correctly', async () => {
+    const row = {
+      anchor_id: 'a1', kyc_server_url: 'https://kyc.example.com',
+      auth_token: 'tok', polling_interval_minutes: 60, enabled: true,
+    };
+    const repo = new KycRepository(mockPool([row]));
+    const configs = await repo.getConfigs();
+    expect(configs[0].anchor_id).toBe('a1');
+  });
+});
+
+// ── FxRateRepository ──────────────────────────────────────────────────────────
+
+describe('FxRateRepository', () => {
+  it('findById returns null when no rows', async () => {
+    const repo = new FxRateRepository(mockPool([]));
+    expect(await repo.findById('tx-1')).toBeNull();
+  });
+
+  it('save calls pool.query with correct args', async () => {
+    const pool = mockPool([]);
+    const repo = new FxRateRepository(pool);
+    const rate = { transaction_id: 'tx-1', rate: 1.5, provider: 'test', timestamp: new Date(), from_currency: 'USD', to_currency: 'EUR' };
+    await repo.save(rate);
+    expect(pool.query).toHaveBeenCalledOnce();
+  });
+});
+
+// ── WebhookRepository ─────────────────────────────────────────────────────────
+
+describe('WebhookRepository', () => {
+  it('getActiveSubscribers returns mapped rows', async () => {
+    const row = { id: '1', url: 'https://hook.example.com', secret: null, active: true, created_at: new Date(), updated_at: new Date() };
+    const repo = new WebhookRepository(mockPool([row]));
+    const subs = await repo.getActiveSubscribers();
+    expect(subs[0].url).toBe('https://hook.example.com');
+  });
+
+  it('getPending passes limit param', async () => {
+    const pool = mockPool([]);
+    const repo = new WebhookRepository(pool);
+    await repo.getPending(25);
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), [25]);
+  });
+});

--- a/backend/src/admin-audit-log.ts
+++ b/backend/src/admin-audit-log.ts
@@ -1,0 +1,88 @@
+import { Pool } from 'pg';
+
+export interface AuditLogEntry {
+  id: number;
+  admin_address: string;
+  action: string;
+  target: string | null;
+  params_json: Record<string, unknown> | null;
+  tx_hash: string | null;
+  created_at: Date;
+}
+
+export interface AuditLogFilter {
+  admin_address?: string;
+  action?: string;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export class AdminAuditLogService {
+  constructor(private readonly pool: Pool) {}
+
+  async log(entry: Omit<AuditLogEntry, 'id' | 'created_at'>): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO admin_audit_log (admin_address, action, target, params_json, tx_hash)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        entry.admin_address,
+        entry.action,
+        entry.target ?? null,
+        entry.params_json ? JSON.stringify(entry.params_json) : null,
+        entry.tx_hash ?? null,
+      ]
+    );
+  }
+
+  async query(filter: AuditLogFilter = {}): Promise<{ entries: AuditLogEntry[]; total: number }> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filter.admin_address) {
+      params.push(filter.admin_address);
+      conditions.push(`admin_address = $${params.length}`);
+    }
+    if (filter.action) {
+      params.push(filter.action);
+      conditions.push(`action = $${params.length}`);
+    }
+    if (filter.from) {
+      params.push(filter.from);
+      conditions.push(`created_at >= $${params.length}`);
+    }
+    if (filter.to) {
+      params.push(filter.to);
+      conditions.push(`created_at <= $${params.length}`);
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*) FROM admin_audit_log ${where}`,
+      params
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    const limit = Math.min(filter.limit ?? 50, 200);
+    const offset = filter.offset ?? 0;
+
+    const rows = await this.pool.query(
+      `SELECT * FROM admin_audit_log ${where}
+       ORDER BY created_at DESC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
+    );
+
+    return { entries: rows.rows as AuditLogEntry[], total };
+  }
+
+  async purgeOlderThan(days: number): Promise<number> {
+    const result = await this.pool.query(
+      `DELETE FROM admin_audit_log WHERE created_at < NOW() - ($1 || ' days')::INTERVAL`,
+      [days]
+    );
+    return result.rowCount ?? 0;
+  }
+}

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -27,6 +27,7 @@ import { getMetricsService } from './metrics';
 import { sanitizeInput } from './sanitizer';
 import docsRouter from './routes/docs';
 import { Sep24Service, Sep24InitiateRequest, Sep24ConfigError, Sep24AnchorError } from './sep24-service';
+import { AdminAuditLogService } from './admin-audit-log';
 
 const app = express();
 const fxRateCache = getFxRateCache();
@@ -682,6 +683,28 @@ app.post('/api/simulate-settlement', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error simulating settlement:', error);
     res.status(500).json({ error: 'Failed to simulate settlement' });
+  }
+});
+
+// Admin audit log
+app.get('/api/admin/audit-log', async (req: Request, res: Response) => {
+  try {
+    const auditService = new AdminAuditLogService(pool);
+    const limit  = Math.min(parseInt(req.query.limit  as string) || 50, 200);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const filter = {
+      admin_address: req.query.admin_address as string | undefined,
+      action:        req.query.action        as string | undefined,
+      from:  req.query.from  ? new Date(req.query.from  as string) : undefined,
+      to:    req.query.to    ? new Date(req.query.to    as string) : undefined,
+      limit,
+      offset,
+    };
+    const { entries, total } = await auditService.query(filter);
+    res.json({ total, limit, offset, entries });
+  } catch (error) {
+    logger.error('Error fetching audit log', error);
+    res.status(500).json({ error: 'Failed to fetch audit log' });
   }
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,5 @@
+// MUST be imported first so OTel patches are applied before other modules load
+import './tracing';
 import dotenv from 'dotenv';
 import app from './api';
 import { initDatabase, getPool } from './database';
@@ -5,6 +7,8 @@ import { startBackgroundJobs } from './scheduler';
 import { WebhookHandler } from './webhook-handler';
 import { KycService } from './kyc-service';
 import { createWebhookVerificationMiddleware } from './webhook-middleware';
+import { AdminAuditLogService } from './admin-audit-log';
+import { remittanceEventEmitter } from './remittance/events';
 
 dotenv.config();
 
@@ -23,6 +27,10 @@ async function start() {
 
     // Setup webhook handler
     const pool = getPool();
+
+    // Wire audit log service into the global event emitter
+    const auditLogService = new AdminAuditLogService(pool);
+    remittanceEventEmitter.setAuditLogService(auditLogService);
     
     // Apply HMAC verification middleware to all /webhooks routes
     const webhookVerification = createWebhookVerificationMiddleware({

--- a/backend/src/remittance/events.ts
+++ b/backend/src/remittance/events.ts
@@ -8,6 +8,7 @@
 import { EventEmitter } from 'events';
 import { RemittanceData } from '../webhooks/types';
 import { WebhookService } from '../webhooks/service';
+import { AdminAuditLogService } from '../admin-audit-log';
 
 export interface RemittanceStatusChangeEvent {
   remittanceId: string;
@@ -22,6 +23,15 @@ export interface RemittanceStatusChangeEvent {
   timestamp: Date;
 }
 
+/** Admin actions that should be written to the audit log. */
+export interface AdminActionEvent {
+  adminAddress: string;
+  action: string;
+  target?: string;
+  params?: Record<string, unknown>;
+  txHash?: string;
+}
+
 /**
  * Remittance Event Emitter
  * 
@@ -29,12 +39,32 @@ export interface RemittanceStatusChangeEvent {
  */
 export class RemittanceEventEmitter extends EventEmitter {
   private webhookService?: WebhookService;
+  private auditLogService?: AdminAuditLogService;
 
-  /**
-   * Set webhook service for event notification
-   */
   setWebhookService(webhookService: WebhookService): void {
     this.webhookService = webhookService;
+  }
+
+  setAuditLogService(auditLogService: AdminAuditLogService): void {
+    this.auditLogService = auditLogService;
+  }
+
+  /** Emit an admin action and persist it to the audit log. */
+  async emitAdminAction(event: AdminActionEvent): Promise<void> {
+    this.emit('admin-action', event);
+    if (this.auditLogService) {
+      try {
+        await this.auditLogService.log({
+          admin_address: event.adminAddress,
+          action: event.action,
+          target: event.target ?? null,
+          params_json: event.params ?? null,
+          tx_hash: event.txHash ?? null,
+        });
+      } catch (err) {
+        console.error('Failed to write admin audit log entry:', err);
+      }
+    }
   }
 
   /**
@@ -59,6 +89,7 @@ export class RemittanceEventEmitter extends EventEmitter {
             reason: event.reason,
             metadata: event.metadata,
             createdAt: event.timestamp.toISOString(),
+            updatedAt: event.timestamp.toISOString(),
           }
         );
 

--- a/backend/src/repositories/AnchorRepository.ts
+++ b/backend/src/repositories/AnchorRepository.ts
@@ -1,0 +1,92 @@
+import { Pool } from 'pg';
+import { Sep24TransactionDbRecord } from '../database';
+
+export class AnchorRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async save(record: Omit<Sep24TransactionDbRecord, 'id' | 'created_at' | 'updated_at'>): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO sep24_transactions
+         (transaction_id, anchor_id, direction, status, asset_code,
+          amount, amount_in, amount_out, amount_fee,
+          stellar_transaction_id, external_transaction_id,
+          user_id, interactive_url, instructions_url,
+          kyc_status, kyc_web_url, status_eta, message)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
+       ON CONFLICT (transaction_id) DO UPDATE SET
+         status                  = EXCLUDED.status,
+         amount_in               = COALESCE(EXCLUDED.amount_in, sep24_transactions.amount_in),
+         amount_out              = COALESCE(EXCLUDED.amount_out, sep24_transactions.amount_out),
+         amount_fee              = COALESCE(EXCLUDED.amount_fee, sep24_transactions.amount_fee),
+         stellar_transaction_id  = COALESCE(EXCLUDED.stellar_transaction_id, sep24_transactions.stellar_transaction_id),
+         external_transaction_id = COALESCE(EXCLUDED.external_transaction_id, sep24_transactions.external_transaction_id),
+         kyc_status              = COALESCE(EXCLUDED.kyc_status, sep24_transactions.kyc_status),
+         message                 = COALESCE(EXCLUDED.message, sep24_transactions.message),
+         updated_at              = NOW()`,
+      [
+        record.transaction_id, record.anchor_id, record.direction, record.status, record.asset_code,
+        record.amount ?? null, record.amount_in ?? null, record.amount_out ?? null, record.amount_fee ?? null,
+        record.stellar_transaction_id ?? null, record.external_transaction_id ?? null,
+        record.user_id, record.interactive_url ?? null, record.instructions_url ?? null,
+        record.kyc_status ?? null, record.kyc_web_url ?? null, record.status_eta ?? null, record.message ?? null,
+      ]
+    );
+  }
+
+  async findById(transactionId: string): Promise<Sep24TransactionDbRecord | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM sep24_transactions WHERE transaction_id = $1`,
+      [transactionId]
+    );
+    return (result.rows[0] as Sep24TransactionDbRecord) ?? null;
+  }
+
+  async findByUser(userId: string): Promise<Sep24TransactionDbRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM sep24_transactions WHERE user_id = $1 ORDER BY created_at DESC LIMIT 100`,
+      [userId]
+    );
+    return result.rows as Sep24TransactionDbRecord[];
+  }
+
+  async findPending(anchorId: string, minutesSinceLastPoll: number): Promise<Sep24TransactionDbRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM sep24_transactions
+       WHERE anchor_id = $1
+         AND status NOT IN ('completed', 'refunded', 'expired', 'error')
+         AND (last_polled IS NULL OR last_polled < NOW() - ($2 || ' minutes')::INTERVAL)
+       ORDER BY created_at ASC
+       LIMIT 50`,
+      [anchorId, minutesSinceLastPoll]
+    );
+    return result.rows as Sep24TransactionDbRecord[];
+  }
+
+  async updateStatus(
+    transactionId: string,
+    status: string,
+    fields: {
+      amountIn?: string; amountOut?: string; amountFee?: string;
+      stellarTransactionId?: string; externalTransactionId?: string; message?: string;
+    } = {}
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE sep24_transactions SET
+         status                  = $2,
+         amount_in               = COALESCE($3, amount_in),
+         amount_out              = COALESCE($4, amount_out),
+         amount_fee              = COALESCE($5, amount_fee),
+         stellar_transaction_id  = COALESCE($6, stellar_transaction_id),
+         external_transaction_id = COALESCE($7, external_transaction_id),
+         message                 = COALESCE($8, message),
+         last_polled             = NOW(),
+         updated_at              = NOW()
+       WHERE transaction_id = $1`,
+      [
+        transactionId, status,
+        fields.amountIn ?? null, fields.amountOut ?? null, fields.amountFee ?? null,
+        fields.stellarTransactionId ?? null, fields.externalTransactionId ?? null, fields.message ?? null,
+      ]
+    );
+  }
+}

--- a/backend/src/repositories/FxRateRepository.ts
+++ b/backend/src/repositories/FxRateRepository.ts
@@ -1,0 +1,34 @@
+import { Pool } from 'pg';
+import { FxRate, FxRateRecord } from '../types';
+
+export class FxRateRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async save(fxRate: FxRate): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO fx_rates (transaction_id, rate, provider, timestamp, from_currency, to_currency)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (transaction_id) DO NOTHING`,
+      [fxRate.transaction_id, fxRate.rate, fxRate.provider, fxRate.timestamp, fxRate.from_currency, fxRate.to_currency]
+    );
+  }
+
+  async findById(transactionId: string): Promise<FxRateRecord | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM fx_rates WHERE transaction_id = $1`,
+      [transactionId]
+    );
+    if (!result.rows[0]) return null;
+    const r = result.rows[0];
+    return {
+      id: r.id,
+      transaction_id: r.transaction_id,
+      rate: parseFloat(r.rate),
+      provider: r.provider,
+      timestamp: r.timestamp,
+      from_currency: r.from_currency,
+      to_currency: r.to_currency,
+      created_at: r.created_at,
+    };
+  }
+}

--- a/backend/src/repositories/KycRepository.ts
+++ b/backend/src/repositories/KycRepository.ts
@@ -1,0 +1,112 @@
+import { Pool } from 'pg';
+import { KycStatus, DbUserKycStatus, AnchorKycConfig } from '../types';
+
+export class KycRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async saveConfig(config: AnchorKycConfig): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO anchor_kyc_configs
+         (anchor_id, kyc_server_url, auth_token, polling_interval_minutes, enabled)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (anchor_id) DO UPDATE SET
+         kyc_server_url           = EXCLUDED.kyc_server_url,
+         auth_token               = EXCLUDED.auth_token,
+         polling_interval_minutes = EXCLUDED.polling_interval_minutes,
+         enabled                  = EXCLUDED.enabled,
+         updated_at               = NOW()`,
+      [config.anchor_id, config.kyc_server_url, config.auth_token, config.polling_interval_minutes, config.enabled]
+    );
+  }
+
+  async getConfigs(): Promise<AnchorKycConfig[]> {
+    const result = await this.pool.query(`SELECT * FROM anchor_kyc_configs WHERE enabled = TRUE`);
+    return result.rows.map((r) => ({
+      anchor_id: r.anchor_id,
+      kyc_server_url: r.kyc_server_url,
+      auth_token: r.auth_token,
+      polling_interval_minutes: r.polling_interval_minutes,
+      enabled: r.enabled,
+    }));
+  }
+
+  async saveUserStatus(kycStatus: DbUserKycStatus): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO user_kyc_status
+         (user_id, anchor_id, status, last_checked, expires_at, rejection_reason, verification_data)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (user_id, anchor_id) DO UPDATE SET
+         status            = EXCLUDED.status,
+         last_checked      = EXCLUDED.last_checked,
+         expires_at        = EXCLUDED.expires_at,
+         rejection_reason  = EXCLUDED.rejection_reason,
+         verification_data = EXCLUDED.verification_data,
+         updated_at        = NOW()`,
+      [
+        kycStatus.user_id,
+        kycStatus.anchor_id,
+        kycStatus.status,
+        kycStatus.last_checked,
+        kycStatus.expires_at ?? null,
+        kycStatus.rejection_reason ?? null,
+        kycStatus.verification_data ? JSON.stringify(kycStatus.verification_data) : null,
+      ]
+    );
+  }
+
+  async getUserStatus(userId: string, anchorId: string): Promise<DbUserKycStatus | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM user_kyc_status WHERE user_id = $1 AND anchor_id = $2`,
+      [userId, anchorId]
+    );
+    if (!result.rows[0]) return null;
+    const r = result.rows[0];
+    return {
+      user_id: r.user_id,
+      anchor_id: r.anchor_id,
+      status: r.status as KycStatus,
+      last_checked: r.last_checked,
+      expires_at: r.expires_at,
+      rejection_reason: r.rejection_reason,
+      verification_data: r.verification_data,
+    };
+  }
+
+  async getUsersNeedingCheck(anchorId: string, minutesSinceLastCheck: number): Promise<DbUserKycStatus[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM user_kyc_status
+       WHERE anchor_id = $1
+         AND last_checked < NOW() - ($2 || ' minutes')::INTERVAL
+         AND status IN ('pending', 'approved')
+       ORDER BY last_checked ASC
+       LIMIT 100`,
+      [anchorId, minutesSinceLastCheck]
+    );
+    return result.rows.map((r) => ({
+      user_id: r.user_id,
+      anchor_id: r.anchor_id,
+      status: r.status as KycStatus,
+      last_checked: r.last_checked,
+      expires_at: r.expires_at,
+      rejection_reason: r.rejection_reason,
+      verification_data: r.verification_data,
+    }));
+  }
+
+  async getApprovedUsers(): Promise<DbUserKycStatus[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM user_kyc_status
+       WHERE status = 'approved' AND (expires_at IS NULL OR expires_at > NOW())
+       ORDER BY last_checked DESC`
+    );
+    return result.rows.map((r) => ({
+      user_id: r.user_id,
+      anchor_id: r.anchor_id,
+      status: r.status as KycStatus,
+      last_checked: r.last_checked,
+      expires_at: r.expires_at,
+      rejection_reason: r.rejection_reason,
+      verification_data: r.verification_data,
+    }));
+  }
+}

--- a/backend/src/repositories/RemittanceRepository.ts
+++ b/backend/src/repositories/RemittanceRepository.ts
@@ -1,0 +1,101 @@
+import { Pool } from 'pg';
+
+export interface TransactionRecord {
+  id?: string;
+  transaction_id: string;
+  anchor_id?: string;
+  kind?: 'deposit' | 'withdrawal';
+  status?: string;
+  status_eta?: number;
+  amount_in?: number;
+  amount_out?: number;
+  amount_fee?: number;
+  asset_code?: string;
+  stellar_transaction_id?: string;
+  external_transaction_id?: string;
+  kyc_status?: string;
+  kyc_fields?: Record<string, unknown>;
+  kyc_rejection_reason?: string;
+  message?: string;
+  memo?: string;
+  sender_address?: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export class RemittanceRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findById(transactionId: string): Promise<TransactionRecord | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM transactions WHERE transaction_id = $1`,
+      [transactionId]
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async findBySender(
+    senderAddress: string,
+    limit = 100,
+    offset = 0
+  ): Promise<TransactionRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM transactions
+       WHERE sender_address = $1
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [senderAddress, limit, offset]
+    );
+    return result.rows;
+  }
+
+  async findPending(): Promise<TransactionRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM transactions
+       WHERE status NOT IN ('completed', 'refunded', 'expired', 'error')
+       ORDER BY created_at ASC
+       LIMIT 100`
+    );
+    return result.rows;
+  }
+
+  async upsert(record: Omit<TransactionRecord, 'id' | 'created_at' | 'updated_at'>): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO transactions
+         (transaction_id, anchor_id, kind, status, status_eta,
+          amount_in, amount_out, amount_fee, asset_code,
+          stellar_transaction_id, external_transaction_id,
+          kyc_status, kyc_fields, kyc_rejection_reason, message, memo, sender_address)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+       ON CONFLICT (transaction_id) DO UPDATE SET
+         status                  = EXCLUDED.status,
+         amount_in               = COALESCE(EXCLUDED.amount_in, transactions.amount_in),
+         amount_out              = COALESCE(EXCLUDED.amount_out, transactions.amount_out),
+         amount_fee              = COALESCE(EXCLUDED.amount_fee, transactions.amount_fee),
+         stellar_transaction_id  = COALESCE(EXCLUDED.stellar_transaction_id, transactions.stellar_transaction_id),
+         external_transaction_id = COALESCE(EXCLUDED.external_transaction_id, transactions.external_transaction_id),
+         kyc_status              = COALESCE(EXCLUDED.kyc_status, transactions.kyc_status),
+         message                 = COALESCE(EXCLUDED.message, transactions.message),
+         updated_at              = NOW()`,
+      [
+        record.transaction_id,
+        record.anchor_id ?? null,
+        record.kind ?? null,
+        record.status ?? null,
+        record.status_eta ?? null,
+        record.amount_in ?? null,
+        record.amount_out ?? null,
+        record.amount_fee ?? null,
+        record.asset_code ?? null,
+        record.stellar_transaction_id ?? null,
+        record.external_transaction_id ?? null,
+        record.kyc_status ?? null,
+        record.kyc_fields ? JSON.stringify(record.kyc_fields) : null,
+        record.kyc_rejection_reason ?? null,
+        record.message ?? null,
+        record.memo ?? null,
+        record.sender_address ?? null,
+      ]
+    );
+  }
+}

--- a/backend/src/repositories/WebhookRepository.ts
+++ b/backend/src/repositories/WebhookRepository.ts
@@ -1,0 +1,100 @@
+import { Pool } from 'pg';
+import { WebhookSubscriber, WebhookDelivery } from '../types';
+
+function mapRow(row: Record<string, unknown>): WebhookDelivery {
+  return {
+    id: String(row.id),
+    event_type: String(row.event_type),
+    event_key: String(row.event_key),
+    subscriber_id: String(row.subscriber_id),
+    target_url: String(row.target_url),
+    payload: row.payload,
+    status: row.status as WebhookDelivery['status'],
+    attempt_count: Number(row.attempt_count),
+    max_attempts: Number(row.max_attempts),
+    next_retry_at: row.next_retry_at as Date,
+    last_error: row.last_error as string | null | undefined,
+    response_status: row.response_status as number | null | undefined,
+    delivered_at: row.delivered_at as Date | null | undefined,
+  };
+}
+
+export class WebhookRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async getActiveSubscribers(): Promise<WebhookSubscriber[]> {
+    const result = await this.pool.query(
+      `SELECT id, url, secret, active, created_at, updated_at
+       FROM webhook_subscribers WHERE active = true`
+    );
+    return result.rows.map((r) => ({
+      id: String(r.id),
+      url: String(r.url),
+      secret: r.secret as string | null,
+      active: Boolean(r.active),
+      created_at: r.created_at as Date,
+      updated_at: r.updated_at as Date,
+    }));
+  }
+
+  async enqueue(
+    eventType: string,
+    eventKey: string,
+    subscriber: WebhookSubscriber,
+    payload: unknown,
+    maxAttempts: number
+  ): Promise<WebhookDelivery> {
+    const result = await this.pool.query(
+      `INSERT INTO webhook_deliveries
+         (event_type, event_key, subscriber_id, target_url, payload, max_attempts, status, attempt_count, next_retry_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'pending', 0, NOW())
+       ON CONFLICT (event_type, event_key, subscriber_id) DO UPDATE SET
+         payload      = EXCLUDED.payload,
+         max_attempts = EXCLUDED.max_attempts,
+         status       = 'pending',
+         attempt_count = 0,
+         next_retry_at = NOW(),
+         updated_at   = NOW()
+       RETURNING *`,
+      [eventType, eventKey, subscriber.id, subscriber.url, JSON.stringify(payload), maxAttempts]
+    );
+    return mapRow(result.rows[0] as Record<string, unknown>);
+  }
+
+  async getPending(limit: number): Promise<WebhookDelivery[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM webhook_deliveries
+       WHERE status = 'pending' AND next_retry_at <= NOW()
+       ORDER BY next_retry_at ASC LIMIT $1`,
+      [limit]
+    );
+    return result.rows.map((r) => mapRow(r as Record<string, unknown>));
+  }
+
+  async markSuccess(id: string, responseStatus: number): Promise<void> {
+    await this.pool.query(
+      `UPDATE webhook_deliveries
+       SET status = 'success', response_status = $2, delivered_at = NOW(), updated_at = NOW()
+       WHERE id = $1`,
+      [id, responseStatus]
+    );
+  }
+
+  async markFailure(
+    id: string,
+    attemptCount: number,
+    maxAttempts: number,
+    nextRetryAt: Date,
+    message: string,
+    responseStatus: number | null
+  ): Promise<void> {
+    const status: WebhookDelivery['status'] = attemptCount >= maxAttempts ? 'failed' : 'pending';
+    await this.pool.query(
+      `UPDATE webhook_deliveries
+       SET attempt_count = $2, status = $3, next_retry_at = $4,
+           last_error = $5, response_status = $6, updated_at = NOW()
+       WHERE id = $1`,
+      [id, attemptCount, status, nextRetryAt, message, responseStatus]
+    );
+  }
+}

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -1,0 +1,5 @@
+export { RemittanceRepository } from './RemittanceRepository';
+export { KycRepository } from './KycRepository';
+export { AnchorRepository } from './AnchorRepository';
+export { WebhookRepository } from './WebhookRepository';
+export { FxRateRepository } from './FxRateRepository';

--- a/backend/src/tracing.ts
+++ b/backend/src/tracing.ts
@@ -1,0 +1,89 @@
+/**
+ * OpenTelemetry instrumentation for SwiftRemit backend.
+ *
+ * Import this module FIRST (before any other imports) in index.ts so that
+ * auto-instrumentation patches are applied before the libraries are loaded.
+ *
+ * Environment variables:
+ *   OTEL_EXPORTER_OTLP_ENDPOINT  – OTLP HTTP endpoint (default: http://localhost:4318)
+ *   OTEL_SERVICE_NAME            – Service name reported in traces (default: swiftremit-backend)
+ *   OTEL_ENABLED                 – Set to "false" to disable tracing (default: true)
+ */
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
+import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { trace, context, propagation, SpanStatusCode, Span } from '@opentelemetry/api';
+
+const enabled = process.env.OTEL_ENABLED !== 'false';
+
+let sdk: NodeSDK | null = null;
+
+if (enabled) {
+  const exporter = new OTLPTraceExporter({
+    url: `${process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4318'}/v1/traces`,
+  });
+
+  sdk = new NodeSDK({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME ?? 'swiftremit-backend',
+      [ATTR_SERVICE_VERSION]: process.env.npm_package_version ?? '1.0.0',
+    }),
+    traceExporter: exporter,
+    instrumentations: [
+      new HttpInstrumentation({
+        // Propagate W3C trace context to outbound anchor API calls
+        headersToSpanAttributes: {
+          client: { requestHeaders: ['x-correlation-id'] },
+        },
+      }),
+      new ExpressInstrumentation(),
+      new PgInstrumentation({ enhancedDatabaseReporting: false }),
+    ],
+  });
+
+  sdk.start();
+  console.log('[otel] Tracing started — exporting to', process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4318');
+
+  process.on('SIGTERM', () => sdk!.shutdown().catch(console.error));
+  process.on('SIGINT',  () => sdk!.shutdown().catch(console.error));
+}
+
+/** Returns the active tracer for manual span creation. */
+export function getTracer(name = 'swiftremit') {
+  return trace.getTracer(name);
+}
+
+/**
+ * Wrap an async operation in a named span.
+ * Automatically records exceptions and sets error status.
+ */
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  attributes?: Record<string, string | number | boolean>
+): Promise<T> {
+  const tracer = getTracer();
+  return tracer.startActiveSpan(name, async (span) => {
+    if (attributes) {
+      span.setAttributes(attributes);
+    }
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export { trace, context, propagation };

--- a/backend/src/webhooks/store.ts
+++ b/backend/src/webhooks/store.ts
@@ -165,7 +165,7 @@ export class PostgresWebhookStore implements IWebhookStore {
       `UPDATE webhooks SET active = FALSE WHERE id = $1`,
       [id]
     );
-    return result.rowCount > 0;
+    return (result.rowCount ?? 0) > 0;
   }
 
   async getWebhook(id: string): Promise<WebhookSubscriber | null> {


### PR DESCRIPTION
closes #452 
closes #453 
closes #454 
closes #455 


- Add idempotent migrations for transaction indexes (sender, status)
- Add admin_audit_log table migration + AdminAuditLogService
- Expose GET /api/admin/audit-log with pagination and filtering
- Wire audit log into RemittanceEventEmitter via emitAdminAction()
- Split database.ts into domain repositories (Remittance, Kyc, Anchor, Webhook, FxRate)
- Add repository unit tests with mocked Pool
- Add OpenTelemetry tracing (HTTP, Express, pg) with OTLP exporter
- Add withSpan() helper for manual instrumentation
- Document Jaeger local setup in README and env vars in .env.example