### PR TITLE
feat:fix: adaptive rate limiting with exponential backoff for KYC polling

### DIFF
--- a/backend/src/kyc-service.ts
+++ b/backend/src/kyc-service.ts
@@ -11,6 +11,28 @@ interface Sep12KycResponse {
   fields?: any;
 }
 
+const DEFAULT_INTER_REQUEST_DELAY_MS = 1000;
+const MAX_BACKOFF_MS = 32000;
+const BACKOFF_MULTIPLIER = 2;
+
+/** Returns a promise that resolves after `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Calculates exponential backoff delay with jitter.
+ * @param attempt - zero-based retry attempt number
+ * @param baseDelayMs - the base delay for this anchor
+ */
+function calcBackoff(attempt: number, baseDelayMs: number): number {
+  const exponential = baseDelayMs * Math.pow(BACKOFF_MULTIPLIER, attempt);
+  const capped = Math.min(exponential, MAX_BACKOFF_MS);
+  // Add ±10% jitter to avoid thundering herd
+  const jitter = capped * 0.1 * (Math.random() * 2 - 1);
+  return Math.round(capped + jitter);
+}
+
 export class KycService {
   private configs: Map<string, AnchorKycConfig> = new Map();
 
@@ -32,45 +54,68 @@ export class KycService {
 
   private async pollAnchorKycStatus(anchorId: string, config: AnchorKycConfig): Promise<void> {
     const usersToCheck = await getUsersNeedingKycCheck(anchorId, config.polling_interval_minutes);
+    const baseDelayMs = config.inter_request_delay_ms ?? DEFAULT_INTER_REQUEST_DELAY_MS;
 
-    console.log(`Checking KYC status for ${usersToCheck.length} users on anchor ${anchorId}`);
+    console.log(`Checking KYC status for ${usersToCheck.length} users on anchor ${anchorId} (base delay: ${baseDelayMs}ms)`);
 
     for (const userKyc of usersToCheck) {
-      try {
-        const kycResponse = await this.queryAnchorKycStatus(config, userKyc.user_id);
+      let attempt = 0;
+      let success = false;
 
-        if (kycResponse) {
-          const updatedStatus: DbUserKycStatus = {
-            ...userKyc,
-            status: this.mapSep12StatusToInternal(kycResponse.status),
-            last_checked: new Date(),
-            expires_at: kycResponse.expires_at ? new Date(kycResponse.expires_at) : undefined,
-            rejection_reason: kycResponse.rejection_reason,
-            verification_data: kycResponse.fields,
-          };
+      while (!success) {
+        try {
+          const kycResponse = await this.queryAnchorKycStatus(config, userKyc.user_id);
 
-          await saveUserKycStatus(updatedStatus);
+          if (kycResponse) {
+            const updatedStatus: DbUserKycStatus = {
+              ...userKyc,
+              status: this.mapSep12StatusToInternal(kycResponse.status),
+              last_checked: new Date(),
+              expires_at: kycResponse.expires_at ? new Date(kycResponse.expires_at) : undefined,
+              rejection_reason: kycResponse.rejection_reason,
+              verification_data: kycResponse.fields,
+            };
 
-          // Update on-chain status if approved
-          if (updatedStatus.status === 'approved') {
-            try {
-              await updateKycStatusOnChain(userKyc.user_id, true);
-            } catch (error) {
-              console.error(`Failed to update on-chain KYC status for user ${userKyc.user_id}:`, error);
-            }
-          } else if (updatedStatus.status === 'rejected') {
-            try {
-              await updateKycStatusOnChain(userKyc.user_id, false);
-            } catch (error) {
-              console.error(`Failed to update on-chain KYC status for user ${userKyc.user_id}:`, error);
+            await saveUserKycStatus(updatedStatus);
+
+            // Update on-chain status if approved or rejected
+            if (updatedStatus.status === 'approved') {
+              try {
+                await updateKycStatusOnChain(userKyc.user_id, true);
+              } catch (error) {
+                console.error(`Failed to update on-chain KYC status for user ${userKyc.user_id}:`, error);
+              }
+            } else if (updatedStatus.status === 'rejected') {
+              try {
+                await updateKycStatusOnChain(userKyc.user_id, false);
+              } catch (error) {
+                console.error(`Failed to update on-chain KYC status for user ${userKyc.user_id}:`, error);
+              }
             }
           }
-        }
 
-        // Rate limiting - wait 1 second between requests
-        await new Promise(resolve => setTimeout(resolve, 1000));
-      } catch (error) {
-        console.error(`Failed to check KYC status for user ${userKyc.user_id} on anchor ${anchorId}:`, error);
+          success = true;
+
+          // Configurable inter-request delay (adaptive: reset after a successful request)
+          await sleep(baseDelayMs);
+        } catch (error) {
+          if (axios.isAxiosError(error) && error.response?.status === 429) {
+            attempt++;
+            const retryAfterHeader = error.response.headers['retry-after'];
+            const retryAfterMs = retryAfterHeader
+              ? parseInt(retryAfterHeader, 10) * 1000
+              : calcBackoff(attempt, baseDelayMs);
+
+            console.warn(
+              `Rate limited (429) by anchor ${anchorId} for user ${userKyc.user_id}. ` +
+              `Retrying in ${retryAfterMs}ms (attempt ${attempt})...`
+            );
+            await sleep(retryAfterMs);
+          } else {
+            console.error(`Failed to check KYC status for user ${userKyc.user_id} on anchor ${anchorId}:`, error);
+            success = true; // Don't retry on non-429 errors; move to next user
+          }
+        }
       }
     }
   }
@@ -92,6 +137,10 @@ export class KycService {
         if (error.response?.status === 404) {
           // User not found in anchor's system
           return null;
+        }
+        if (error.response?.status === 429) {
+          // Re-throw so the caller can apply exponential backoff
+          throw error;
         }
         console.error(`HTTP error querying KYC status: ${error.response?.status} ${error.response?.statusText}`);
       } else {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -91,6 +91,8 @@ export interface AnchorKycConfig {
   auth_token: string;
   polling_interval_minutes: number;
   enabled: boolean;
+  /** Base delay in ms between requests for this anchor. Defaults to 1000ms if not set. */
+  inter_request_delay_ms?: number;
 }
 
 /** Raw database row from user_kyc_status table */


### PR DESCRIPTION
Description:
kyc-service.ts uses await new Promise(resolve => setTimeout(resolve, 1000)) between KYC requests. This hardcoded 1-second delay doesn't adapt to anchor rate limits and can still trigger 429 responses from slow anchors.

Location: backend/src/kyc-service.ts

Impact: Medium — KYC polling may be throttled or fail under load

Suggested Fix:

Implement exponential backoff on 429 responses
Make the inter-request delay configurable per anchor
 closes #562 