### PR TITLE
fix: include integrator_fee in FeeBreakdown validation

### DIFF
--- a/ISSUE_560_FIX_SUMMARY.md
+++ b/ISSUE_560_FIX_SUMMARY.md
@@ -1,0 +1,84 @@
+# Issue #560 Fix Summary: FeeBreakdown Integrator Fee Validation
+
+## Problem
+`FeeBreakdown::validate()` was checking that `platform_fee + protocol_fee + net_amount == amount` but did not account for the `integrator_fee` field when present, causing validation to fail for integrator-fee transactions.
+
+## Solution
+Updated the `FeeBreakdown` struct and its validation logic to properly handle integrator fees.
+
+### Changes Made
+
+#### 1. **FeeBreakdown Struct** (`src/fee_service.rs`)
+- Added `integrator_fee: i128` field to the struct
+- Updated documentation to reflect the new field in the net_amount calculation
+
+```rust
+pub struct FeeBreakdown {
+    pub amount: i128,
+    pub platform_fee: i128,
+    pub protocol_fee: i128,
+    pub integrator_fee: i128,  // NEW
+    pub net_amount: i128,
+    pub corridor: Option<String>,
+}
+```
+
+#### 2. **Validation Logic** (`src/fee_service.rs`)
+- Updated `validate()` method to include `integrator_fee` in the sum check
+- Updated documentation to reflect the new validation formula: `amount = platform_fee + protocol_fee + integrator_fee + net_amount`
+- Added `integrator_fee` to the negative value check
+
+```rust
+pub fn validate(&self) -> Result<(), ContractError> {
+    let total = self
+        .platform_fee
+        .checked_add(self.protocol_fee)
+        .and_then(|sum| sum.checked_add(self.integrator_fee))  // NEW
+        .and_then(|sum| sum.checked_add(self.net_amount))
+        .ok_or(ContractError::Overflow)?;
+
+    if total != self.amount {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    // Ensure no negative values
+    if self.amount < 0 || self.platform_fee < 0 || self.protocol_fee < 0 
+        || self.integrator_fee < 0 || self.net_amount < 0  // NEW
+    {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    Ok(())
+}
+```
+
+#### 3. **Test Coverage** (`src/fee_service.rs`)
+Added three dedicated tests for integrator fee validation:
+
+- `test_fee_breakdown_with_integrator_fee()` - Validates correct breakdown with integrator fee
+- `test_fee_breakdown_integrator_fee_mismatch()` - Ensures validation fails when math doesn't add up
+- `test_fee_breakdown_negative_integrator_fee()` - Ensures validation rejects negative integrator fees
+
+#### 4. **Updated All FeeBreakdown Constructions**
+Updated all places where `FeeBreakdown` is constructed to include the `integrator_fee` field:
+
+- `src/fee_service.rs` - 2 occurrences in `calculate_fees_with_breakdown()` and `calculate_fees_with_breakdown_for_sender()`
+- `src/fee_service.rs` - 3 test occurrences
+- `src/test_coverage_gaps.rs` - 4 test occurrences
+- `src/fee_calculation_standalone_tests.rs` - Updated struct definition and 2 test occurrences
+- `src/fee_service_property_tests.rs` - 2 test occurrences
+- `src/test_fee_property.rs` - 1 test occurrence
+
+All new constructions set `integrator_fee: 0` by default, maintaining backward compatibility.
+
+## Impact
+- **High** - Fixes validation logic for integrator-fee transactions
+- **Backward Compatible** - Existing code continues to work with `integrator_fee: 0`
+- **Test Coverage** - Added comprehensive tests for integrator fee scenarios
+
+## Validation
+The fix ensures that:
+1. Integrator fee transactions are properly validated
+2. The mathematical consistency check includes all fee components
+3. Negative integrator fees are rejected
+4. All existing tests continue to pass with the new field

--- a/src/fee_calculation_standalone_tests.rs
+++ b/src/fee_calculation_standalone_tests.rs
@@ -95,6 +95,7 @@ mod standalone_property_tests {
         amount: i128,
         platform_fee: i128,
         protocol_fee: i128,
+        integrator_fee: i128,
         net_amount: i128,
     }
 
@@ -102,6 +103,7 @@ mod standalone_property_tests {
         fn validate(&self) -> Result<(), &'static str> {
             let total = self.platform_fee
                 .checked_add(self.protocol_fee)
+                .and_then(|sum| sum.checked_add(self.integrator_fee))
                 .and_then(|sum| sum.checked_add(self.net_amount))
                 .ok_or("Overflow in validation")?;
             
@@ -109,7 +111,7 @@ mod standalone_property_tests {
                 return Err("Breakdown inconsistent");
             }
             
-            if self.amount < 0 || self.platform_fee < 0 || self.protocol_fee < 0 || self.net_amount < 0 {
+            if self.amount < 0 || self.platform_fee < 0 || self.protocol_fee < 0 || self.integrator_fee < 0 || self.net_amount < 0 {
                 return Err("Negative values");
             }
             
@@ -138,6 +140,7 @@ mod standalone_property_tests {
             amount,
             platform_fee,
             protocol_fee,
+            integrator_fee: 0,
             net_amount,
         };
         
@@ -475,6 +478,7 @@ mod standalone_property_tests {
             amount: 1000,
             platform_fee: 25,
             protocol_fee: 5,
+            integrator_fee: 0,
             net_amount: 970,
         };
         assert!(breakdown.validate().is_ok());
@@ -483,6 +487,7 @@ mod standalone_property_tests {
             amount: 1000,
             platform_fee: 25,
             protocol_fee: 5,
+            integrator_fee: 0,
             net_amount: 900, // Wrong!
         };
         assert!(invalid_breakdown.validate().is_err());

--- a/src/fee_service.rs
+++ b/src/fee_service.rs
@@ -32,7 +32,9 @@ pub struct FeeBreakdown {
     pub platform_fee: i128,
     /// Protocol fee for treasury
     pub protocol_fee: i128,
-    /// Net amount after all fees (amount - platform_fee - protocol_fee)
+    /// Integrator fee (if applicable)
+    pub integrator_fee: i128,
+    /// Net amount after all fees (amount - platform_fee - protocol_fee - integrator_fee)
     pub net_amount: i128,
     /// Optional corridor identifier (from_country-to_country)
     pub corridor: Option<String>,
@@ -41,7 +43,7 @@ pub struct FeeBreakdown {
 impl FeeBreakdown {
     /// Validates that the fee breakdown is mathematically consistent
     ///
-    /// Ensures: amount = platform_fee + protocol_fee + net_amount
+    /// Ensures: amount = platform_fee + protocol_fee + integrator_fee + net_amount
     ///
     /// # Returns
     ///
@@ -51,6 +53,7 @@ impl FeeBreakdown {
         let total = self
             .platform_fee
             .checked_add(self.protocol_fee)
+            .and_then(|sum| sum.checked_add(self.integrator_fee))
             .and_then(|sum| sum.checked_add(self.net_amount))
             .ok_or(ContractError::Overflow)?;
 
@@ -59,7 +62,7 @@ impl FeeBreakdown {
         }
 
         // Ensure no negative values
-        if self.amount < 0 || self.platform_fee < 0 || self.protocol_fee < 0 || self.net_amount < 0
+        if self.amount < 0 || self.platform_fee < 0 || self.protocol_fee < 0 || self.integrator_fee < 0 || self.net_amount < 0
         {
             return Err(ContractError::InvalidAmount);
         }
@@ -198,6 +201,7 @@ pub fn calculate_fees_with_breakdown(
         amount,
         platform_fee,
         protocol_fee,
+        integrator_fee: 0,
         net_amount,
         corridor: corridor_id,
     };
@@ -254,6 +258,7 @@ pub fn calculate_fees_with_breakdown_for_sender(
         amount,
         platform_fee,
         protocol_fee,
+        integrator_fee: 0,
         net_amount,
         corridor: corridor_id,
     };
@@ -527,6 +532,7 @@ mod tests {
             amount: 1000,
             platform_fee: 25,
             protocol_fee: 5,
+            integrator_fee: 0,
             net_amount: 970,
             corridor: None,
         };
@@ -540,6 +546,7 @@ mod tests {
             amount: 1000,
             platform_fee: 25,
             protocol_fee: 5,
+            integrator_fee: 0,
             net_amount: 900, // Wrong! Should be 970
             corridor: None,
         };
@@ -553,6 +560,7 @@ mod tests {
             amount: 1000,
             platform_fee: -25,
             protocol_fee: 5,
+            integrator_fee: 0,
             net_amount: 1020,
             corridor: None,
         };
@@ -588,5 +596,47 @@ mod tests {
 
         let corridor_id = format_corridor_id(&env, &from, &to);
         assert_eq!(corridor_id, String::from_str(&env, "GB-NG"));
+    }
+
+    #[test]
+    fn test_fee_breakdown_with_integrator_fee() {
+        let breakdown = FeeBreakdown {
+            amount: 1000,
+            platform_fee: 25,
+            protocol_fee: 5,
+            integrator_fee: 10,
+            net_amount: 960,
+            corridor: None,
+        };
+
+        assert!(breakdown.validate().is_ok());
+    }
+
+    #[test]
+    fn test_fee_breakdown_integrator_fee_mismatch() {
+        let breakdown = FeeBreakdown {
+            amount: 1000,
+            platform_fee: 25,
+            protocol_fee: 5,
+            integrator_fee: 10,
+            net_amount: 970, // Wrong! Should be 960 (1000 - 25 - 5 - 10)
+            corridor: None,
+        };
+
+        assert!(breakdown.validate().is_err());
+    }
+
+    #[test]
+    fn test_fee_breakdown_negative_integrator_fee() {
+        let breakdown = FeeBreakdown {
+            amount: 1000,
+            platform_fee: 25,
+            protocol_fee: 5,
+            integrator_fee: -10,
+            net_amount: 980,
+            corridor: None,
+        };
+
+        assert!(breakdown.validate().is_err());
     }
 }

--- a/src/fee_service_property_tests.rs
+++ b/src/fee_service_property_tests.rs
@@ -218,6 +218,7 @@ mod property_tests {
                 amount,
                 platform_fee: (amount * platform_fee_bps as i128 / FEE_DIVISOR).max(MIN_FEE),
                 protocol_fee: amount * protocol_fee_bps as i128 / FEE_DIVISOR,
+                integrator_fee: 0,
                 net_amount: 0, // Will be calculated
                 corridor: None,
             };
@@ -312,6 +313,7 @@ mod property_tests {
                 amount,
                 platform_fee,
                 protocol_fee,
+                integrator_fee: 0,
                 net_amount,
                 corridor: None,
             };

--- a/src/test_coverage_gaps.rs
+++ b/src/test_coverage_gaps.rs
@@ -264,6 +264,7 @@ fn test_fee_breakdown_validate_ok() {
         amount: 1_000,
         platform_fee: 25,
         protocol_fee: 0,
+        integrator_fee: 0,
         net_amount: 975,
         corridor: None,
     };
@@ -278,6 +279,7 @@ fn test_fee_breakdown_validate_mismatch() {
         amount: 1_000,
         platform_fee: 25,
         protocol_fee: 0,
+        integrator_fee: 0,
         net_amount: 900, // wrong — doesn't sum to 1000
         corridor: None,
     };
@@ -292,6 +294,7 @@ fn test_fee_breakdown_validate_negative_amount() {
         amount: -1,
         platform_fee: 0,
         protocol_fee: 0,
+        integrator_fee: 0,
         net_amount: -1,
         corridor: None,
     };
@@ -306,6 +309,7 @@ fn test_fee_breakdown_validate_negative_fee() {
         amount: 1_000,
         platform_fee: -25,
         protocol_fee: 0,
+        integrator_fee: 0,
         net_amount: 1_025,
         corridor: None,
     };

--- a/src/test_fee_property.rs
+++ b/src/test_fee_property.rs
@@ -208,6 +208,7 @@ proptest! {
                         amount,
                         platform_fee: fee,
                         protocol_fee,
+                        integrator_fee: 0,
                         net_amount: net,
                         corridor: None,
                     };


### PR DESCRIPTION
 ## Summary

I've successfully fixed issue #560. The problem was that FeeBreakdown::validate() didn't account for the integrator_fee field when validating the fee 
breakdown.

Changes made:

1. Added integrator_fee field to the FeeBreakdown struct
2. Updated validation logic to include integrator fees in the sum check: amount = platform_fee + protocol_fee + integrator_fee + net_amount
3. Added negative value check for the integrator fee
4. Updated all FeeBreakdown constructions across 6 files to include the new field (set to 0 by default for backward compatibility)
5. Added 3 dedicated tests for integrator fee validation scenarios:
   - Valid breakdown with integrator fee
   - Mismatch detection when math doesn't add up
   - Rejection of negative integrator fees

The fix is minimal, focused, and maintains backward compatibility while properly handling integrator-fee transactions.
Closes #560 