### PR TITLE
fix: SEP-24 poller does not handle anchor timeout on pending_anchor status

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,8 @@ MIN_REPUTATION_SCORE=50
 # SEP24_WEBHOOK_ANCHOR_1=https://your-server.com/webhooks/anchor
 # SEP24_POLL_INTERVAL_ANCHOR_1=5
 # SEP24_TIMEOUT_ANCHOR_1=30
+
+# Anchor timeout: hours before a pending_anchor transaction is marked as error (default: 24)
+ANCHOR_TIMEOUT_HOURS=24
+# Optional webhook URL to notify when a transaction times out in pending_anchor status
+ANCHOR_TIMEOUT_WEBHOOK_URL=

--- a/backend/src/__tests__/sep24-service.test.ts
+++ b/backend/src/__tests__/sep24-service.test.ts
@@ -18,7 +18,11 @@ vi.mock('../database', async (importOriginal) => {
       { anchor_id: 'anchor_test', kyc_server_url: 'http://localhost:0/sep24' },
     ]),
     saveSep24Transaction: vi.fn(async (record) => {
-      sep24Rows.set(record.transaction_id, { ...sep24Rows.get(record.transaction_id), ...record });
+      sep24Rows.set(record.transaction_id, {
+        created_at: new Date(),
+        ...sep24Rows.get(record.transaction_id),
+        ...record,
+      });
     }),
     getSep24Transaction: vi.fn(async (transactionId: string) => sep24Rows.get(transactionId) ?? null),
     getSep24TransactionById: vi.fn(async (transactionId: string) => sep24Rows.get(transactionId) ?? null),
@@ -259,6 +263,39 @@ describe('Sep24Service', () => {
       
       // Poll - should not throw
       await service.pollAllTransactions();
+    });
+  });
+
+  describe('anchor timeout (pending_anchor)', () => {
+    it('transitions pending_anchor transaction to error after timeout and increments counter', async () => {
+      // Set a very short timeout (0 hours) so any transaction is immediately stale
+      process.env.ANCHOR_TIMEOUT_HOURS = '0';
+      const timeoutService = new Sep24Service(pool);
+      await timeoutService.initialize();
+
+      const request: Sep24InitiateRequest = {
+        user_id: 'timeout-user',
+        anchor_id: 'anchor_test',
+        direction: 'deposit',
+        asset_code: 'USDC',
+        amount: '50.00',
+      };
+
+      const result = await timeoutService.initiateFlow(request);
+
+      // Confirm it starts as pending_anchor
+      const before = await timeoutService.getTransactionStatus(result.transaction_id);
+      expect(before?.status).toBe('pending_anchor');
+
+      // Poll — should detect timeout and mark as error
+      await timeoutService.pollAllTransactions();
+
+      const after = await timeoutService.getTransactionStatus(result.transaction_id);
+      expect(after?.status).toBe('error');
+      expect(timeoutService.getStalledTransactionsTotal()).toBe(1);
+
+      // Restore default
+      process.env.ANCHOR_TIMEOUT_HOURS = '24';
     });
   });
 

--- a/backend/src/sep24-service.ts
+++ b/backend/src/sep24-service.ts
@@ -157,12 +157,25 @@ export class Sep24Service {
   private pool: Pool;
   private anchorConfigs: Map<string, AnchorSep24Config> = new Map();
   private httpClient: AxiosInstance;
+  /** Configurable anchor timeout in hours (default: 24). */
+  private anchorTimeoutHours: number;
+  /** Prometheus counter: number of transactions timed out due to anchor unresponsiveness. */
+  private stalledTransactionsTotal = 0;
+  /** Optional webhook URL to notify on anchor timeout. */
+  private timeoutWebhookUrl?: string;
 
   constructor(pool: Pool) {
     this.pool = pool;
+    this.anchorTimeoutHours = parseFloat(process.env.ANCHOR_TIMEOUT_HOURS ?? '24');
+    this.timeoutWebhookUrl = process.env.ANCHOR_TIMEOUT_WEBHOOK_URL;
     this.httpClient = axios.create({
       timeout: 30000, // 30 second timeout for SEP-24 requests
     });
+  }
+
+  /** Return the current stalled_transactions_total counter value (for Prometheus scraping). */
+  getStalledTransactionsTotal(): number {
+    return this.stalledTransactionsTotal;
   }
 
   /**
@@ -334,12 +347,23 @@ export class Sep24Service {
 
     for (const transaction of pendingTransactions) {
       try {
-        // Check for timeout
+        // Check for anchor timeout on pending_anchor status
         const createdAt = transaction.created_at || new Date();
-        const timeSinceCreation = (Date.now() - createdAt.getTime()) / (1000 * 60);
-        
-        if (timeSinceCreation > config.timeout_minutes) {
-          // Mark as expired
+        const ageHours = (Date.now() - (createdAt instanceof Date ? createdAt : new Date(createdAt as string)).getTime()) / (1000 * 60 * 60);
+
+        if (transaction.status === 'pending_anchor' && ageHours > this.anchorTimeoutHours) {
+          await updateSep24TransactionStatus(transaction.transaction_id, 'error');
+          this.stalledTransactionsTotal++;
+          console.warn(
+            `Transaction ${transaction.transaction_id} timed out after ${ageHours.toFixed(1)}h in pending_anchor`
+          );
+          await this.notifyAnchorTimeout(transaction as Sep24TransactionRecord);
+          continue;
+        }
+
+        // Legacy timeout path (non-pending_anchor statuses)
+        const timeSinceCreationMinutes = ageHours * 60;
+        if (timeSinceCreationMinutes > config.timeout_minutes) {
           await updateSep24TransactionStatus(transaction.transaction_id, 'expired');
           console.log(`Transaction ${transaction.transaction_id} marked as expired`);
           continue;
@@ -379,6 +403,35 @@ export class Sep24Service {
       } catch (error) {
         console.error(`Failed to poll transaction ${transaction.transaction_id}:`, error);
       }
+    }
+  }
+
+  /**
+   * Send a webhook notification when a transaction times out in pending_anchor status.
+   */
+  private async notifyAnchorTimeout(transaction: Sep24TransactionRecord): Promise<void> {
+    const webhookUrl = this.timeoutWebhookUrl;
+    if (!webhookUrl) return;
+
+    const payload = {
+      event: 'sep24.anchor_timeout',
+      transaction_id: transaction.transaction_id,
+      anchor_id: transaction.anchor_id,
+      user_id: transaction.user_id,
+      asset_code: transaction.asset_code,
+      amount: transaction.amount,
+      created_at: transaction.created_at,
+      timeout_hours: this.anchorTimeoutHours,
+    };
+
+    try {
+      await this.httpClient.post(webhookUrl, payload, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 10_000,
+      });
+      console.log(`Anchor timeout webhook sent for transaction ${transaction.transaction_id}`);
+    } catch (error) {
+      console.error(`Failed to send anchor timeout webhook for ${transaction.transaction_id}:`, error);
     }
   }
 


### PR DESCRIPTION
Closes #433

## Changes

- `ANCHOR_TIMEOUT_HOURS` env var (default: 24) — configurable timeout window
- Transactions stuck in `pending_anchor` beyond the threshold are transitioned to `error`
- `stalledTransactionsTotal` counter incremented on each timeout, exposed via `getStalledTransactionsTotal()` for Prometheus scraping
- `notifyAnchorTimeout` POSTs a `sep24.anchor_timeout` webhook to `ANCHOR_TIMEOUT_WEBHOOK_URL` when configured
- Both env vars documented in `backend/.env.example`

## Tests
1 new test: sets `ANCHOR_TIMEOUT_HOURS=0`, initiates a transaction, polls, asserts status is `error` and counter is 1