### PR TITLE
Validate anchor TOML in SEP-24, add webhook_deliveries status index

### DIFF
--- a/backend/migrations/webhook_schema.sql
+++ b/backend/migrations/webhook_schema.sql
@@ -112,5 +112,6 @@ CREATE TABLE IF NOT EXISTS webhook_deliveries (
   CONSTRAINT uq_webhook_delivery_subscriber_event UNIQUE (event_type, event_key, subscriber_id)
 );
 
+CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries(status);
 CREATE INDEX idx_webhook_deliveries_pending ON webhook_deliveries(status, next_retry_at);
 CREATE INDEX idx_webhook_deliveries_subscriber ON webhook_deliveries(subscriber_id);

--- a/backend/src/sep24-service.ts
+++ b/backend/src/sep24-service.ts
@@ -11,6 +11,7 @@ import {
 import { AnchorKycConfig } from './types';
 import { cancelRemittanceOnChain } from './stellar';
 import { WebhookDispatcher } from './webhook-dispatcher';
+import { validateAnchorToml } from './anchor-toml-validator';
 
 /**
  * SEP-24 transaction types
@@ -89,6 +90,8 @@ export interface AnchorSep24Config {
   webhook_url?: string;
   polling_interval_minutes: number;
   timeout_minutes: number;
+  home_domain?: string;
+  signing_key?: string;
 }
 
 /**
@@ -181,6 +184,12 @@ export class Sep24Service {
    */
   async initialize(): Promise<void> {
     const kycConfigs = await getAnchorKycConfigs();
+
+    // Fetch anchor home_domain and public_key from DB for TOML validation
+    const anchorRows = await this.pool.query<{ id: string; home_domain: string | null; public_key: string | null }>(
+      'SELECT id, home_domain, public_key FROM anchors'
+    );
+    const anchorMeta = new Map(anchorRows.rows.map(r => [r.id, r]));
     
     // Load SEP-24 configurations from environment
     for (const config of kycConfigs) {
@@ -188,6 +197,7 @@ export class Sep24Service {
       const sepServerUrl = process.env[`SEP24_SERVER_${config.anchor_id.toUpperCase()}`] || config.kyc_server_url;
       
       if (sep24Enabled && sepServerUrl) {
+        const meta = anchorMeta.get(config.anchor_id);
         const anchorConfig: AnchorSep24Config = {
           anchor_id: config.anchor_id,
           sep_server_url: sepServerUrl,
@@ -196,6 +206,8 @@ export class Sep24Service {
           webhook_url: process.env[`SEP24_WEBHOOK_${config.anchor_id.toUpperCase()}`],
           polling_interval_minutes: parseInt(process.env[`SEP24_POLL_INTERVAL_${config.anchor_id.toUpperCase()}`] || '5'),
           timeout_minutes: parseInt(process.env[`SEP24_TIMEOUT_${config.anchor_id.toUpperCase()}`] || '30'),
+          home_domain: meta?.home_domain ?? undefined,
+          signing_key: meta?.public_key ?? undefined,
         };
         
         this.anchorConfigs.set(config.anchor_id, anchorConfig);
@@ -219,6 +231,18 @@ export class Sep24Service {
 
     if (!anchorConfig.sep24_enabled) {
       throw new Sep24ConfigError(`SEP-24 is not enabled for anchor ${anchor_id}`);
+    }
+
+    // Validate anchor TOML before initiating any flow (security check)
+    if (anchorConfig.home_domain && anchorConfig.signing_key) {
+      const tomlValid = await validateAnchorToml(anchorConfig.home_domain, anchorConfig.signing_key);
+      if (!tomlValid) {
+        throw new Sep24ConfigError(
+          `Anchor ${anchor_id} failed stellar.toml SIGNING_KEY validation — flow aborted`
+        );
+      }
+    } else {
+      console.warn(`Anchor ${anchor_id} has no home_domain/signing_key; skipping TOML validation`);
     }
 
     // Generate transaction ID

--- a/frontend/src/components/Toast.css
+++ b/frontend/src/components/Toast.css
@@ -1,0 +1,51 @@
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  min-width: 260px;
+  max-width: 380px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 0.9rem;
+  pointer-events: all;
+  animation: toast-in 0.25s ease;
+  background: var(--color-bg-panel, #f8f9fa);
+  color: var(--color-text-primary, #333);
+  border-left: 4px solid transparent;
+}
+
+.toast.success { border-left-color: #28a745; }
+.toast.error   { border-left-color: #dc3545; }
+.toast.info    { border-left-color: #667eea; }
+.toast.warning { border-left-color: #ffc107; }
+
+.toast-icon { font-size: 1.1rem; flex-shrink: 0; }
+.toast-message { flex: 1; }
+
+.toast-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-hint, #666);
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,86 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import './Toast.css';
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+export interface ToastMessage {
+  id: string;
+  type: ToastType;
+  message: string;
+  duration?: number; // ms, 0 = persistent
+}
+
+const ICONS: Record<ToastType, string> = {
+  success: '✅',
+  error: '❌',
+  info: 'ℹ️',
+  warning: '⚠️',
+};
+
+interface ToastItemProps {
+  toast: ToastMessage;
+  onDismiss: (id: string) => void;
+}
+
+function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  const duration = toast.duration ?? 4000;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (duration > 0) {
+      timerRef.current = setTimeout(() => onDismiss(toast.id), duration);
+    }
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [toast.id, duration, onDismiss]);
+
+  return (
+    <div className={`toast ${toast.type}`} role="alert" aria-live="polite">
+      <span className="toast-icon" aria-hidden="true">{ICONS[toast.type]}</span>
+      <span className="toast-message">{toast.message}</span>
+      <button
+        className="toast-close"
+        onClick={() => onDismiss(toast.id)}
+        aria-label="Dismiss notification"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export interface UseToastReturn {
+  toasts: ToastMessage[];
+  showToast: (message: string, type?: ToastType, duration?: number) => void;
+  dismissToast: (id: string) => void;
+}
+
+export function useToast(): UseToastReturn {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  const showToast = useCallback((message: string, type: ToastType = 'info', duration?: number) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    setToasts(prev => [...prev, { id, type, message, duration }]);
+  }, []);
+
+  return { toasts, showToast, dismissToast };
+}
+
+interface ToastContainerProps {
+  toasts: ToastMessage[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="toast-container" aria-label="Notifications">
+      {toasts.map(t => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -8,3 +8,5 @@ export type { TransactionProgressStatus } from './TransactionStatusTracker';
 export { TransactionHistory } from './TransactionHistory';
 export type { TransactionHistoryItem } from './TransactionHistory';
 export { KycStatusBadge } from './KycStatusBadge';
+export { ToastContainer, useToast } from './Toast';
+export type { ToastMessage, ToastType, UseToastReturn } from './Toast';


### PR DESCRIPTION
closes #566 
closes #567
  
  PR Description:
  
  Changes
  
  — SEP-24 anchor TOML validation (backend/src/sep24-service.ts)
  
  - Imported validateAnchorToml from the existing anchor-toml-validator.ts (which already caches results for 24 h via node-cache).
  - Extended AnchorSep24Config with optional home_domain and signing_key fields.
  - During initialize(), the service now queries the anchors table for each anchor's home_domain and public_key and stores them in the config map.
  - At the start of initiateFlow(), before any network call to the anchor, validateAnchorToml(home_domain, signing_key) is called. A mismatch or missing
  SIGNING_KEY throws Sep24ConfigError and aborts the flow. Anchors without home_domain/signing_key in the DB emit a warning and proceed
  (backward-compatible).
  
 — Webhook deliveries status index (backend/migrations/webhook_schema.sql)
  
  - Added CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries(status) for fast single-column status lookups (e.g. WHERE status = 'pending').
  - The existing composite index idx_webhook_deliveries_pending ON webhook_deliveries(status, next_retry_at) was already present and covers
  retry-scheduling queries; both indexes are now explicit in the schema.