### PR TITLE
feat: Add database migration runner with version tracking (#451)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,9 @@
     "test:webhook:manual": "tsx scripts/test-webhook.ts",
     "lint": "eslint src --ext .ts",
     "webhook:example": "tsx examples/send-webhook.ts",
-    "validate:openapi": "swagger-cli validate openapi.yaml"
+    "validate:openapi": "swagger-cli validate openapi.yaml",
+    "migrate": "tsx src/migrate.ts migrate",
+    "migrate:rollback": "tsx src/migrate.ts rollback"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",

--- a/backend/src/__tests__/migrate.test.ts
+++ b/backend/src/__tests__/migrate.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+
+// Mock pg Pool
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue({
+  query: mockQuery,
+  release: mockRelease,
+});
+const mockPool = {
+  query: mockQuery,
+  connect: mockConnect,
+};
+
+vi.mock('pg', () => ({
+  Pool: vi.fn().mockImplementation(() => mockPool),
+}));
+
+// Mock fs so we control which migration files exist
+vi.mock('fs');
+
+import { migrate, rollback } from '../migrate';
+
+const FAKE_MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
+
+describe('migrate()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // schema_migrations table exists, no applied migrations yet
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT filename FROM schema_migrations ORDER BY id')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    vi.mocked(fs.readdirSync).mockReturnValue(['001_init.sql', '002_add_index.sql'] as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('CREATE TABLE test (id SERIAL);' as any);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it('creates schema_migrations table on first run', async () => {
+    await migrate(mockPool as any);
+    const calls = mockQuery.mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls.some(s => s.includes('CREATE TABLE IF NOT EXISTS schema_migrations'))).toBe(true);
+  });
+
+  it('applies pending migrations in order', async () => {
+    await migrate(mockPool as any);
+    const insertCalls = mockQuery.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO schema_migrations')
+    );
+    expect(insertCalls.length).toBe(2);
+    expect(insertCalls[0][1][0]).toBe('001_init.sql');
+    expect(insertCalls[1][1][0]).toBe('002_add_index.sql');
+  });
+
+  it('skips already-applied migrations', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT filename FROM schema_migrations ORDER BY id')) {
+        return Promise.resolve({ rows: [{ filename: '001_init.sql' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await migrate(mockPool as any);
+    const insertCalls = mockQuery.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO schema_migrations')
+    );
+    // Only 002 should be applied
+    expect(insertCalls.length).toBe(1);
+    expect(insertCalls[0][1][0]).toBe('002_add_index.sql');
+  });
+
+  it('rolls back on SQL error and re-throws', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT filename FROM schema_migrations ORDER BY id')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql === 'CREATE TABLE test (id SERIAL);') {
+        return Promise.reject(new Error('syntax error'));
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(migrate(mockPool as any)).rejects.toThrow('syntax error');
+    const calls = mockQuery.mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls).toContain('ROLLBACK');
+  });
+});
+
+describe('rollback()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('ORDER BY id DESC LIMIT 1')) {
+        return Promise.resolve({ rows: [{ filename: '002_add_index.sql' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('DROP TABLE test;' as any);
+  });
+
+  it('executes the .down.sql file and removes the record', async () => {
+    await rollback(mockPool as any);
+    const deleteCalls = mockQuery.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('DELETE FROM schema_migrations')
+    );
+    expect(deleteCalls.length).toBe(1);
+    expect(deleteCalls[0][1][0]).toBe('002_add_index.sql');
+  });
+
+  it('throws when no .down.sql file exists', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    await expect(rollback(mockPool as any)).rejects.toThrow('No rollback file found');
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import app from './api';
 import { initDatabase, getPool } from './database';
+import { migrate } from './migrate';
 import { startBackgroundJobs } from './scheduler';
 import { WebhookHandler } from './webhook-handler';
 import { KycService } from './kyc-service';
@@ -16,13 +17,18 @@ async function start() {
     await initDatabase();
     console.log('Database initialized');
 
+    // Run pending migrations automatically on startup
+    const pool = getPool();
+    await migrate(pool);
+    console.log('Migrations applied');
+
     // Initialize KYC service
     const kycService = new KycService();
     await kycService.initialize();
     console.log('KYC service initialized');
 
     // Setup webhook handler
-    const pool = getPool();
+    // (pool already declared above)
     
     // Apply HMAC verification middleware to all /webhooks routes
     const webhookVerification = createWebhookVerificationMiddleware({

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,0 +1,169 @@
+/**
+ * Database migration runner
+ *
+ * - Tracks applied migrations in schema_migrations table
+ * - Runs pending migrations on startup in filename order
+ * - Supports rollback of the last applied migration (if a .down.sql exists)
+ *
+ * Usage:
+ *   npm run migrate            — apply all pending migrations
+ *   npm run migrate:rollback   — roll back the last applied migration
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function getPool(): Pool {
+  return new Pool({
+    connectionString: process.env.DATABASE_URL,
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432'),
+    database: process.env.DB_NAME || 'swiftremit',
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || '',
+  });
+}
+
+async function ensureMigrationsTable(pool: Pool): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id          SERIAL PRIMARY KEY,
+      filename    VARCHAR(255) NOT NULL UNIQUE,
+      applied_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+      checksum    VARCHAR(64)  NOT NULL
+    )
+  `);
+}
+
+function checksum(content: string): string {
+  // Simple djb2 hash — no crypto dependency needed
+  let hash = 5381;
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash) ^ content.charCodeAt(i);
+    hash = hash >>> 0; // keep 32-bit unsigned
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/** Return sorted list of .sql migration files (excludes .down.sql) */
+function getMigrationFiles(): string[] {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter(f => f.endsWith('.sql') && !f.endsWith('.down.sql'))
+    .sort();
+}
+
+async function getAppliedMigrations(pool: Pool): Promise<Set<string>> {
+  const result = await pool.query<{ filename: string }>(
+    'SELECT filename FROM schema_migrations ORDER BY id'
+  );
+  return new Set(result.rows.map(r => r.filename));
+}
+
+// ─── migrate ────────────────────────────────────────────────────────────────
+
+export async function migrate(pool: Pool): Promise<void> {
+  await ensureMigrationsTable(pool);
+
+  const applied = await getAppliedMigrations(pool);
+  const files = getMigrationFiles();
+  const pending = files.filter(f => !applied.has(f));
+
+  if (pending.length === 0) {
+    console.log('No pending migrations.');
+    return;
+  }
+
+  for (const filename of pending) {
+    const filePath = path.join(MIGRATIONS_DIR, filename);
+    const sql = fs.readFileSync(filePath, 'utf8');
+    const hash = checksum(sql);
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query(
+        'INSERT INTO schema_migrations (filename, checksum) VALUES ($1, $2)',
+        [filename, hash]
+      );
+      await client.query('COMMIT');
+      console.log(`✓ Applied: ${filename}`);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      console.error(`✗ Failed:  ${filename}`, err);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+// ─── rollback ───────────────────────────────────────────────────────────────
+
+export async function rollback(pool: Pool): Promise<void> {
+  await ensureMigrationsTable(pool);
+
+  const result = await pool.query<{ filename: string }>(
+    'SELECT filename FROM schema_migrations ORDER BY id DESC LIMIT 1'
+  );
+
+  if (result.rows.length === 0) {
+    console.log('Nothing to roll back.');
+    return;
+  }
+
+  const { filename } = result.rows[0];
+  const downFile = filename.replace(/\.sql$/, '.down.sql');
+  const downPath = path.join(MIGRATIONS_DIR, downFile);
+
+  if (!fs.existsSync(downPath)) {
+    throw new Error(
+      `No rollback file found for ${filename}. Expected: ${downFile}`
+    );
+  }
+
+  const sql = fs.readFileSync(downPath, 'utf8');
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(sql);
+    await client.query(
+      'DELETE FROM schema_migrations WHERE filename = $1',
+      [filename]
+    );
+    await client.query('COMMIT');
+    console.log(`↩ Rolled back: ${filename}`);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error(`✗ Rollback failed: ${filename}`, err);
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+// ─── CLI entry point ─────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const command = process.argv[2] ?? 'migrate';
+  const pool = getPool();
+
+  const run = command === 'rollback' ? rollback : migrate;
+
+  run(pool)
+    .then(() => pool.end())
+    .catch(err => {
+      console.error(err);
+      pool.end();
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Closes #451

Adds a custom migration runner that tracks applied migrations in a `schema_migrations` table, runs pending migrations automatically on startup, and supports rollback.

## Changes

### `backend/src/migrate.ts` (new)
- `migrate(pool)` — ensures `schema_migrations` table exists, reads all `*.sql` files from `backend/migrations/` in sorted order, skips already-applied ones, runs each in a transaction, records filename + checksum
- `rollback(pool)` — finds the last applied migration, runs the matching `.down.sql` file in a transaction, removes the record
- Standalone CLI: `tsx src/migrate.ts [migrate|rollback]`

### `backend/src/index.ts`
- Calls `migrate(pool)` after `initDatabase()` on every startup — pending migrations are applied automatically before the server starts listening

### `backend/package.json`
- Added `"migrate": "tsx src/migrate.ts migrate"`
- Added `"migrate:rollback": "tsx src/migrate.ts rollback"`

## Acceptance Criteria
- [x] Migrations run automatically on startup
- [x] Applied migrations tracked in `schema_migrations` DB table (filename, checksum, applied_at)
- [x] Rollback command works (`npm run migrate:rollback`)
- [x] Existing SQL files in `backend/migrations/` are picked up automatically
- [x] `migrate.test.ts` covers: table creation, ordered apply, skip-already-applied, transaction rollback on error, rollback command, missing .down.sql error