### PR TITLE
fix: close AnchorSelector dropdown on outside tap on mobile

### DIFF
--- a/frontend/src/components/AnchorSelector.tsx
+++ b/frontend/src/components/AnchorSelector.tsx
@@ -179,9 +179,9 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
     }
   }, [focusedIndex, isOpen]);
 
-  // Close dropdown when clicking outside
+  // Close dropdown when clicking/tapping outside (pointerdown covers mouse + touch)
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleOutsidePointer = (event: PointerEvent) => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node) &&
           triggerRef.current && !triggerRef.current.contains(event.target as Node)) {
         setIsOpen(false);
@@ -190,8 +190,8 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
     };
 
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener('pointerdown', handleOutsidePointer);
+      return () => document.removeEventListener('pointerdown', handleOutsidePointer);
     }
   }, [isOpen]);
 


### PR DESCRIPTION
## Summary

Fixes #445

`AnchorSelector.tsx` used a `mousedown` event listener to detect outside clicks. On mobile touch devices `mousedown` is not reliably fired, so the dropdown stayed open after tapping outside.

## Changes

- Replaced `mousedown` with `pointerdown` in the outside-click `useEffect`. `pointerdown` is fired for both mouse and touch input, covering iOS Safari and Android Chrome.

## Acceptance Criteria

- [x] Dropdown closes on outside tap on mobile
- [x] Existing mouse behaviour unchanged
- [x] Works on iOS Safari and Android Chrome (pointerdown is supported in all modern browsers)