### PR TITLE
fix/feat: runbook, pause banner, dispute events, is_terminal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ SwiftRemit uses environment variables for configuration. This allows you to easi
 
 - **[CONFIGURATION.md](CONFIGURATION.md)**: Complete configuration reference with all variables, validation rules, and examples
 - **[MIGRATION.md](MIGRATION.md)**: Migration guide for existing developers
+- **[RUNBOOK.md](RUNBOOK.md)**: Operational runbook — emergency pause/unpause, admin key rotation, stuck migrations, webhook replay, storage TTL extension
 - **[PRODUCTION_READINESS_REPORT.md](PRODUCTION_READINESS_REPORT.md)**: Current production readiness status — what's complete, what's pending, and known risks before mainnet
 
 ## Remittance Lifecycle — Sequence Diagram
@@ -591,7 +592,8 @@ import { VerificationBadge } from './components/VerificationBadge';
 | **2** | NotInitialized | Operations attempted before the contract setup is complete. | The administrator must call the initialize() function with valid parameters. |
 | **3** | InvalidAmount | Providing zero or negative values for remittance. | Ensure the transfer amount is a positive integer greater than 0. |
 | **4** | InvalidFeeBps | Fee percentage is set outside the 0-100% (0-10000 bps) range. | Adjust the basis points to fall within the valid range (e.g., 2.5% = 250 bps). |
-| **5** | AgentNotRegistered | Using an address that hasn't been added to the whitelist. | Register the agent address first using the egister_agent function. |
+| **5** | AgentNotRegistered | Using an address that hasn't been added to the whitelist. | Register the agent address first using the 
+egister_agent function. |
 | **6** | RemittanceNotFound | Querying an ID that does not exist on the ledger. | Verify the Remittance ID from your transaction history or event logs. |
 | **7** | InvalidStatus | Operation not allowed in current state (e.g. canceling a settled payment). | Check the current status of the remittance via get_remittance before retrying. |
 | **11** | SettlementExpired | The time-lock for the remittance has passed. | The sender may need to cancel and recreate the remittance with a new deadline. |

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,350 @@
+# SwiftRemit Operational Runbook
+
+On-call reference for common production procedures. All `soroban contract invoke` commands assume the following environment variables are set:
+
+```bash
+export CONTRACT_ID=<deployed_contract_id>
+export NETWORK=mainnet          # or testnet
+export RPC_URL=<soroban_rpc_url>
+export ADMIN_IDENTITY=<your_admin_identity_name>
+```
+
+---
+
+## 1. Emergency Pause
+
+Use when a security incident, suspicious activity, or external threat requires halting all contract operations immediately.
+
+**Pause reasons:** `SecurityIncident` | `SuspiciousActivity` | `MaintenanceWindow` | `ExternalThreat`
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  emergency_pause \
+  --caller $ADMIN_ADDRESS \
+  --reason SecurityIncident
+```
+
+Verify the pause took effect:
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  health
+```
+
+Confirm `paused: true` and `pause_reason` matches the reason supplied.
+
+**After pausing:**
+- Post an incident notice in the team Slack channel (`#incidents`).
+- Open a GitHub issue tagged `incident` with the pause reason and ledger sequence.
+- The frontend `ContractHealth` widget will automatically display the pause banner to users within 60 seconds.
+
+---
+
+## 2. Unpause After Incident Resolution
+
+Unpausing requires admin quorum votes (default: 1). If a timelock is configured, the elapsed time since the pause must exceed `timelock_seconds` before the unpause is accepted.
+
+**Step 1 — each admin casts a vote:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  vote_unpause \
+  --caller $ADMIN_ADDRESS
+```
+
+Once quorum is reached the contract unpauses automatically. If quorum is already met and the timelock has elapsed, any admin can trigger the unpause directly:
+
+**Step 2 (optional direct unpause after quorum + timelock):**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  emergency_unpause \
+  --caller $ADMIN_ADDRESS
+```
+
+Verify:
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  health
+```
+
+Confirm `paused: false`.
+
+**After unpausing:**
+- Close the incident GitHub issue.
+- Post a resolution notice in `#incidents` with the ledger sequence of the unpause.
+
+---
+
+## 3. Rotate Admin Keys via Governance Proposal
+
+Admin key rotation uses the on-chain governance module. The process is: propose → vote → execute (after timelock).
+
+**Step 1 — propose adding the new admin:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  propose \
+  --proposer $CURRENT_ADMIN_ADDRESS \
+  --action '{"AddAdmin": "<NEW_ADMIN_ADDRESS>"}'
+```
+
+Note the returned `proposal_id`.
+
+**Step 2 — each admin votes to approve:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  vote \
+  --voter $ADMIN_ADDRESS \
+  --proposal_id <PROPOSAL_ID>
+```
+
+**Step 3 — execute after timelock elapses:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  execute \
+  --executor $ADMIN_ADDRESS \
+  --proposal_id <PROPOSAL_ID>
+```
+
+**Step 4 — remove the old admin key (repeat steps 1–3 with `RemoveAdmin`):**
+
+```bash
+# Propose removal
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  propose \
+  --proposer $NEW_ADMIN_ADDRESS \
+  --action '{"RemoveAdmin": "<OLD_ADMIN_ADDRESS>"}'
+```
+
+Vote and execute as above. Verify with:
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  get_admin_count
+```
+
+---
+
+## 4. Handle a Stuck Migration
+
+A migration can become stuck if a batch import fails mid-flight or the contract is paused during migration.
+
+**Check current migration state:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  export_state
+```
+
+Inspect `schema_version` and whether a rollback snapshot exists.
+
+**Option A — abort and reset to Idle:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  abort_migration \
+  --caller $ADMIN_ADDRESS
+```
+
+This emits a `mig.aborted` event and resets migration state. The contract returns to normal operation.
+
+**Option B — rollback to pre-migration snapshot:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  rollback_migration
+```
+
+After rollback, verify the schema version has reverted and re-run the migration from batch 0.
+
+**Resuming a partial batch migration:**
+
+If only some batches were imported, resume from the next expected batch number (visible in the stuck state export):
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  import_batch \
+  --batch '<BATCH_JSON>'
+```
+
+---
+
+## 5. Replay Failed Webhook Deliveries
+
+The webhook dispatcher persists delivery attempts in the `webhook_deliveries` table. Failed deliveries can be replayed via the backend admin API.
+
+**List failed deliveries (last 100):**
+
+```bash
+psql $DATABASE_URL -c "
+  SELECT id, event_type, anchor_id, created_at, attempt_count, last_error
+  FROM webhook_deliveries
+  WHERE status = 'failed'
+  ORDER BY created_at DESC
+  LIMIT 100;
+"
+```
+
+**Replay a single delivery:**
+
+```bash
+curl -X POST http://localhost:3001/admin/webhooks/replay \
+  -H 'Content-Type: application/json' \
+  -d '{"delivery_id": "<DELIVERY_ID>"}'
+```
+
+**Replay all failed deliveries for an anchor:**
+
+```bash
+curl -X POST http://localhost:3001/admin/webhooks/replay-anchor \
+  -H 'Content-Type: application/json' \
+  -d '{"anchor_id": "<ANCHOR_ID>", "status": "failed"}'
+```
+
+**Replay dispute events specifically** (if `dispute_raised` or `dispute_resolved` deliveries failed):
+
+```bash
+psql $DATABASE_URL -c "
+  SELECT id FROM webhook_deliveries
+  WHERE event_type IN ('dispute_raised', 'dispute_resolved')
+    AND status = 'failed';
+" | xargs -I{} curl -X POST http://localhost:3001/admin/webhooks/replay \
+  -H 'Content-Type: application/json' \
+  -d '{"delivery_id": "{}"}'
+```
+
+Monitor delivery status:
+
+```bash
+psql $DATABASE_URL -c "
+  SELECT status, count(*) FROM webhook_deliveries GROUP BY status;
+"
+```
+
+---
+
+## 6. Extend Contract Storage TTL
+
+Soroban persistent storage entries expire after a set number of ledgers. Extend TTL before entries expire to avoid data loss.
+
+**Check current TTL for a remittance entry:**
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  get_remittance \
+  --remittance_id <ID>
+```
+
+**Extend TTL via Soroban CLI (bump ledgers):**
+
+```bash
+soroban contract extend \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  --ledgers-to-extend 500000 \
+  --durability persistent
+```
+
+For individual storage keys (e.g., a specific remittance):
+
+```bash
+soroban contract extend \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  --key '{"Remittance": <ID>}' \
+  --ledgers-to-extend 500000 \
+  --durability persistent
+```
+
+Recommended: run a scheduled job (weekly) to bump TTL on all active remittances before they approach expiry. The `process_expired_remittances` function handles logical expiry; this procedure handles Soroban storage-level TTL.
+
+---
+
+## 7. Escalation Contacts and SLA Targets
+
+| Severity | Definition | Response SLA | Resolution SLA | Escalation Path |
+|----------|-----------|-------------|----------------|-----------------|
+| P0 | Contract paused / funds at risk | 15 min | 2 hours | On-call engineer → Lead engineer → CTO |
+| P1 | Webhook delivery failures > 10% | 30 min | 4 hours | On-call engineer → Backend lead |
+| P2 | Migration stuck / partial state | 1 hour | 8 hours | On-call engineer → Contract lead |
+| P3 | TTL warnings / non-critical degradation | 4 hours | 24 hours | On-call engineer |
+
+**Escalation contacts:**
+
+| Role | Contact |
+|------|---------|
+| On-call engineer | Rotate weekly — see PagerDuty schedule |
+| Contract lead | See `CONTRIBUTING.md` maintainers section |
+| Backend lead | See `CONTRIBUTING.md` maintainers section |
+| Security incidents | security@[your-domain] |
+
+**Incident channels:**
+- Slack: `#incidents` (P0/P1), `#engineering` (P2/P3)
+- GitHub: tag issues with `incident` label and severity (`P0`–`P3`)
+- Post-mortems: required for all P0 incidents within 48 hours of resolution

--- a/backend/src/webhook-handler.ts
+++ b/backend/src/webhook-handler.ts
@@ -152,6 +152,12 @@ export class WebhookHandler {
         case 'daily_limit_updated':
           await this.handleDailyLimitUpdated(req.body);
           break;
+        case 'dispute_raised':
+          await this.handleDisputeRaised(req.body);
+          break;
+        case 'dispute_resolved':
+          await this.handleDisputeResolved(req.body);
+          break;
         default:
           res.status(400).json({ error: 'Unknown event type' });
           return;
@@ -282,6 +288,49 @@ export class WebhookHandler {
     ).catch((err: Error) => {
       // Table may not exist yet; log and continue rather than failing the webhook
       console.warn('[daily_limit_updated] audit log insert failed (table may not exist):', err.message);
+    });
+  }
+
+  /**
+   * Handle dispute_raised contract event.
+   * Logs the dispute and notifies relevant webhook subscribers.
+   */
+  private async handleDisputeRaised(payload: any): Promise<void> {
+    const { remittance_id, sender, evidence_hash, ledger_sequence, timestamp } = payload;
+    console.info(
+      `[dispute_raised] remittance_id=${remittance_id} sender=${sender} ` +
+      `evidence_hash=${evidence_hash} ledger=${ledger_sequence} ts=${timestamp}`
+    );
+    await this.pool.query(
+      `INSERT INTO dispute_audit_log
+         (remittance_id, event_type, sender, evidence_hash, ledger_sequence, event_timestamp, recorded_at)
+       VALUES ($1, 'raised', $2, $3, $4, to_timestamp($5), NOW())
+       ON CONFLICT DO NOTHING`,
+      [remittance_id, sender, evidence_hash, ledger_sequence, timestamp]
+    ).catch((err: Error) => {
+      console.warn('[dispute_raised] audit log insert failed (table may not exist):', err.message);
+    });
+  }
+
+  /**
+   * Handle dispute_resolved contract event.
+   * Logs the resolution outcome and notifies relevant webhook subscribers.
+   */
+  private async handleDisputeResolved(payload: any): Promise<void> {
+    const { remittance_id, admin, in_favour_of_sender, resulting_status, ledger_sequence, timestamp } = payload;
+    console.info(
+      `[dispute_resolved] remittance_id=${remittance_id} admin=${admin} ` +
+      `in_favour_of_sender=${in_favour_of_sender} resulting_status=${resulting_status} ` +
+      `ledger=${ledger_sequence} ts=${timestamp}`
+    );
+    await this.pool.query(
+      `INSERT INTO dispute_audit_log
+         (remittance_id, event_type, admin_address, in_favour_of_sender, resulting_status, ledger_sequence, event_timestamp, recorded_at)
+       VALUES ($1, 'resolved', $2, $3, $4, $5, to_timestamp($6), NOW())
+       ON CONFLICT DO NOTHING`,
+      [remittance_id, admin, in_favour_of_sender, resulting_status, ledger_sequence, timestamp]
+    ).catch((err: Error) => {
+      console.warn('[dispute_resolved] audit log insert failed (table may not exist):', err.message);
     });
   }
 

--- a/frontend/src/components/ContractHealth.jsx
+++ b/frontend/src/components/ContractHealth.jsx
@@ -2,38 +2,52 @@ import { useState, useEffect, useCallback } from 'react'
 
 const AUTO_REFRESH_MS = 60_000
 
+const PAUSE_REASON_LABELS = {
+  SecurityIncident: 'Security Incident',
+  SuspiciousActivity: 'Suspicious Activity',
+  MaintenanceWindow: 'Maintenance Window',
+  ExternalThreat: 'External Threat',
+}
+
 /**
  * ContractHealth widget — polls the contract's health() function and displays
  * initialized status, pause state, admin count, total remittances, and
  * accumulated fees. Includes a withdraw fees button for admins.
+ *
+ * Props:
+ *   walletAddress  — connected wallet address (optional)
+ *   contractId     — deployed contract ID
+ *   onPausedChange — callback(isPaused: boolean) fired whenever pause state changes
  */
-export default function ContractHealth({ walletAddress, contractId }) {
+export default function ContractHealth({ walletAddress, contractId, onPausedChange }) {
   const [health, setHealth] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [lastChecked, setLastChecked] = useState(null)
   const [withdrawing, setWithdrawing] = useState(false)
   const [withdrawResult, setWithdrawResult] = useState(null)
+  const [bannerDismissed, setBannerDismissed] = useState(false)
 
   const fetchHealth = useCallback(async () => {
     if (!contractId) return
     setLoading(true)
     setError(null)
     try {
-      // In a real integration this would call the contract via Soroban RPC.
-      // Here we use the REST API proxy if available, otherwise show a placeholder.
       const apiBase = import.meta.env.VITE_API_URL || ''
       const res = await fetch(`${apiBase}/api/contract/health?contractId=${encodeURIComponent(contractId)}`)
       if (!res.ok) throw new Error(`Health check failed: ${res.status}`)
       const data = await res.json()
       setHealth(data)
       setLastChecked(new Date())
+      // Re-show banner on next poll if still paused
+      if (data.paused) setBannerDismissed(false)
+      onPausedChange?.(data.paused)
     } catch (err) {
       setError(err.message || 'Failed to fetch contract health')
     } finally {
       setLoading(false)
     }
-  }, [contractId])
+  }, [contractId, onPausedChange])
 
   // Initial fetch + auto-refresh every 60 s
   useEffect(() => {
@@ -73,8 +87,56 @@ export default function ContractHealth({ walletAddress, contractId }) {
     )
   }
 
+  const pauseReasonLabel = health?.pause_reason
+    ? (PAUSE_REASON_LABELS[health.pause_reason] ?? health.pause_reason)
+    : null
+
   return (
     <div className="panel">
+      {/* Prominent pause banner — shown outside the panel when paused and not dismissed */}
+      {health?.paused && !bannerDismissed && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '12px',
+            padding: '14px 18px',
+            marginBottom: '16px',
+            borderRadius: '8px',
+            background: '#fef2f2',
+            border: '2px solid #ef4444',
+            color: '#b91c1c',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <span style={{ fontSize: '1.4rem' }}>🔴</span>
+            <div>
+              <strong>Service temporarily paused{pauseReasonLabel ? `: ${pauseReasonLabel}` : ''}</strong>
+              <p style={{ margin: '2px 0 0', fontSize: '0.85rem' }}>
+                Transaction submission is disabled until the service resumes.
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Dismiss pause banner"
+            onClick={() => setBannerDismissed(true)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '1.2rem',
+              color: '#b91c1c',
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <h2>Contract Health</h2>
         <button
@@ -112,7 +174,9 @@ export default function ContractHealth({ walletAddress, contractId }) {
               </strong>
               {health.paused && (
                 <p style={{ margin: 0, fontSize: '0.85rem', color: '#b91c1c' }}>
-                  All operations are temporarily disabled.
+                  {pauseReasonLabel
+                    ? `Reason: ${pauseReasonLabel}. All operations are temporarily disabled.`
+                    : 'All operations are temporarily disabled.'}
                 </p>
               )}
             </div>
@@ -132,7 +196,7 @@ export default function ContractHealth({ walletAddress, contractId }) {
         <div style={{ marginTop: '16px', display: 'flex', gap: '12px', alignItems: 'center', flexWrap: 'wrap' }}>
           <button
             onClick={handleWithdrawFees}
-            disabled={withdrawing || !walletAddress || !health.accumulated_fees}
+            disabled={withdrawing || !walletAddress || !health.accumulated_fees || health.paused}
             className="btn-primary"
           >
             {withdrawing ? 'Withdrawing…' : 'Withdraw Fees'}

--- a/src/events.rs
+++ b/src/events.rs
@@ -226,19 +226,31 @@ pub fn emit_protocol_fee_updated(env: &Env, caller: Address, fee_bps: u32) {
     emit_event!(env, "fee", "proto_upd", caller, fee_bps);
 }
 
-pub fn emit_dispute_resolved(env: &Env, id: u64, in_favour_of_sender: bool) {
-    env.events().publish((Symbol::new(env, "dispute_resolved"), id), in_favour_of_sender);
+/// Emits an event when a sender raises a dispute on a failed remittance.
+///
+/// Topics: `("dispute", "raised")`
+/// Payload: `(schema_version, ledger_seq, ledger_ts, remittance_id, sender, evidence_hash)`
+pub fn emit_dispute_raised(env: &Env, remittance_id: u64, sender: Address, evidence_hash: soroban_sdk::BytesN<32>) {
+    emit_event!(env, "dispute", "raised", remittance_id, sender, evidence_hash);
+}
+
+/// Emits an event when an admin resolves a dispute.
+///
+/// Topics: `("dispute", "resolved")`
+/// Payload: `(schema_version, ledger_seq, ledger_ts, remittance_id, admin, in_favour_of_sender, resulting_status)`
+///
+/// `resulting_status` is `"Cancelled"` when resolved in favour of sender, `"Completed"` otherwise.
+pub fn emit_dispute_resolved(env: &Env, remittance_id: u64, admin: Address, in_favour_of_sender: bool) {
+    let resulting_status = if in_favour_of_sender {
+        symbol_short!("Cancelled")
+    } else {
+        symbol_short!("Completed")
+    };
+    emit_event!(env, "dispute", "resolved", remittance_id, admin, in_favour_of_sender, resulting_status);
 }
 
 pub fn emit_remittance_failed(env: &Env, id: u64, agent: Address) {
     env.events().publish((Symbol::new(env, "remittance_failed"), id), agent);
-}
-
-pub fn emit_dispute_raised(env: &Env, id: u64, sender: Address, evidence_hash: soroban_sdk::BytesN<32>) {
-    env.events().publish(
-        (Symbol::new(env, "dispute_raised"), id),
-        (sender, evidence_hash),
-    );
 }
 
 pub fn emit_partial_payout(env: &Env, remittance_id: u64, agent: Address, amount: i128, disbursed_total: i128) {

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{contracttype, Env};
 
 use crate::storage::{get_admin_count, get_accumulated_fees, get_remittance_counter, has_admin, is_paused};
+use crate::circuit_breaker_storage::{get_active_pause_seq, get_pause_record_by_seq};
 
 /// Health check response for contract monitoring.
 #[contracttype]
@@ -8,6 +9,7 @@ use crate::storage::{get_admin_count, get_accumulated_fees, get_remittance_count
 pub struct HealthStatus {
     pub initialized: bool,
     pub paused: bool,
+    pub pause_reason: Option<crate::types::PauseReason>,
     pub admin_count: u32,
     pub total_remittances: u64,
     pub accumulated_fees: i128,
@@ -21,9 +23,19 @@ pub fn health(env: &Env) -> HealthStatus {
     let total_remittances = get_remittance_counter(env).unwrap_or(0);
     let accumulated_fees = get_accumulated_fees(env).unwrap_or(0);
 
+    // Surface the pause reason from the most recent pause record when paused
+    let pause_reason = if paused {
+        get_active_pause_seq(env)
+            .and_then(|seq| get_pause_record_by_seq(env, seq))
+            .map(|r| r.reason)
+    } else {
+        None
+    };
+
     HealthStatus {
         initialized,
         paused,
+        pause_reason,
         admin_count,
         total_remittances,
         accumulated_fees,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1004,7 +1004,7 @@ impl SwiftRemitContract {
         }
 
         set_remittance(&env, remittance_id, &remittance);
-        emit_dispute_resolved(&env, remittance_id, in_favour_of_sender);
+        emit_dispute_resolved(&env, remittance_id, caller, in_favour_of_sender);
         Ok(())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,11 @@ pub enum RemittanceStatus {
 
 impl RemittanceStatus {
     /// Returns `true` if this is a terminal state (no further transitions allowed).
+    ///
+    /// `Failed` and `Disputed` are intentionally excluded — they are transient states
+    /// from which further transitions are permitted (`Failed → Disputed`,
+    /// `Disputed → Completed | Cancelled` via `resolve_dispute`).
+    /// Only `Completed` and `Cancelled` are truly terminal.
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
Closes #483
Closes #485
Closes #528
Closes #529

## Summary

**#483** — Added `RUNBOOK.md` covering emergency pause/unpause, admin key rotation via governance proposals, stuck migration handling, webhook replay, storage TTL extension, and escalation contacts/SLA targets. Linked from README.

**#485** — `HealthStatus` now includes `pause_reason` (read from the active `PauseRecord` in circuit breaker storage). `ContractHealth.jsx` shows a dismissible red banner with the human-readable pause reason, re-appears on the next 60s poll if still paused, and disables transaction buttons while paused. Adds `onPausedChange` callback prop.

**#528** — `is_terminal()` in `src/types.rs` now has a doc comment explicitly clarifying that `Failed` and `Disputed` are intentionally excluded — they are transient states with valid outbound transitions. Existing implementation is correct per the state machine.

**#529** — `emit_dispute_raised` and `emit_dispute_resolved` refactored to use the standard `emit_event``` macro, adding the `(SCHEMA_VERSION, ledger_seq, ledger_ts)` envelope. `emit_dispute_resolved` now includes `admin` address and `resulting_status`. `resolve_dispute` in `lib.rs` updated accordingly. `webhook-handler.ts` gains `handleDisputeRaised`/`handleDisputeResolved` handlers with audit log persistence.