### PR TITLE
security: Add per-group rate limiting to REST API (#449)

### DIFF
--- a/backend/src/__tests__/rate-limit.test.ts
+++ b/backend/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+// Minimal mocks so app can be imported without real DB/Stellar
+vi.mock('../database', () => ({
+  initDatabase: vi.fn().mockResolvedValue(undefined),
+  getPool: vi.fn(() => ({ query: vi.fn().mockResolvedValue({ rows: [] }), connect: vi.fn() })),
+  getAssetVerification: vi.fn().mockResolvedValue(null),
+  saveAssetVerification: vi.fn().mockResolvedValue(undefined),
+  reportSuspiciousAsset: vi.fn().mockResolvedValue(undefined),
+  getVerifiedAssets: vi.fn().mockResolvedValue([]),
+  saveFxRate: vi.fn().mockResolvedValue(undefined),
+  getFxRate: vi.fn().mockResolvedValue(null),
+  saveAnchorKycConfig: vi.fn().mockResolvedValue(undefined),
+  getUserKycStatus: vi.fn().mockResolvedValue(null),
+  saveUserKycStatus: vi.fn().mockResolvedValue(undefined),
+  saveAssetReport: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../verifier', () => ({
+  AssetVerifier: vi.fn().mockImplementation(() => ({ verifyAsset: vi.fn() })),
+}));
+vi.mock('../stellar', () => ({
+  storeVerificationOnChain: vi.fn().mockResolvedValue(undefined),
+  simulateSettlement: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('../sep24-service', () => ({
+  Sep24Service: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    initiateFlow: vi.fn(),
+    getTransactionStatus: vi.fn(),
+  })),
+  Sep24ConfigError: class extends Error {},
+  Sep24AnchorError: class extends Error { statusCode = 502; },
+}));
+vi.mock('../kyc-upsert-service', () => ({
+  KycUpsertService: vi.fn().mockImplementation(() => ({
+    getStatusForUser: vi.fn().mockResolvedValue(null),
+  })),
+}));
+vi.mock('../transfer-guard', () => ({
+  createTransferGuard: vi.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+vi.mock('../fx-rate-cache', () => ({
+  getFxRateCache: vi.fn(() => ({ getCurrentRate: vi.fn().mockResolvedValue({}) })),
+}));
+vi.mock('../routes/docs', () => ({ default: { use: vi.fn(), get: vi.fn() } }));
+
+describe('Rate limiting', () => {
+  it('returns 429 with Retry-After header when limit exceeded', async () => {
+    // Import app fresh for this test
+    const { default: app } = await import('../api');
+
+    // Exhaust the public limiter (max=100/min) by sending 101 requests
+    // We use a path that hits the public limiter
+    const responses = await Promise.all(
+      Array.from({ length: 101 }, () =>
+        request(app).get('/api/verification/verified')
+      )
+    );
+
+    const blocked = responses.filter(r => r.status === 429);
+    expect(blocked.length).toBeGreaterThan(0);
+
+    const first429 = blocked[0];
+    expect(first429.headers).toHaveProperty('retry-after');
+    expect(Number(first429.headers['retry-after'])).toBeGreaterThan(0);
+    expect(first429.body).toMatchObject({ error: 'Too many requests' });
+  });
+});

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -56,14 +56,35 @@ async function getSep24ServiceInstance(): Promise<Sep24Service> {
   return sep24Service;
 }
 
-// Rate limiting
-const limiter = rateLimit({
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '900000'),
-  max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100'),
-  message: 'Too many requests from this IP, please try again later.',
-});
+// Per-group rate limiters
+function makeRateLimiter(max: number, windowMs = 60_000) {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req: Request, res: Response) => {
+      const retryAfter = Math.ceil(windowMs / 1000);
+      res.set('Retry-After', String(retryAfter));
+      metricsService.incrementRateLimitExceeded(req.path);
+      res.status(429).json({
+        error: 'Too many requests',
+        retryAfter,
+      });
+    },
+  });
+}
 
-app.use('/api/', limiter);
+// Public endpoints: 100 req/min
+const publicLimiter = makeRateLimiter(100);
+// Webhook endpoints: 1000 req/min (higher for anchor callbacks)
+const webhookLimiter = makeRateLimiter(1000);
+// Admin endpoints: 20 req/min
+const adminLimiter = makeRateLimiter(20);
+
+app.use('/api/webhook', webhookLimiter);
+app.use('/api/kyc/config', adminLimiter);
+app.use('/api/', publicLimiter);
 
 // Metrics endpoint (excluded from rate limiting)
 app.get('/metrics', async (req: Request, res: Response) => {

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -11,10 +11,20 @@ export class MetricsService {
     swiftremit_webhook_deliveries_total: {} as Record<string, number>,
     swiftremit_active_remittances: 0,
     swiftremit_accumulated_fees: 0,
+    swiftremit_rate_limit_exceeded_total: {} as Record<string, number>,
   };
 
   constructor(pool: Pool) {
     this.pool = pool;
+  }
+
+  /**
+   * Increment rate limit exceeded counter for a given path
+   */
+  incrementRateLimitExceeded(path: string): void {
+    const key = path.replace(/\/[^/]+$/, '/:id').replace(/[^a-zA-Z0-9_/:]/g, '_');
+    this.metrics.swiftremit_rate_limit_exceeded_total[key] =
+      (this.metrics.swiftremit_rate_limit_exceeded_total[key] ?? 0) + 1;
   }
 
   /**
@@ -149,6 +159,13 @@ export class MetricsService {
     lines.push('# HELP swiftremit_accumulated_fees Total accumulated fees from completed transactions');
     lines.push('# TYPE swiftremit_accumulated_fees gauge');
     lines.push(`swiftremit_accumulated_fees ${this.metrics.swiftremit_accumulated_fees}`);
+
+    // Rate limit exceeded counter
+    lines.push('# HELP swiftremit_rate_limit_exceeded_total Total number of rate limit rejections by path');
+    lines.push('# TYPE swiftremit_rate_limit_exceeded_total counter');
+    Object.entries(this.metrics.swiftremit_rate_limit_exceeded_total).forEach(([path, count]) => {
+      lines.push(`swiftremit_rate_limit_exceeded_total{path="${path}"} ${count}`);
+    });
 
     return lines.join('\n') + '\n';
   }


### PR DESCRIPTION
## Summary

Closes #449

Replaces the single global rate limiter with per-group limiters and adds a Prometheus counter for rate limit rejections.

## Changes

### `backend/src/api.ts`
- Removed single `limiter` applied to all `/api/` routes
- Added `makeRateLimiter(max, windowMs)` factory using `express-rate-limit`
- Applied three limiters:
  - `/api/webhook/*` — 1000 req/min (anchor callbacks)
  - `/api/kyc/config` — 20 req/min (admin)
  - `/api/*` — 100 req/min (public fallback)
- All 429 responses include `Retry-After` header (seconds) and JSON body `{ error, retryAfter }`
- Calls `metricsService.incrementRateLimitExceeded(path)` on every rejection

### `backend/src/metrics.ts`
- Added `swiftremit_rate_limit_exceeded_total` in-memory counter keyed by normalised path
- Added `incrementRateLimitExceeded(path)` public method
- Exposed counter in Prometheus text output

## Acceptance Criteria
- [x] Rate limiting applied to all route groups
- [x] 429 response with `Retry-After` header
- [x] `swiftremit_rate_limit_exceeded_total` counter metric added
- [x] `rate-limit.test.ts` verifies 429 + Retry-After enforcement