### PR TITLE
feat: add KYC status auto-polling to KycStatusBadge

### DIFF
--- a/frontend/src/components/KycStatusBadge.css
+++ b/frontend/src/components/KycStatusBadge.css
@@ -151,3 +151,10 @@
     text-align: left;
   }
 }
+
+.kyc-badge-checking {
+  font-size: 0.7em;
+  opacity: 0.7;
+  margin-left: 4px;
+  font-style: italic;
+}

--- a/frontend/src/components/KycStatusBadge.tsx
+++ b/frontend/src/components/KycStatusBadge.tsx
@@ -21,25 +21,43 @@ interface UserKycStatusResponse {
   last_checked: string;
 }
 
+const TERMINAL_STATUSES: KycStatus[] = ['approved', 'rejected'];
+
 interface KycStatusBadgeProps {
   userId: string;
   apiUrl?: string;
   showDetails?: boolean;
+  pollingIntervalMs?: number;
 }
 
 export const KycStatusBadge: React.FC<KycStatusBadgeProps> = ({
   userId,
   apiUrl = 'http://localhost:3000',
   showDetails = true,
+  pollingIntervalMs = 30_000,
 }) => {
   const [status, setStatus] = useState<UserKycStatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [polling, setPolling] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     fetchKycStatus();
   }, [apiUrl, userId]);
+
+  // Auto-poll while status is pending
+  useEffect(() => {
+    if (!status || TERMINAL_STATUSES.includes(status.overall_status) || pollingIntervalMs <= 0) return;
+
+    const id = setInterval(async () => {
+      setPolling(true);
+      await fetchKycStatus();
+      setPolling(false);
+    }, pollingIntervalMs);
+
+    return () => clearInterval(id);
+  }, [status?.overall_status, pollingIntervalMs]);
 
   const fetchKycStatus = async () => {
     try {
@@ -95,6 +113,7 @@ export const KycStatusBadge: React.FC<KycStatusBadgeProps> = ({
       >
         <span className="kyc-badge-icon">{badgeIcon}</span>
         <span className="kyc-badge-text">{badgeText}</span>
+        {polling && <span className="kyc-badge-checking" aria-live="polite">Checking...</span>}
       </div>
 
       {showModal && (


### PR DESCRIPTION
## Summary

Closes #444

`KycStatusBadge.tsx` displayed KYC status but never refreshed it. Users had to reload the page to see a status change (e.g. pending → approved).

## Changes

- Added a `useEffect` that sets up a `setInterval` when `overall_status` is `pending`
- Interval is cleared automatically when status reaches a terminal state (`approved` / `rejected`)
- Added `pollingIntervalMs` prop (default `30000`); set to `0` to disable polling
- Shows a subtle `Checking...` indicator next to the badge text during each poll
- Added `.kyc-badge-checking` style to `KycStatusBadge.css`

## Acceptance Criteria

- [x] Auto-polls when status is pending
- [x] Stops polling on terminal status
- [x] Loading indicator during poll
- [x] Prop to disable/configure polling