### PR TITLE
Harden wallet sessions and type dispute flow

### DIFF
--- a/backend/src/__tests__/e2e.test.ts
+++ b/backend/src/__tests__/e2e.test.ts
@@ -704,9 +704,27 @@ describe('Dispute resolution flow', () => {
   const TX_ID = 'tx-dispute-001';
   const USER_ID = 'user-dispute';
 
+  function seedCreatedWithdrawal() {
+    seedTransaction({
+      transaction_id: TX_ID,
+      kind: 'withdrawal',
+      status: 'pending_anchor',
+      amount_in: '100.00',
+      amount_out: '97.50',
+      amount_fee: '2.50',
+    });
+  }
+
   // Helper: seed a transaction in Failed state (simulates mark_failed having run)
   function seedFailed() {
-    seedTransaction({ transaction_id: TX_ID, kind: 'withdrawal', status: 'failed' });
+    seedTransaction({
+      transaction_id: TX_ID,
+      kind: 'withdrawal',
+      status: 'failed',
+      amount_in: '100.00',
+      amount_out: '97.50',
+      amount_fee: '2.50',
+    });
   }
 
   // ── mark_failed ─────────────────────────────────────────────────────────────
@@ -761,14 +779,23 @@ describe('Dispute resolution flow', () => {
 
   // ── resolve_dispute — sender wins ───────────────────────────────────────────
 
-  it('admin resolves dispute in favour of sender — sender receives full refund', async () => {
-    seedFailed();
-    // Transition to disputed first
+  it('covers the sender refund lifecycle from creation to dispute resolution', async () => {
+    seedCreatedWithdrawal();
+
+    const failRes = await sendWebhook({
+      event_type: 'withdrawal_update',
+      transaction_id: TX_ID,
+      status: 'error',
+      message: 'Payout failed before dispute',
+    });
+
+    expect(failRes.status).toBe(200);
+    expect(db.tx.get(TX_ID)?.status).toBe('error');
+
+    // Simulate the contract-side raise_dispute transition after the failed payout.
     db.tx.set(TX_ID, {
       ...db.tx.get(TX_ID)!,
       status: 'disputed',
-      amount_in: '100.00',
-      amount_fee: '2.50',
     });
 
     const res = await sendWebhook({
@@ -780,21 +807,31 @@ describe('Dispute resolution flow', () => {
     });
 
     expect(res.status).toBe(200);
-    // After sender-wins resolution the remittance is refunded/cancelled
     const tx = db.tx.get(TX_ID);
     expect(['refunded', 'cancelled', 'resolved_sender']).toContain(tx?.status);
+    expect(tx?.amount_in).toBe('100.00');
+    expect(tx?.amount_fee).toBe('2.50');
   });
 
   // ── resolve_dispute — agent wins ────────────────────────────────────────────
 
-  it('admin resolves dispute in favour of agent — agent receives net amount', async () => {
-    seedFailed();
+  it('covers the agent payout lifecycle from creation to dispute resolution', async () => {
+    seedCreatedWithdrawal();
+
+    const failRes = await sendWebhook({
+      event_type: 'withdrawal_update',
+      transaction_id: TX_ID,
+      status: 'error',
+      message: 'Payout failed before dispute',
+    });
+
+    expect(failRes.status).toBe(200);
+    expect(db.tx.get(TX_ID)?.status).toBe('error');
+
+    // Simulate the contract-side raise_dispute transition after the failed payout.
     db.tx.set(TX_ID, {
       ...db.tx.get(TX_ID)!,
       status: 'disputed',
-      amount_in: '100.00',
-      amount_out: '97.50',
-      amount_fee: '2.50',
     });
 
     const res = await sendWebhook({
@@ -808,6 +845,8 @@ describe('Dispute resolution flow', () => {
     expect(res.status).toBe(200);
     const tx = db.tx.get(TX_ID);
     expect(['completed', 'resolved_agent']).toContain(tx?.status);
+    expect(tx?.amount_out).toBe('97.50');
+    expect(tx?.amount_fee).toBe('2.50');
   });
 
   // ── non-admin resolve attempt ────────────────────────────────────────────────

--- a/frontend/src/components/DisputeResolution.tsx
+++ b/frontend/src/components/DisputeResolution.tsx
@@ -1,16 +1,82 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
-export default function DisputeResolution() {
-  const [disputes, setDisputes] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [auditLog, setAuditLog] = useState([]);
-  const [resolving, setResolving] = useState(null); // { id, favour }
-  const [confirmOpen, setConfirmOpen] = useState(null); // { id, inFavourOfSender }
+interface DisputeItem {
+  id: string | number;
+  sender: string;
+  agent: string;
+  amount: string | number;
+  created_at?: string | null;
+  evidence_hash?: string | null;
+}
 
-  useEffect(() => { fetchDisputes(); fetchAuditLog(); }, []);
+interface AuditLogItem {
+  remittance_id: string | number;
+  resolved_at?: string | null;
+  in_favour_of_sender: boolean;
+  resolved_by?: string | null;
+}
+
+interface ConfirmState {
+  id: string | number;
+  inFavourOfSender: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isDisputeItem(value: unknown): value is DisputeItem {
+  return (
+    isRecord(value) &&
+    (typeof value.id === 'string' || typeof value.id === 'number') &&
+    typeof value.sender === 'string' &&
+    typeof value.agent === 'string' &&
+    (typeof value.amount === 'string' || typeof value.amount === 'number') &&
+    (value.created_at === undefined || value.created_at === null || typeof value.created_at === 'string') &&
+    (value.evidence_hash === undefined || value.evidence_hash === null || typeof value.evidence_hash === 'string')
+  );
+}
+
+function isAuditLogItem(value: unknown): value is AuditLogItem {
+  return (
+    isRecord(value) &&
+    (typeof value.remittance_id === 'string' || typeof value.remittance_id === 'number') &&
+    typeof value.in_favour_of_sender === 'boolean' &&
+    (value.resolved_at === undefined || value.resolved_at === null || typeof value.resolved_at === 'string') &&
+    (value.resolved_by === undefined || value.resolved_by === null || typeof value.resolved_by === 'string')
+  );
+}
+
+function parseDisputesResponse(value: unknown): DisputeItem[] {
+  if (!Array.isArray(value) || !value.every(isDisputeItem)) {
+    throw new Error('Invalid disputes response');
+  }
+
+  return value;
+}
+
+function parseAuditLogResponse(value: unknown): AuditLogItem[] {
+  if (!Array.isArray(value) || !value.every(isAuditLogItem)) {
+    throw new Error('Invalid dispute audit response');
+  }
+
+  return value;
+}
+
+export default function DisputeResolution() {
+  const [disputes, setDisputes] = useState<DisputeItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [auditLog, setAuditLog] = useState<AuditLogItem[]>([]);
+  const [resolving, setResolving] = useState<string | number | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState<ConfirmState | null>(null);
+
+  useEffect(() => {
+    void fetchDisputes();
+    void fetchAuditLog();
+  }, []);
 
   async function fetchDisputes() {
     setLoading(true);
@@ -18,9 +84,10 @@ export default function DisputeResolution() {
     try {
       const res = await fetch(`${API_URL}/api/remittances?status=Disputed`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDisputes(await res.json());
-    } catch (e) {
-      setError(e.message);
+      const data: unknown = await res.json();
+      setDisputes(parseDisputesResponse(data));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
       setDisputes([]);
     } finally {
       setLoading(false);
@@ -30,17 +97,27 @@ export default function DisputeResolution() {
   async function fetchAuditLog() {
     try {
       const res = await fetch(`${API_URL}/api/disputes/audit`);
-      if (res.ok) setAuditLog(await res.json());
+      if (!res.ok) {
+        return;
+      }
+
+      const data: unknown = await res.json();
+      setAuditLog(parseAuditLogResponse(data));
     } catch {
+      setAuditLog([]);
       // audit log is non-critical
     }
   }
 
-  function openConfirm(id, inFavourOfSender) {
+  function openConfirm(id: string | number, inFavourOfSender: boolean) {
     setConfirmOpen({ id, inFavourOfSender });
   }
 
   async function confirmResolve() {
+    if (!confirmOpen) {
+      return;
+    }
+
     const { id, inFavourOfSender } = confirmOpen;
     setConfirmOpen(null);
     setResolving(id);
@@ -54,8 +131,8 @@ export default function DisputeResolution() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       await fetchDisputes();
       await fetchAuditLog();
-    } catch (e) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setResolving(null);
     }
@@ -67,7 +144,6 @@ export default function DisputeResolution() {
 
       {error && <div className="error" role="alert">{error}</div>}
 
-      {/* Confirmation dialog */}
       {confirmOpen && (
         <div
           role="dialog"
@@ -103,7 +179,7 @@ export default function DisputeResolution() {
           <p>No disputed remittances.</p>
         ) : (
           <ul style={{ listStyle: 'none', padding: 0 }}>
-            {disputes.map(d => (
+            {disputes.map((d) => (
               <li
                 key={d.id}
                 style={{ border: '1px solid #fed7d7', borderRadius: '8px', padding: '16px', marginBottom: '12px', background: '#fff5f5' }}
@@ -167,8 +243,11 @@ export default function DisputeResolution() {
               </tr>
             </thead>
             <tbody>
-              {auditLog.map((entry, i) => (
-                <tr key={i} style={{ borderBottom: '1px solid #e2e8f0' }}>
+              {auditLog.map((entry) => (
+                <tr
+                  key={`${entry.remittance_id}-${entry.resolved_at ?? 'pending'}-${entry.resolved_by ?? 'unknown'}`}
+                  style={{ borderBottom: '1px solid #e2e8f0' }}
+                >
                   <td style={{ padding: '6px' }}>#{entry.remittance_id}</td>
                   <td style={{ padding: '6px' }}>{entry.resolved_at ? new Date(entry.resolved_at).toLocaleString() : '—'}</td>
                   <td style={{ padding: '6px' }}>{entry.in_favour_of_sender ? 'Sender' : 'Agent'}</td>

--- a/frontend/src/components/WalletConnection.tsx
+++ b/frontend/src/components/WalletConnection.tsx
@@ -7,6 +7,12 @@ import type { NetworkType } from '../utils/freighter';
 export type { NetworkType };
 
 const STORAGE_KEY = 'swiftremit_wallet_address';
+const DEFAULT_STORAGE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface StoredWalletSession {
+  publicKey: string;
+  storedAt: number;
+}
 
 interface WalletConnectionResult {
   publicKey: string;
@@ -15,9 +21,34 @@ interface WalletConnectionResult {
 
 interface WalletConnectionProps {
   defaultNetwork?: NetworkType;
+  storageTtlMs?: number;
   onConnect?: () => Promise<WalletConnectionResult>;
   onDisconnect?: () => Promise<void> | void;
   onRequestSignature?: () => Promise<void>;
+}
+
+function parseStoredWalletSession(raw: string | null, storageTtlMs: number): StoredWalletSession | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredWalletSession>;
+    if (typeof parsed.publicKey !== 'string' || typeof parsed.storedAt !== 'number') {
+      return null;
+    }
+
+    if (Date.now() - parsed.storedAt > storageTtlMs) {
+      return null;
+    }
+
+    return {
+      publicKey: parsed.publicKey,
+      storedAt: parsed.storedAt,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function truncatePublicKey(publicKey: string): string {
@@ -43,6 +74,7 @@ function isRejectedSignature(error: unknown): boolean {
 
 export const WalletConnection: React.FC<WalletConnectionProps> = ({
   defaultNetwork = 'Testnet',
+  storageTtlMs = DEFAULT_STORAGE_TTL_MS,
   onConnect,
   onDisconnect,
   onRequestSignature,
@@ -63,12 +95,15 @@ export const WalletConnection: React.FC<WalletConnectionProps> = ({
 
   // Restore session from localStorage on mount
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (!stored) return;
+    const stored = parseStoredWalletSession(localStorage.getItem(STORAGE_KEY), storageTtlMs);
+    if (!stored) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
 
     FreighterService.connect()
       .then((result) => {
-        if (result.publicKey === stored) {
+        if (result.publicKey === stored.publicKey) {
           setPublicKey(result.publicKey);
           setNetwork(result.network ?? defaultNetwork);
           setConnected(true);
@@ -88,7 +123,7 @@ export const WalletConnection: React.FC<WalletConnectionProps> = ({
         localStorage.removeItem(STORAGE_KEY);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [defaultNetwork, storageTtlMs, t]);
 
   const handleConnect = async () => {
     setError(null);
@@ -105,7 +140,13 @@ export const WalletConnection: React.FC<WalletConnectionProps> = ({
       setNetwork(connectedNetwork);
       setConnected(true);
 
-      localStorage.setItem(STORAGE_KEY, result.publicKey);
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          publicKey: result.publicKey,
+          storedAt: Date.now(),
+        } satisfies StoredWalletSession)
+      );
 
       if (FreighterService.isNetworkMismatch(connectedNetwork, defaultNetwork)) {
         setNetworkWarning(

--- a/frontend/src/components/__tests__/WalletConnection.test.tsx
+++ b/frontend/src/components/__tests__/WalletConnection.test.tsx
@@ -11,11 +11,13 @@ vi.mock('@stellar/freighter-api', () => ({
 }));
 
 const MOCK_PUBLIC_KEY = 'GBZXN7PIRZGNMHGAU2LYGAZGQG4RYSQ3TB2T6O3COVGW6OLBDEQ2COFQ';
+const STORAGE_KEY = 'swiftremit_wallet_address';
 
 describe('WalletConnection', () => {
   beforeEach(() => {
     // Reset all mocks before each test
     vi.clearAllMocks();
+    localStorage.clear();
     
     // Default: Freighter is installed
     window.freighter = {
@@ -91,6 +93,10 @@ describe('WalletConnection', () => {
       await waitFor(() => {
         expect(screen.getByText(/GBZXN7...Q2COFQ/)).toBeInTheDocument();
         expect(screen.getByText(/connected public key/i)).toBeInTheDocument();
+      });
+
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toMatchObject({
+        publicKey: MOCK_PUBLIC_KEY,
       });
     });
 
@@ -308,12 +314,16 @@ describe('WalletConnection', () => {
         expect(screen.getByText(/GBZXN7...Q2COFQ/)).toBeInTheDocument();
       });
 
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
       fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
 
       await waitFor(() => {
         expect(screen.getByText(/not connected/i)).toBeInTheDocument();
         expect(screen.queryByText(/GBZXN7...Q2COFQ/)).not.toBeInTheDocument();
       });
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
 
     it('shows disconnecting state', async () => {
@@ -488,6 +498,45 @@ describe('WalletConnection', () => {
       await waitFor(() => {
         expect(screen.getByText('SHORTKEY')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('session persistence', () => {
+    it('restores a fresh stored session', async () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          publicKey: MOCK_PUBLIC_KEY,
+          storedAt: Date.now(),
+        })
+      );
+      vi.mocked(freighterApi.isConnected).mockResolvedValue({ isConnected: true });
+      vi.mocked(freighterApi.getAddress).mockResolvedValue({ address: MOCK_PUBLIC_KEY });
+      vi.mocked(freighterApi.getNetwork).mockResolvedValue({ network: 'TESTNET', networkPassphrase: 'Test SDF Network ; September 2015' });
+
+      render(<WalletConnection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('GBZXN7...Q2COFQ')).toBeInTheDocument();
+      });
+    });
+
+    it('drops expired stored sessions before reconnecting', async () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          publicKey: MOCK_PUBLIC_KEY,
+          storedAt: Date.now() - 10_000,
+        })
+      );
+
+      render(<WalletConnection storageTtlMs={1_000} />);
+
+      await waitFor(() => {
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      });
+      expect(screen.getByText(/not connected/i)).toBeInTheDocument();
+      expect(freighterApi.isConnected).not.toHaveBeenCalled();
     });
   });
 });

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -38,6 +38,23 @@ import {
 /** Maximum number of entries allowed in a single batch remittance call. */
 export const MAX_BATCH_SIZE = 50;
 
+function shouldAllowHttp(rpcUrl: string): boolean {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(rpcUrl);
+  } catch {
+    return false;
+  }
+
+  if (parsedUrl.protocol !== "http:") {
+    return false;
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
 export class SwiftRemitClient {
   private readonly contract: Contract;
   private readonly server: SorobanRpc.Server;
@@ -49,7 +66,13 @@ export class SwiftRemitClient {
 
   constructor(options: SwiftRemitClientOptions) {
     this.contract = new Contract(options.contractId);
-    this.server = new SorobanRpc.Server(options.rpcUrl, { allowHttp: true });
+    const allowHttp = shouldAllowHttp(options.rpcUrl);
+    this.server = new SorobanRpc.Server(options.rpcUrl, { allowHttp });
+    if (allowHttp) {
+      console.warn(
+        `[SwiftRemitClient] Using insecure HTTP RPC connection for ${options.rpcUrl}. Restrict this to local or test environments.`
+      );
+    }
     this.networkPassphrase = options.networkPassphrase;
     this.fee = options.fee ?? BASE_FEE;
     this.retries = options.retries ?? 3;

--- a/sdk/src/events.test.ts
+++ b/sdk/src/events.test.ts
@@ -4,6 +4,7 @@ import { xdr, scValToNative } from "@stellar/stellar-sdk";
 
 // Minimal mock of SorobanRpc.Server
 const mockGetEvents = vi.fn();
+const mockServerConstructor = vi.fn();
 
 vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
@@ -12,6 +13,9 @@ vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
     SorobanRpc: {
       ...actual.SorobanRpc,
       Server: class {
+        constructor(...args: unknown[]) {
+          mockServerConstructor(...args);
+        }
         getEvents = mockGetEvents;
         getAccount = vi.fn();
         simulateTransaction = vi.fn();
@@ -48,6 +52,32 @@ describe("subscribeToRemittanceEvents", () => {
       networkPassphrase: "Test SDF Network ; September 2015",
       rpcUrl: "https://soroban-testnet.stellar.org",
     });
+  });
+
+  it("disables allowHttp for non-local HTTPS endpoints", () => {
+    expect(mockServerConstructor).toHaveBeenCalledWith(
+      "https://soroban-testnet.stellar.org",
+      { allowHttp: false }
+    );
+  });
+
+  it("allows localhost HTTP endpoints and warns once", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    new SwiftRemitClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "http://localhost:8000",
+    });
+
+    expect(mockServerConstructor).toHaveBeenLastCalledWith(
+      "http://localhost:8000",
+      { allowHttp: true }
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Using insecure HTTP RPC connection")
+    );
+    warnSpy.mockRestore();
   });
 
   it("returns an unsubscribe function", () => {

--- a/src/test_dispute.rs
+++ b/src/test_dispute.rs
@@ -112,10 +112,17 @@ fn test_mark_failed_transitions_to_failed() {
     contract.register_agent(&agent);
 
     let id = contract.create_remittance(&sender, &agent, &1_000i128, &None);
+    let sender_before = balance(&env, &token, &sender);
+    let agent_before = balance(&env, &token, &agent);
+    let contract_before = balance(&env, &token, &contract.address);
+
     contract.mark_failed(&id);
 
     let r = contract.get_remittance(&id);
     assert_eq!(r.status, crate::types::RemittanceStatus::Failed);
+    assert_eq!(balance(&env, &token, &sender), sender_before);
+    assert_eq!(balance(&env, &token, &agent), agent_before);
+    assert_eq!(balance(&env, &token, &contract.address), contract_before);
 }
 
 #[test]
@@ -149,11 +156,17 @@ fn test_mark_failed_on_completed_remittance_rejected() {
 fn test_raise_dispute_transitions_to_disputed() {
     let f = setup_failed_remittance();
     let hash = evidence_hash(&f.env);
+    let sender_before = balance(&f.env, &f.token, &f.sender);
+    let agent_before = balance(&f.env, &f.token, &f.agent);
+    let contract_before = balance(&f.env, &f.token, &f.contract.address);
 
     f.contract.raise_dispute(&f.remittance_id, &hash);
 
     let r = f.contract.get_remittance(&f.remittance_id);
     assert_eq!(r.status, crate::types::RemittanceStatus::Disputed);
+    assert_eq!(balance(&f.env, &f.token, &f.sender), sender_before);
+    assert_eq!(balance(&f.env, &f.token, &f.agent), agent_before);
+    assert_eq!(balance(&f.env, &f.token, &f.contract.address), contract_before);
 }
 
 #[test]
@@ -214,6 +227,7 @@ fn test_resolve_dispute_sender_wins_full_refund() {
     let hash = evidence_hash(&f.env);
 
     let sender_before = balance(&f.env, &f.token, &f.sender);
+    let agent_before = balance(&f.env, &f.token, &f.agent);
     let contract_before = balance(&f.env, &f.token, &f.contract.address);
 
     f.contract.raise_dispute(&f.remittance_id, &hash);
@@ -226,6 +240,7 @@ fn test_resolve_dispute_sender_wins_full_refund() {
     // Sender receives the full remittance amount back
     let sender_after = balance(&f.env, &f.token, &f.sender);
     assert_eq!(sender_after - sender_before, 1_000);
+    assert_eq!(balance(&f.env, &f.token, &f.agent), agent_before);
 
     // Contract balance decreases by the full amount
     let contract_after = balance(&f.env, &f.token, &f.contract.address);
@@ -241,7 +256,9 @@ fn test_resolve_dispute_agent_wins_net_amount_to_agent() {
     let f = setup_failed_remittance();
     let hash = evidence_hash(&f.env);
 
+    let sender_before = balance(&f.env, &f.token, &f.sender);
     let agent_before = balance(&f.env, &f.token, &f.agent);
+    let contract_before = balance(&f.env, &f.token, &f.contract.address);
 
     f.contract.raise_dispute(&f.remittance_id, &hash);
     f.contract.resolve_dispute(&f.remittance_id, &false);
@@ -253,6 +270,12 @@ fn test_resolve_dispute_agent_wins_net_amount_to_agent() {
     // Agent receives net amount (amount - fee = 1000 - 25 = 975 at 2.5% fee)
     let agent_after = balance(&f.env, &f.token, &f.agent);
     assert_eq!(agent_after - agent_before, 975);
+    assert_eq!(balance(&f.env, &f.token, &f.sender), sender_before);
+
+    // Contract retains only the fee after paying the agent.
+    let contract_after = balance(&f.env, &f.token, &f.contract.address);
+    assert_eq!(contract_before - contract_after, 975);
+    assert_eq!(contract_after, 25);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
closes #570 
closes #571 
closes #572
closes #573

PR description:

**Summary**
add TTL-based wallet session persistence and clear stale wallet keys on restore/disconnect
convert DisputeResolution to TypeScript with typed state and runtime API shape validation
restrict SDK allowHttp to localhost HTTP endpoints and warn when insecure RPC is used
strengthen dispute lifecycle coverage in frontend, SDK, backend E2E, and contract dispute tests

**Notes**
DisputeResolution.jsx was replaced with DisputeResolution.tsx
backend dispute E2E now covers fuller create/fail/dispute/resolve flows, but still simulates the contract-side disputed transition inside the test harness
local verification was limited by missing vitest binaries and an in-progress Cargo dependency compile/download step