### PR TITLE
fix(database): avoid connection leak when initDatabase fails and guard client release

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -1,4 +1,4 @@
-import { Pool } from 'pg';
+import { Pool, PoolClient } from 'pg';
 import {
   AssetVerification,
   VerificationStatus,
@@ -11,16 +11,23 @@ import {
   WebhookDelivery,
 } from './types';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  max: 20,
-  idleTimeoutMillis: 30000,
-  connectionTimeoutMillis: 2000,
-});
+let pool: Pool;
+try {
+  pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    max: 20,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 2000,
+  });
+} catch (error) {
+  console.error('Failed to initialize PostgreSQL pool:', error);
+  throw error;
+}
 
 export async function initDatabase() {
-  const client = await pool.connect();
+  let client: PoolClient | undefined;
   try {
+    client = await pool.connect();
     await client.query(`      CREATE TABLE IF NOT EXISTS transactions (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         transaction_id VARCHAR(255) UNIQUE NOT NULL,
@@ -187,7 +194,7 @@ export async function initDatabase() {
     `);
     console.log('Database initialized successfully');
   } finally {
-    client.release();
+    client?.release();
   }
 }
 


### PR DESCRIPTION
closes #565 

Database init connection leak
In [database.ts](https://fictional-fiesta-p7rpg4647qgqc77x6.github.dev/), [initDatabase()](https://fictional-fiesta-p7rpg4647qgqc77x6.github.dev/) acquires a database client from the pool, but if pool initialization fails or the client is never assigned, cleanup can be skipped.
That can leak connections and exhaust the pool under repeated initialization failures.