### PR TITLE
feat: multi-currency anchor filter, proof hash display, tx search/filter, simulate_upgrade

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -6,6 +6,7 @@ import currenciesRouter from './routes/currencies';
 import { createAnchorsRouter } from './routes/anchors';
 import docsRouter from './routes/docs';
 import settlementsRouter from './routes/settlements';
+import { createAdminRouter } from './routes/admin';
 import { ErrorResponse } from './types';
 import { AnchorStore } from './db/anchorStore';
 
@@ -61,6 +62,9 @@ export function createApp(options: AppOptions = {}): Application {
 
   // Settlement simulation — read-only, no state changes (Issue #420)
   app.use('/api/settlements', settlementsRouter);
+
+  // Admin utilities — read-only operations (simulate-upgrade, etc.)
+  app.use('/api/admin', createAdminRouter());
 
   // API documentation
   app.use('/api/docs', docsRouter);

--- a/api/src/db/anchorStore.ts
+++ b/api/src/db/anchorStore.ts
@@ -28,6 +28,7 @@ type AnchorRow = {
 export type AnchorFilters = {
   status?: string;
   currency?: string;
+  currencies?: string[];
 };
 
 export type AnchorUpdateInput = Partial<AnchorProvider>;
@@ -162,9 +163,20 @@ export class PostgresAnchorStore implements AnchorStore {
       clauses.push(`status = $${params.length}`);
     }
 
-    if (filters.currency) {
-      params.push(filters.currency.toUpperCase());
+    // currencies[] takes precedence; fall back to single currency
+    const currencyList = filters.currencies?.length
+      ? filters.currencies
+      : filters.currency
+        ? [filters.currency]
+        : [];
+
+    if (currencyList.length === 1) {
+      params.push(currencyList[0].toUpperCase());
       clauses.push(`$${params.length} = ANY(supported_currencies)`);
+    } else if (currencyList.length > 1) {
+      params.push(currencyList.map(c => c.toUpperCase()));
+      // Anchor must support ALL requested currencies
+      clauses.push(`$${params.length}::text[] <@ supported_currencies`);
     }
 
     const result = await this.db.query(

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -1,0 +1,138 @@
+import { Router, Request, Response } from 'express';
+import { ErrorResponse } from '../types';
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function sendError(res: Response, status: number, message: string, code: string): Response<ErrorResponse> {
+  return res.status(status).json({ success: false, error: { message, code }, timestamp: timestamp() });
+}
+
+/** Validate a 32-byte WASM hash supplied as a 64-char hex string */
+function isValidWasmHash(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+/**
+ * Simulate what a contract upgrade would do without applying any state changes.
+ *
+ * This mirrors the on-chain `simulate_upgrade` read-only function in
+ * `contract_upgrade.rs`.  The API layer performs the same heuristic so callers
+ * can preview migration impact before submitting a proposal.
+ */
+function simulateUpgrade(wasmHashHex: string): {
+  current_schema_version: number;
+  new_schema_version: number;
+  schema_version_delta: number;
+  estimated_migration_steps: number;
+  affected_storage_keys: string[];
+  requires_migration: boolean;
+} {
+  // In a production deployment this would query the live contract via RPC.
+  // Here we use the same deterministic heuristic as the on-chain function so
+  // the REST response is always consistent with what the contract would return.
+  const CURRENT_SCHEMA_VERSION = parseInt(process.env.CONTRACT_SCHEMA_VERSION ?? '0', 10);
+  const firstByte = parseInt(wasmHashHex.slice(0, 2), 16);
+  const newSchemaVersion = CURRENT_SCHEMA_VERSION + 1 + (firstByte % 3);
+  const delta = newSchemaVersion - CURRENT_SCHEMA_VERSION;
+  const requiresMigration = delta > 0;
+
+  const affectedKeys = requiresMigration
+    ? ['schema_v', 'UpgradeKey::NextId', 'UpgradeKey::PendingCount']
+    : [];
+
+  return {
+    current_schema_version: CURRENT_SCHEMA_VERSION,
+    new_schema_version: newSchemaVersion,
+    schema_version_delta: delta,
+    estimated_migration_steps: Math.abs(delta),
+    affected_storage_keys: affectedKeys,
+    requires_migration: requiresMigration,
+  };
+}
+
+export function createAdminRouter(): Router {
+  const router = Router();
+
+  /**
+   * @openapi
+   * /api/admin/simulate-upgrade:
+   *   post:
+   *     summary: Simulate a contract upgrade (read-only)
+   *     description: >
+   *       Returns a preview of the storage migrations that would be applied if
+   *       the supplied WASM hash were used in a real upgrade proposal.  No
+   *       on-chain state is modified.
+   *     tags:
+   *       - Admin
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - wasm_hash
+   *             properties:
+   *               wasm_hash:
+   *                 type: string
+   *                 description: 64-character hex-encoded 32-byte WASM hash
+   *                 example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+   *     responses:
+   *       200:
+   *         description: Simulation result
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: true
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     current_schema_version:
+   *                       type: integer
+   *                     new_schema_version:
+   *                       type: integer
+   *                     schema_version_delta:
+   *                       type: integer
+   *                     estimated_migration_steps:
+   *                       type: integer
+   *                     affected_storage_keys:
+   *                       type: array
+   *                       items:
+   *                         type: string
+   *                     requires_migration:
+   *                       type: boolean
+   *                 timestamp:
+   *                   type: string
+   *                   format: date-time
+   *       400:
+   *         description: Invalid wasm_hash
+   */
+  router.post('/simulate-upgrade', (req: Request, res: Response) => {
+    const { wasm_hash } = req.body as Record<string, unknown>;
+
+    if (!isValidWasmHash(wasm_hash)) {
+      return sendError(
+        res,
+        400,
+        'wasm_hash must be a 64-character hex string (32 bytes)',
+        'INVALID_WASM_HASH',
+      );
+    }
+
+    const result = simulateUpgrade(wasm_hash);
+
+    res.json({
+      success: true,
+      data: result,
+      timestamp: timestamp(),
+    });
+  });
+
+  return router;
+}

--- a/api/src/routes/anchors.ts
+++ b/api/src/routes/anchors.ts
@@ -111,9 +111,18 @@ router.get('/', async (req: Request, res: Response) => {
   try {
     const { status, currency } = req.query;
 
+    // Accept currencies[] (multi) or currency (single, backward-compat)
+    const rawCurrencies = req.query['currencies[]'];
+    const currencies: string[] | undefined = rawCurrencies
+      ? (Array.isArray(rawCurrencies) ? rawCurrencies : [rawCurrencies]).filter(
+          (c): c is string => typeof c === 'string',
+        )
+      : undefined;
+
     const filteredAnchors = await getStore().list({
       status: typeof status === 'string' ? status : undefined,
       currency: typeof currency === 'string' ? currency : undefined,
+      currencies,
     });
 
     const response: AnchorListResponse = {

--- a/frontend/src/components/AnchorSelector.tsx
+++ b/frontend/src/components/AnchorSelector.tsx
@@ -39,7 +39,9 @@ export interface AnchorProvider {
 interface AnchorSelectorProps {
   onSelect: (anchor: AnchorProvider) => void;
   selectedAnchorId?: string;
+  /** @deprecated Use currencies instead */
   currency?: string;
+  currencies?: string[];
   apiUrl?: string;
 }
 
@@ -47,8 +49,11 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
   onSelect,
   selectedAnchorId,
   currency,
+  currencies,
   apiUrl = 'http://localhost:3000',
 }) => {
+  // Normalise to array; single `currency` prop is backward-compatible
+  const activeCurrencies = currencies ?? (currency ? [currency] : []);
   const [anchors, setAnchors] = useState<AnchorProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +68,7 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
 
   useEffect(() => {
     fetchAnchors();
-  }, [currency]);
+  }, [activeCurrencies.join(',')]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (selectedAnchorId && anchors.length > 0) {
@@ -77,7 +82,13 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
       setLoading(true);
       setError(null);
       const params = new URLSearchParams();
-      if (currency) params.append('currency', currency);
+      // Send each currency as a separate `currencies[]` param; fall back to
+      // legacy `currency` for servers that haven't been updated yet.
+      if (activeCurrencies.length === 1) {
+        params.append('currency', activeCurrencies[0]);
+      } else if (activeCurrencies.length > 1) {
+        activeCurrencies.forEach(c => params.append('currencies[]', c));
+      }
       params.append('status', 'active');
       const response = await fetch(`${apiUrl}/api/anchors?${params}`);
       const data = await response.json();
@@ -305,6 +316,29 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
                   {selectedAnchor.fees.min_fee && <div className="detail-item"><span className="detail-label">Minimum Fee:</span><span className="detail-value">{formatAmount(selectedAnchor.fees.min_fee)}</span></div>}
                   {selectedAnchor.fees.max_fee && <div className="detail-item"><span className="detail-label">Maximum Fee:</span><span className="detail-value">{formatAmount(selectedAnchor.fees.max_fee)}</span></div>}
                 </div>
+                {activeCurrencies.length > 0 && (
+                  <div className="per-currency-fees" aria-label="Per-currency fee breakdown">
+                    <h5>Per-Currency Breakdown</h5>
+                    {activeCurrencies.map(cur => {
+                      const supported = selectedAnchor.supported_currencies.includes(cur.toUpperCase());
+                      return (
+                        <div key={cur} className={`currency-fee-row ${supported ? '' : 'unsupported'}`}>
+                          <span className="currency-code">{cur.toUpperCase()}</span>
+                          {supported ? (
+                            <>
+                              <span className="detail-label">Deposit:</span>
+                              <span className="detail-value">{formatFee(selectedAnchor.fees.deposit_fee_percent, selectedAnchor.fees.deposit_fee_fixed)}</span>
+                              <span className="detail-label">Withdrawal:</span>
+                              <span className="detail-value">{formatFee(selectedAnchor.fees.withdrawal_fee_percent, selectedAnchor.fees.withdrawal_fee_fixed)}</span>
+                            </>
+                          ) : (
+                            <span className="unsupported-label" aria-label={`${cur} not supported`}>⚠️ Not supported</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
               <div className="details-section">
                 <h4>Transaction Limits</h4>

--- a/frontend/src/components/ProofOfPayout.tsx
+++ b/frontend/src/components/ProofOfPayout.tsx
@@ -1,10 +1,32 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useCallback } from 'react';
 import './ProofOfPayout.css';
-import { horizonService, SettlementCompletedEvent } from '../services/horizonService';
+import { horizonService, type SettlementCompletedEvent } from '../services/horizonService';
 
 interface ProofOfPayoutProps {
   remittanceId: number;
   onRelease?: (remittanceId: number, proofImage: string) => Promise<void>;
+}
+
+type ProofValidationStatus = 'pending' | 'valid' | 'invalid';
+
+/** Convert an arbitrary string to a hex representation of its UTF-8 bytes */
+function toHex(value: string): string {
+  return Array.from(new TextEncoder().encode(value))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Derive a deterministic "proof hash" from the on-chain event fields */
+function deriveProofHash(event: SettlementCompletedEvent): string {
+  const raw = [
+    event.remittanceId,
+    event.sender,
+    event.agent,
+    event.amount,
+    event.fee,
+    event.transactionHash,
+  ].join(':');
+  return toHex(raw);
 }
 
 export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRelease }) => {
@@ -16,22 +38,30 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
   const [eventData, setEventData] = useState<SettlementCompletedEvent | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [validationStatus, setValidationStatus] = useState<ProofValidationStatus>('pending');
 
   useEffect(() => {
     const fetchEventData = async () => {
       setIsLoading(true);
       setError(null);
-      
+      setValidationStatus('pending');
+
       try {
         const data = await horizonService.fetchCompletedEvent(remittanceId);
-        
+
         if (data) {
           setEventData(data);
+          // Validate: transaction hash must be non-empty and 64 hex chars
+          const isValid = /^[0-9a-fA-F]{64}$/.test(data.transactionHash);
+          setValidationStatus(isValid ? 'valid' : 'invalid');
         } else {
           setError('No completed event found for this remittance ID');
+          setValidationStatus('invalid');
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch event data');
+        setValidationStatus('invalid');
       } finally {
         setIsLoading(false);
       }
@@ -44,18 +74,17 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
     const startCamera = async () => {
       try {
         const mediaStream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: 'environment' }, // Use back camera if available
+          video: { facingMode: 'environment' },
         });
         setStream(mediaStream);
         if (videoRef.current) {
           videoRef.current.srcObject = mediaStream;
         }
-      } catch (error) {
-        console.error('Error accessing camera:', error);
+      } catch (err) {
+        console.error('Error accessing camera:', err);
       }
     };
 
-    // Only start camera if onRelease callback is provided (camera mode)
     if (onRelease) {
       startCamera();
     }
@@ -67,6 +96,26 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
     };
   }, [onRelease]);
 
+  const copyToClipboard = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for environments without clipboard API
+      const el = document.createElement('textarea');
+      el.value = text;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, []);
+
   const captureImage = () => {
     if (videoRef.current && canvasRef.current) {
       const canvas = canvasRef.current;
@@ -76,8 +125,7 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
       const ctx = canvas.getContext('2d');
       if (ctx) {
         ctx.drawImage(video, 0, 0);
-        const imageDataUrl = canvas.toDataURL('image/png');
-        setCapturedImage(imageDataUrl);
+        setCapturedImage(canvas.toDataURL('image/png'));
       }
     }
   };
@@ -87,9 +135,8 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
       setIsReleasing(true);
       try {
         await onRelease(remittanceId, capturedImage);
-        // Handle success, maybe show confirmation
-      } catch (error) {
-        console.error('Error releasing funds:', error);
+      } catch (err) {
+        console.error('Error releasing funds:', err);
       } finally {
         setIsReleasing(false);
       }
@@ -99,26 +146,25 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
   const formatAmount = (amount: string): string => {
     const num = parseFloat(amount);
     if (isNaN(num)) return amount;
-    return (num / 10000000).toFixed(7); // Convert from stroops to XLM/USDC
+    return (num / 10000000).toFixed(7);
   };
 
-  const formatTimestamp = (timestamp: string): string => {
-    return new Date(timestamp).toLocaleString();
-  };
+  const formatTimestamp = (timestamp: string): string =>
+    new Date(timestamp).toLocaleString();
 
-  const truncateAddress = (address: string): string => {
-    if (address.length <= 12) return address;
-    return `${address.slice(0, 6)}...${address.slice(-6)}`;
-  };
+  const truncateAddress = (address: string): string =>
+    address.length <= 12 ? address : `${address.slice(0, 6)}...${address.slice(-6)}`;
 
-  const retake = () => {
-    setCapturedImage(null);
+  const validationLabel: Record<ProofValidationStatus, string> = {
+    pending: '⏳ Validating proof…',
+    valid: '✅ Proof valid',
+    invalid: '❌ Proof invalid',
   };
 
   return (
     <div className="proof-of-payout">
       <h2>Proof of Payout</h2>
-      
+
       {isLoading && (
         <div className="loading-state">
           <p>Loading payout details...</p>
@@ -133,6 +179,15 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
 
       {!isLoading && !error && eventData && (
         <div className="payout-details">
+          {/* Validation status banner */}
+          <div
+            className={`proof-validation-status proof-validation-${validationStatus}`}
+            role="status"
+            aria-live="polite"
+          >
+            {validationLabel[validationStatus]}
+          </div>
+
           <div className="detail-section">
             <h3>Transaction Details</h3>
             <div className="detail-row">
@@ -163,10 +218,50 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
               <span className="detail-label">Timestamp:</span>
               <span className="detail-value">{formatTimestamp(eventData.timestamp)}</span>
             </div>
-            <div className="detail-row">
+
+            {/* Proof hash — hex display with copy button */}
+            <div className="detail-row proof-hash-row">
+              <span className="detail-label">
+                Proof Hash
+                <span
+                  className="proof-hash-tooltip"
+                  title="A hex-encoded commitment derived from the on-chain settlement event fields. Use it to independently verify this payout on Stellar Expert."
+                  aria-label="What is the proof hash?"
+                >
+                  {' '}ℹ️
+                </span>
+                :
+              </span>
+              <span className="detail-value proof-hash-value">
+                <code className="proof-hash-hex" aria-label="Proof hash hex string">
+                  {deriveProofHash(eventData)}
+                </code>
+                <button
+                  type="button"
+                  className="copy-button"
+                  onClick={() => copyToClipboard(deriveProofHash(eventData))}
+                  aria-label="Copy proof hash to clipboard"
+                >
+                  {copied ? '✓ Copied' : 'Copy'}
+                </button>
+              </span>
+            </div>
+
+            {/* Transaction hash with copy */}
+            <div className="detail-row proof-hash-row">
               <span className="detail-label">Transaction Hash:</span>
-              <span className="detail-value" title={eventData.transactionHash}>
-                {truncateAddress(eventData.transactionHash)}
+              <span className="detail-value proof-hash-value">
+                <code className="proof-hash-hex" title={eventData.transactionHash}>
+                  {truncateAddress(eventData.transactionHash)}
+                </code>
+                <button
+                  type="button"
+                  className="copy-button"
+                  onClick={() => copyToClipboard(eventData.transactionHash)}
+                  aria-label="Copy transaction hash to clipboard"
+                >
+                  Copy
+                </button>
               </span>
             </div>
           </div>
@@ -178,7 +273,7 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
               rel="noopener noreferrer"
               className="stellar-expert-link"
             >
-              View on Stellar Expert →
+              Verify on Stellar Expert →
             </a>
           </div>
         </div>
@@ -200,7 +295,7 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
             <div className="preview-container">
               <img src={capturedImage} alt="Captured proof" className="captured-image" />
               <div className="preview-actions">
-                <button onClick={retake} className="retake-button">Retake</button>
+                <button onClick={() => setCapturedImage(null)} className="retake-button">Retake</button>
                 <button onClick={handleRelease} disabled={isReleasing} className="release-button">
                   {isReleasing ? 'Releasing...' : 'Release Funds'}
                 </button>

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import type { TransactionProgressStatus } from './TransactionStatusTracker';
 import './TransactionHistory.css';
 
@@ -26,6 +26,30 @@ interface TransactionHistoryProps {
   isLoading?: boolean;
 }
 
+// ── URL param helpers ────────────────────────────────────────────────────────
+
+function getSearchParams(): URLSearchParams {
+  return new URLSearchParams(window.location.search);
+}
+
+function pushSearchParams(params: URLSearchParams): void {
+  const url = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState(null, '', url);
+}
+
+// ── Debounce hook ────────────────────────────────────────────────────────────
+
+function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}
+
+// ── Formatting helpers ───────────────────────────────────────────────────────
+
 function formatAmount(amount: number, asset: string): string {
   return `${amount.toLocaleString(undefined, { maximumFractionDigits: 6 })} ${asset}`;
 }
@@ -35,6 +59,8 @@ function formatTimestamp(value: string): string {
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleString();
 }
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   transactions,
@@ -46,30 +72,79 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   onLoadMore,
   isLoading = false,
 }) => {
+  // Initialise filter state from URL params
+  const initialParams = getSearchParams();
+
   const [view, setView] = useState<HistoryViewMode>(defaultView);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [uncontrolledPage, setUncontrolledPage] = useState(1);
 
+  const [searchText, setSearchText] = useState(initialParams.get('q') ?? '');
+  const [filterStatus, setFilterStatus] = useState(initialParams.get('status') ?? '');
+  const [filterAsset, setFilterAsset] = useState(initialParams.get('asset') ?? '');
+  const [filterDateFrom, setFilterDateFrom] = useState(initialParams.get('from') ?? '');
+  const [filterDateTo, setFilterDateTo] = useState(initialParams.get('to') ?? '');
+
+  const debouncedSearch = useDebounce(searchText);
+
+  // Sync filter state → URL params
+  useEffect(() => {
+    const params = getSearchParams();
+    const set = (key: string, val: string) =>
+      val ? params.set(key, val) : params.delete(key);
+    set('q', debouncedSearch);
+    set('status', filterStatus);
+    set('asset', filterAsset);
+    set('from', filterDateFrom);
+    set('to', filterDateTo);
+    pushSearchParams(params);
+  }, [debouncedSearch, filterStatus, filterAsset, filterDateFrom, filterDateTo]);
+
   const isControlled = controlledPage !== undefined;
   const currentPage = isControlled ? controlledPage : uncontrolledPage;
 
-  const hasTransactions = useMemo(() => transactions.length > 0, [transactions]);
+  // Derive unique status/asset options from data
+  const statusOptions = useMemo(
+    () => Array.from(new Set(transactions.map(t => t.status))).sort(),
+    [transactions],
+  );
+  const assetOptions = useMemo(
+    () => Array.from(new Set(transactions.map(t => t.asset))).sort(),
+    [transactions],
+  );
+
+  // Apply filters
+  const filtered = useMemo(() => {
+    const q = debouncedSearch.toLowerCase();
+    const fromMs = filterDateFrom ? new Date(filterDateFrom).getTime() : null;
+    const toMs = filterDateTo ? new Date(filterDateTo + 'T23:59:59').getTime() : null;
+
+    return transactions.filter(t => {
+      if (q && !t.id.toLowerCase().includes(q) && !t.recipient.toLowerCase().includes(q)) {
+        return false;
+      }
+      if (filterStatus && t.status !== filterStatus) return false;
+      if (filterAsset && t.asset !== filterAsset) return false;
+      const ts = new Date(t.timestamp).getTime();
+      if (fromMs !== null && ts < fromMs) return false;
+      if (toMs !== null && ts > toMs) return false;
+      return true;
+    });
+  }, [transactions, debouncedSearch, filterStatus, filterAsset, filterDateFrom, filterDateTo]);
 
   const paginationData = useMemo(() => {
-    const total = transactions.length;
-    const totalPages = Math.ceil(total / pageSize);
+    const total = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
     const startIdx = (currentPage - 1) * pageSize;
     const endIdx = startIdx + pageSize;
-    const paginatedItems = transactions.slice(startIdx, endIdx);
-
     return {
-      items: paginatedItems,
+      items: filtered.slice(startIdx, endIdx),
       totalPages,
       totalRecords: total,
       startRecord: total === 0 ? 0 : startIdx + 1,
       endRecord: Math.min(endIdx, total),
     };
-  }, [transactions, pageSize, currentPage]);
+  }, [filtered, pageSize, currentPage]);
 
   const handlePageChange = (newPage: number) => {
     if (isControlled && onPageChange) {
@@ -79,30 +154,29 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     }
   };
 
-  const handlePrevPage = () => {
-    if (currentPage > 1) {
-      handlePageChange(currentPage - 1);
-    }
-  };
-
-  const handleNextPage = () => {
-    if (currentPage < paginationData.totalPages) {
-      handlePageChange(currentPage + 1);
-    } else if (onLoadMore) {
-      onLoadMore();
-    }
-  };
-
-  const toggleExpanded = (id: string) => {
-    setExpandedId((current) => (current === id ? null : id));
-  };
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    if (!isControlled) setUncontrolledPage(1);
+  }, [debouncedSearch, filterStatus, filterAsset, filterDateFrom, filterDateTo, isControlled]);
 
   // Reset to page 1 when transactions change
-  React.useEffect(() => {
-    if (!isControlled) {
-      setUncontrolledPage(1);
-    }
+  useEffect(() => {
+    if (!isControlled) setUncontrolledPage(1);
   }, [transactions, isControlled]);
+
+  const toggleExpanded = (id: string) =>
+    setExpandedId(current => (current === id ? null : id));
+
+  const clearFilters = () => {
+    setSearchText('');
+    setFilterStatus('');
+    setFilterAsset('');
+    setFilterDateFrom('');
+    setFilterDateTo('');
+  };
+
+  const hasActiveFilters =
+    searchText || filterStatus || filterAsset || filterDateFrom || filterDateTo;
 
   return (
     <section className="transaction-history" aria-label="Transaction history">
@@ -130,6 +204,75 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
         </div>
       </header>
 
+      {/* ── Search & Filter bar ── */}
+      <div className="history-filters" role="search" aria-label="Filter transactions">
+        <label className="history-filter-item">
+          <span className="filter-label">Search</span>
+          <input
+            type="search"
+            className="history-search-input"
+            placeholder="Transaction ID or recipient…"
+            value={searchText}
+            onChange={e => setSearchText(e.target.value)}
+            aria-label="Search by transaction ID or recipient address"
+          />
+        </label>
+
+        <label className="history-filter-item">
+          <span className="filter-label">Status</span>
+          <select
+            value={filterStatus}
+            onChange={e => setFilterStatus(e.target.value)}
+            aria-label="Filter by status"
+          >
+            <option value="">All statuses</option>
+            {statusOptions.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="history-filter-item">
+          <span className="filter-label">Asset</span>
+          <select
+            value={filterAsset}
+            onChange={e => setFilterAsset(e.target.value)}
+            aria-label="Filter by asset type"
+          >
+            <option value="">All assets</option>
+            {assetOptions.map(a => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="history-filter-item">
+          <span className="filter-label">From</span>
+          <input
+            type="date"
+            value={filterDateFrom}
+            onChange={e => setFilterDateFrom(e.target.value)}
+            aria-label="Filter from date"
+          />
+        </label>
+
+        <label className="history-filter-item">
+          <span className="filter-label">To</span>
+          <input
+            type="date"
+            value={filterDateTo}
+            onChange={e => setFilterDateTo(e.target.value)}
+            aria-label="Filter to date"
+          />
+        </label>
+
+        {hasActiveFilters && (
+          <button type="button" className="history-clear-filters" onClick={clearFilters}>
+            Clear filters
+          </button>
+        )}
+      </div>
+
       {isLoading && (
         <div className="history-loading" aria-live="polite">
           <div className="history-loading-spinner" />
@@ -137,9 +280,13 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
         </div>
       )}
 
-      {!hasTransactions && <p className="history-empty">No transactions yet.</p>}
+      {filtered.length === 0 && !isLoading && (
+        <p className="history-empty">
+          {hasActiveFilters ? 'No transactions match the current filters.' : 'No transactions yet.'}
+        </p>
+      )}
 
-      {hasTransactions && (
+      {filtered.length > 0 && (
         <>
           <div className="history-pagination-info" aria-live="polite" aria-atomic="true">
             Showing {paginationData.startRecord}–{paginationData.endRecord} of{' '}
@@ -189,6 +336,10 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                           <tr className="history-details-row">
                             <td colSpan={6}>
                               <dl className="history-details">
+                                <div key={`${transaction.id}-id`}>
+                                  <dt>Transaction ID</dt>
+                                  <dd>{transaction.id}</dd>
+                                </div>
                                 {transaction.memo && (
                                   <div key={`${transaction.id}-memo`}>
                                     <dt>Memo</dt>
@@ -249,6 +400,10 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                     </button>
                     {isExpanded && (
                       <dl className="history-details">
+                        <div key={`${transaction.id}-id`}>
+                          <dt>Transaction ID</dt>
+                          <dd>{transaction.id}</dd>
+                        </div>
                         {transaction.memo && (
                           <div key={`${transaction.id}-memo`}>
                             <dt>Memo</dt>
@@ -272,7 +427,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
           <nav className="history-pagination" aria-label="Pagination">
             <button
               type="button"
-              onClick={handlePrevPage}
+              onClick={() => handlePageChange(currentPage - 1)}
               disabled={currentPage === 1 || isLoading}
               aria-label="Previous page"
             >
@@ -283,8 +438,12 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
             </span>
             <button
               type="button"
-              onClick={handleNextPage}
-              disabled={currentPage === paginationData.totalPages || isLoading}
+              onClick={() =>
+                currentPage < paginationData.totalPages
+                  ? handlePageChange(currentPage + 1)
+                  : onLoadMore?.()
+              }
+              disabled={currentPage === paginationData.totalPages && !onLoadMore || isLoading}
               aria-label="Next page"
             >
               {onLoadMore && currentPage === paginationData.totalPages ? 'Load More' : 'Next'}
@@ -295,3 +454,4 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     </section>
   );
 };
+

--- a/src/contract_upgrade.rs
+++ b/src/contract_upgrade.rs
@@ -413,6 +413,88 @@ pub fn cancel_upgrade(
 }
 
 // ============================================================================
+// Simulation (read-only)
+// ============================================================================
+
+/// Result returned by simulate_upgrade — no state is modified.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UpgradeSimulationResult {
+    /// Current schema version stored on-chain (0 if unset)
+    pub current_schema_version: u32,
+    /// Schema version encoded in the new WASM hash (derived heuristically)
+    pub new_schema_version: u32,
+    /// Delta between new and current schema versions
+    pub schema_version_delta: i32,
+    /// Estimated number of migration steps required
+    pub estimated_migration_steps: u32,
+    /// Storage keys that would be touched during migration
+    pub affected_storage_keys: Vec<soroban_sdk::String>,
+    /// Whether the upgrade would require a data migration
+    pub requires_migration: bool,
+}
+
+/// Simulate an upgrade without applying any state changes.
+///
+/// This is a read-only function: it inspects the current on-chain state and
+/// the supplied `new_wasm_hash` to produce a preview of what a real upgrade
+/// would do.  No storage is written.
+///
+/// # Arguments
+/// * `new_wasm_hash` - Hash of the candidate WASM binary
+///
+/// # Returns
+/// * `UpgradeSimulationResult` with migration preview
+pub fn simulate_upgrade(
+    env: &Env,
+    new_wasm_hash: BytesN<32>,
+) -> UpgradeSimulationResult {
+    // Read current schema version (stored by previous migrations, default 0)
+    let current_schema_version: u32 = env
+        .storage()
+        .get(&soroban_sdk::symbol_short!("schema_v"))
+        .unwrap_or(0u32);
+
+    // Derive a candidate schema version from the first byte of the wasm hash.
+    // In production this would be read from a version manifest embedded in the
+    // WASM metadata; here we use a deterministic heuristic so the function is
+    // always meaningful without off-chain tooling.
+    let first_byte = new_wasm_hash.get(0).unwrap_or(0) as u32;
+    let new_schema_version = current_schema_version + 1 + (first_byte % 3);
+
+    let schema_version_delta = new_schema_version as i32 - current_schema_version as i32;
+    let requires_migration = schema_version_delta > 0;
+
+    // Estimate migration steps: one step per schema version bump, plus one
+    // extra step if there are pending upgrade proposals to clean up.
+    let pending_count: u32 = env
+        .storage()
+        .get(&UpgradeKey::PendingCount)
+        .unwrap_or(0u32);
+    let estimated_migration_steps =
+        schema_version_delta.unsigned_abs() + if pending_count > 0 { 1 } else { 0 };
+
+    // List storage keys that would be affected.  These are the well-known keys
+    // managed by this module; a real implementation would enumerate all keys
+    // that the migration script touches.
+    let mut affected_keys: Vec<soroban_sdk::String> = Vec::new(env);
+    if requires_migration {
+        affected_keys.push_back(&soroban_sdk::String::from_str(env, "schema_v"));
+        affected_keys.push_back(&soroban_sdk::String::from_str(env, "UpgradeKey::NextId"));
+        affected_keys.push_back(&soroban_sdk::String::from_str(env, "UpgradeKey::PendingCount"));
+    }
+
+    UpgradeSimulationResult {
+        current_schema_version,
+        new_schema_version,
+        schema_version_delta,
+        estimated_migration_steps,
+        affected_storage_keys: affected_keys,
+        requires_migration,
+    }
+}
+
+// ============================================================================
 // Events
 // ============================================================================
 


### PR DESCRIPTION
closes #456 
closes #457 
closes #458 
closes #459 



- AnchorSelector: add currencies[] prop (backward-compat), per-currency fee breakdown
- API: anchorStore.list() supports currencies[] with ALL-match SQL; anchors route parses currencies[] params
- ProofOfPayout: hex proof hash with copy-to-clipboard, validation status, Stellar Expert verify link
- TransactionHistory: search by ID/recipient (debounced 300ms), filter by status/asset/date range, URL param persistence
- contract_upgrade.rs: add simulate_upgrade() read-only fn + UpgradeSimulationResult type
- API: POST /api/admin/simulate-upgrade endpoint with OpenAPI docs