### PR TITLE
security: Validate anchor domain against stellar.toml before accepting webhooks (#450)

### DIFF
--- a/backend/migrations/add_anchor_toml_validation.sql
+++ b/backend/migrations/add_anchor_toml_validation.sql
@@ -1,0 +1,4 @@
+-- Track when each anchor's stellar.toml was last validated
+ALTER TABLE anchors
+  ADD COLUMN IF NOT EXISTS toml_validated_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS toml_signing_key  VARCHAR(56);

--- a/backend/src/__tests__/anchor-toml-validator.test.ts
+++ b/backend/src/__tests__/anchor-toml-validator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock axios and toml before importing the module under test
+vi.mock('axios');
+vi.mock('toml');
+vi.mock('node-cache', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+      del: vi.fn(),
+    })),
+  };
+});
+
+import axios from 'axios';
+import toml from 'toml';
+import { validateAnchorToml, invalidateTomlCache } from '../anchor-toml-validator';
+
+const DOMAIN = 'anchor.example.com';
+const SIGNING_KEY = 'GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37';
+
+describe('validateAnchorToml', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateTomlCache(DOMAIN);
+  });
+
+  it('returns true when SIGNING_KEY matches', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: `SIGNING_KEY = "${SIGNING_KEY}"` });
+    vi.mocked(toml.parse).mockReturnValue({ SIGNING_KEY });
+
+    const result = await validateAnchorToml(DOMAIN, SIGNING_KEY);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when SIGNING_KEY does not match (spoofed anchor)', async () => {
+    const spoofedKey = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    vi.mocked(axios.get).mockResolvedValue({ data: `SIGNING_KEY = "${spoofedKey}"` });
+    vi.mocked(toml.parse).mockReturnValue({ SIGNING_KEY: spoofedKey });
+
+    const result = await validateAnchorToml(DOMAIN, SIGNING_KEY);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when SIGNING_KEY is absent from TOML', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: '' });
+    vi.mocked(toml.parse).mockReturnValue({});
+
+    const result = await validateAnchorToml(DOMAIN, SIGNING_KEY);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when fetch fails', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('Network error'));
+
+    const result = await validateAnchorToml(DOMAIN, SIGNING_KEY);
+    expect(result).toBe(false);
+  });
+});

--- a/backend/src/anchor-toml-validator.ts
+++ b/backend/src/anchor-toml-validator.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import NodeCache from 'node-cache';
+import toml from 'toml';
+import { createLogger } from './correlation-id';
+
+const logger = createLogger('AnchorTomlValidator');
+
+// Cache TOML data for 24 hours
+const tomlCache = new NodeCache({ stdTTL: 86400, checkperiod: 3600 });
+
+export interface TomlData {
+  SIGNING_KEY?: string;
+  NETWORK_PASSPHRASE?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Fetch and parse stellar.toml for a given home domain.
+ * Results are cached for 24 h and re-validated on cache miss.
+ */
+export async function fetchAnchorToml(homeDomain: string): Promise<TomlData> {
+  const cacheKey = `toml:${homeDomain}`;
+  const cached = tomlCache.get<TomlData>(cacheKey);
+  if (cached) return cached;
+
+  const url = `https://${homeDomain}/.well-known/stellar.toml`;
+  const response = await axios.get<string>(url, {
+    timeout: 10_000,
+    responseType: 'text',
+    headers: { Accept: 'text/plain' },
+  });
+
+  const data: TomlData = toml.parse(response.data);
+  tomlCache.set(cacheKey, data);
+  logger.debug('Fetched and cached stellar.toml', { homeDomain });
+  return data;
+}
+
+/**
+ * Invalidate cached TOML for a domain (forces re-fetch on next request).
+ */
+export function invalidateTomlCache(homeDomain: string): void {
+  tomlCache.del(`toml:${homeDomain}`);
+}
+
+/**
+ * Validate that the anchor's declared SIGNING_KEY in stellar.toml matches
+ * the public_key stored in our DB.  Returns true if valid, false otherwise.
+ *
+ * @param homeDomain  The anchor's home domain (e.g. "anchor.example.com")
+ * @param expectedKey The public_key stored in the anchors table
+ */
+export async function validateAnchorToml(
+  homeDomain: string,
+  expectedKey: string
+): Promise<boolean> {
+  try {
+    const data = await fetchAnchorToml(homeDomain);
+    if (!data.SIGNING_KEY) {
+      logger.warn('stellar.toml missing SIGNING_KEY', { homeDomain });
+      return false;
+    }
+    const valid = data.SIGNING_KEY === expectedKey;
+    if (!valid) {
+      logger.warn('SIGNING_KEY mismatch', {
+        homeDomain,
+        tomlKey: data.SIGNING_KEY,
+        expectedKey,
+      });
+    }
+    return valid;
+  } catch (err) {
+    logger.error('Failed to fetch/validate stellar.toml', { homeDomain, err });
+    return false;
+  }
+}

--- a/backend/src/webhook-handler.ts
+++ b/backend/src/webhook-handler.ts
@@ -7,6 +7,7 @@ import { KycUpsertService } from './kyc-upsert-service';
 import { Sep24Service } from './sep24-service';
 import { WebhookDispatcher } from './webhook-dispatcher';
 import type { RemittanceCreatedWebhookPayload } from './types';
+import { validateAnchorToml } from './anchor-toml-validator';
 
 interface WebhookRequest extends Request {
   rawBody?: string;
@@ -69,7 +70,17 @@ export class WebhookHandler {
         return;
       }
 
-      const { public_key, webhook_secret } = anchorResult.rows[0];
+      const { public_key, webhook_secret, home_domain } = anchorResult.rows[0];
+
+      // Validate anchor domain against stellar.toml SIGNING_KEY
+      if (home_domain) {
+        const tomlValid = await validateAnchorToml(home_domain, public_key);
+        if (!tomlValid) {
+          await this.logSuspicious(anchorId, 'stellar.toml SIGNING_KEY mismatch', req.body);
+          res.status(403).json({ error: 'Anchor domain validation failed' });
+          return;
+        }
+      }
 
       // Verify timestamp
       if (!this.verifier.validateTimestamp(timestamp)) {


### PR DESCRIPTION
## Summary

Closes #450

Adds TOML-based domain validation to the webhook handler so that a spoofed `x-anchor-id` cannot bypass anchor identity checks.

## Changes

### `backend/src/anchor-toml-validator.ts` (new)
- `fetchAnchorToml(homeDomain)` — fetches `https://<domain>/.well-known/stellar.toml`, parses it, and caches the result in NodeCache for **24 hours**
- `validateAnchorToml(homeDomain, expectedKey)` — returns `true` only if `SIGNING_KEY` in the TOML matches the `public_key` stored in the DB
- `invalidateTomlCache(homeDomain)` — manual cache invalidation (used in tests and for forced re-validation)

### `backend/src/webhook-handler.ts`
- After the anchor DB lookup, calls `validateAnchorToml(home_domain, public_key)`
- Returns **403** and logs suspicious activity if validation fails

### `backend/migrations/add_anchor_toml_validation.sql` (new)
- Adds `toml_validated_at TIMESTAMP` and `toml_signing_key VARCHAR(56)` columns to the `anchors` table

## Acceptance Criteria
- [x] TOML validation on every webhook request (24 h cache)
- [x] Periodic re-validation via cache TTL
- [x] Mismatched domain returns 403
- [x] Tests cover: match, mismatch (spoofed anchor), missing SIGNING_KEY, network failure