### PR TITLE
fix: FX rate cache does not handle provider API rate limit (429) gracefully

### DIFF
--- a/backend/src/__tests__/fx-rate-cache.test.ts
+++ b/backend/src/__tests__/fx-rate-cache.test.ts
@@ -109,6 +109,46 @@ describe('FxRateCache', () => {
       await expect(cache.getCurrentRate('USD', 'EUR')).rejects.toThrow('Failed to fetch FX rate');
     });
 
+    it('returns stale rate with stale:true on 429 when cache entry exists', async () => {
+      const mockResponse = { data: { rates: { EUR: 0.85 } } };
+      const rateLimitError = Object.assign(new Error('Too Many Requests'), {
+        isAxiosError: true,
+        response: { status: 429 },
+      });
+      // Make axios.isAxiosError return true for our error
+      vi.spyOn(axios, 'isAxiosError').mockImplementation((e) => (e as any).isAxiosError === true);
+
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(mockResponse)  // first call succeeds → populates stale cache
+        .mockRejectedValueOnce(rateLimitError); // second call (after invalidate) → 429
+
+      cache = new FxRateCache({ ttlSeconds: 60 });
+
+      // Populate stale cache
+      await cache.getCurrentRate('USD', 'EUR');
+      // Evict live cache so next call hits the API
+      cache.invalidate('USD', 'EUR');
+
+      const result = await cache.getCurrentRate('USD', 'EUR');
+      expect(result.stale).toBe(true);
+      expect(result.cached).toBe(true);
+      expect(result.rate).toBe(0.85);
+    });
+
+    it('throws on 429 when no stale entry exists', async () => {
+      const rateLimitError = Object.assign(new Error('Too Many Requests'), {
+        isAxiosError: true,
+        response: { status: 429 },
+      });
+      vi.spyOn(axios, 'isAxiosError').mockImplementation((e) => (e as any).isAxiosError === true);
+      vi.mocked(axios.get).mockRejectedValueOnce(rateLimitError);
+
+      cache = new FxRateCache({ ttlSeconds: 60 });
+
+      // No stale entry → the original axios error is re-thrown
+      await expect(cache.getCurrentRate('USD', 'EUR')).rejects.toMatchObject({ isAxiosError: true });
+    });
+
     it('includes API key in request headers when provided', async () => {
       const mockResponse = {
         data: {

--- a/backend/src/fx-rate-cache.ts
+++ b/backend/src/fx-rate-cache.ts
@@ -8,6 +8,8 @@ export interface FxRateResponse {
   timestamp: Date;
   provider: string;
   cached: boolean;
+  /** True when the rate is served from a stale cache entry due to a provider error (e.g. 429) */
+  stale?: boolean;
 }
 
 export interface FxRateCacheOptions {
@@ -20,6 +22,8 @@ export interface FxRateCacheOptions {
 
 export class FxRateCache {
   private cache: NodeCache;
+  /** Stale-only store: survives TTL expiry, used as 429 fallback */
+  private staleCache: Map<string, FxRateResponse>;
   private ttlSeconds: number;
   private refreshBeforeExpirySeconds: number;
   private externalApiUrl: string;
@@ -32,6 +36,7 @@ export class FxRateCache {
     this.externalApiUrl = options.externalApiUrl || process.env.FX_API_URL || 'https://api.exchangerate-api.com/v4/latest';
     this.externalApiKey = options.externalApiKey || process.env.FX_API_KEY || '';
     this.refreshTimers = new Map();
+    this.staleCache = new Map();
 
     this.cache = new NodeCache({
       stdTTL: this.ttlSeconds,
@@ -46,7 +51,8 @@ export class FxRateCache {
   }
 
   /**
-   * Get current FX rate with caching
+   * Get current FX rate with caching.
+   * On provider 429, returns the last known stale rate with `stale: true`.
    */
   async getCurrentRate(from: string, to: string): Promise<FxRateResponse> {
     // Normalize to uppercase
@@ -62,15 +68,30 @@ export class FxRateCache {
     }
 
     // Cache miss - fetch from external API
-    const rate = await this.fetchFromExternalApi(fromUpper, toUpper);
-    
-    // Store in cache
-    this.cache.set(cacheKey, rate);
+    try {
+      const rate = await this.fetchFromExternalApi(fromUpper, toUpper);
 
-    // Schedule background refresh
-    this.scheduleBackgroundRefresh(cacheKey, fromUpper, toUpper);
+      // Store in both live cache and stale fallback
+      this.cache.set(cacheKey, rate);
+      this.staleCache.set(cacheKey, rate);
 
-    return { ...rate, cached: false };
+      // Schedule background refresh
+      this.scheduleBackgroundRefresh(cacheKey, fromUpper, toUpper);
+
+      return { ...rate, cached: false };
+    } catch (error) {
+      // On 429, serve stale rate if available
+      if (axios.isAxiosError(error) && error.response?.status === 429) {
+        const stale = this.staleCache.get(cacheKey);
+        if (stale) {
+          console.warn(`FX provider rate-limited (429) for ${fromUpper}/${toUpper}; serving stale rate`);
+          // Schedule a jittered background retry so all pairs don't hammer the API simultaneously
+          this.scheduleJitteredRetry(cacheKey, fromUpper, toUpper);
+          return { ...stale, cached: true, stale: true };
+        }
+      }
+      throw error;
+    }
   }
 
   /**
@@ -107,6 +128,10 @@ export class FxRateCache {
         cached: false,
       };
     } catch (error) {
+      // Re-throw axios errors as-is so callers can inspect the status code (e.g. 429)
+      if (axios.isAxiosError(error)) {
+        throw error;
+      }
       console.error(`Failed to fetch FX rate for ${from}/${to}:`, error);
       throw new Error(`Failed to fetch FX rate: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -127,6 +152,7 @@ export class FxRateCache {
         try {
           const rate = await this.fetchFromExternalApi(from, to);
           this.cache.set(cacheKey, rate);
+          this.staleCache.set(cacheKey, rate);
           
           // Schedule next refresh
           this.scheduleBackgroundRefresh(cacheKey, from, to);
@@ -138,6 +164,27 @@ export class FxRateCache {
 
       this.refreshTimers.set(cacheKey, timer);
     }
+  }
+
+  /**
+   * Schedule a jittered retry after a 429 response to avoid thundering herd.
+   * Retries after 60–120 s (base 60 s + up to 60 s random jitter).
+   */
+  private scheduleJitteredRetry(cacheKey: string, from: string, to: string): void {
+    if (this.refreshTimers.has(cacheKey)) return; // already scheduled
+    const jitterMs = 60_000 + Math.random() * 60_000;
+    const timer = setTimeout(async () => {
+      this.refreshTimers.delete(cacheKey);
+      try {
+        const rate = await this.fetchFromExternalApi(from, to);
+        this.cache.set(cacheKey, rate);
+        this.staleCache.set(cacheKey, rate);
+        this.scheduleBackgroundRefresh(cacheKey, from, to);
+      } catch (error) {
+        console.error(`Jittered retry failed for ${cacheKey}:`, error);
+      }
+    }, jitterMs);
+    this.refreshTimers.set(cacheKey, timer);
   }
 
   /**
@@ -172,6 +219,7 @@ export class FxRateCache {
    */
   clearAll(): void {
     this.cache.flushAll();
+    this.staleCache.clear();
     this.refreshTimers.forEach(timer => clearTimeout(timer));
     this.refreshTimers.clear();
   }


### PR DESCRIPTION
Closes #430

## Changes

- On 429, `getCurrentRate` returns the last known stale rate with `stale: true` instead of propagating the error
- Added `staleCache` Map that persists entries beyond TTL expiry for use as a 429 fallback
- `fetchFromExternalApi` re-throws axios errors as-is so the 429 status code is inspectable by callers
- Jittered retry scheduled after 429 (60–120 s random delay) to avoid thundering herd on recovery
- `clearAll` also flushes the stale cache

## Tests
2 new tests: 429 with stale fallback returns `stale: true`, 429 with no stale entry re-throws