### PR TITLE
fix: resolve security issues #608, #609, #610, #611

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,28 +666,21 @@ impl SwiftRemitContract {
 
         sender.require_auth();
 
-        // Validate all entries before any state changes
+        // Validate all entries and accumulate total before any state changes
         let mut total_amount: i128 = 0;
         for i in 0..batch_size {
             let entry = entries.get_unchecked(i);
             validate_create_remittance_request(&env, &sender, &entry.agent, entry.amount)?;
-
-            // Check daily limit for each entry
-            let default_currency = String::from_str(&env, DEFAULT_DAILY_LIMIT_CURRENCY);
-            let default_country = String::from_str(&env, DEFAULT_DAILY_LIMIT_COUNTRY);
-            enforce_daily_send_limit(
-                &env,
-                &sender,
-                &default_currency,
-                &default_country,
-                entry.amount,
-            )?;
-
-            // Accumulate total amount
             total_amount = total_amount
                 .checked_add(entry.amount)
                 .ok_or(ContractError::Overflow)?;
         }
+
+        // Pre-validate the entire batch total against the daily limit atomically (#611)
+        // This ensures no partial batch can sneak past the limit one entry at a time
+        let default_currency = String::from_str(&env, DEFAULT_DAILY_LIMIT_CURRENCY);
+        let default_country = String::from_str(&env, DEFAULT_DAILY_LIMIT_COUNTRY);
+        enforce_daily_send_limit(&env, &sender, &default_currency, &default_country, total_amount)?;
 
         // Transfer total amount in a single token transfer
         let usdc_token = get_usdc_token(&env)?;
@@ -780,6 +773,7 @@ impl SwiftRemitContract {
     /// Requires Settler role.
     pub fn confirm_payout(
         env: Env,
+        agent: Address,
         remittance_id: u64,
         proof: Option<soroban_sdk::BytesN<32>>,
         recipient_details_hash: Option<BytesN<32>>,
@@ -789,6 +783,11 @@ impl SwiftRemitContract {
         }
         // Centralized validation before business logic (returns remittance to avoid re-read)
         let mut remittance = validate_confirm_payout_request(&env, remittance_id)?;
+
+        // Verify the caller is the specific agent assigned to this remittance (#608)
+        if agent != remittance.agent {
+            return Err(ContractError::Unauthorized);
+        }
 
         // Validate proof against settlement config if required
         if let crate::MaybeSettlementConfig::Some(ref config) = remittance.settlement_config {
@@ -944,6 +943,11 @@ impl SwiftRemitContract {
         remittance.status = RemittanceStatus::Failed;
         remittance.failed_at = Some(env.ledger().timestamp());
         set_remittance(&env, remittance_id, &remittance);
+
+        // Clear idempotency key on Failed so the same key can be reused to retry (#610)
+        if let Some(idem_key) = storage::take_remittance_idempotency_key(&env, remittance_id) {
+            storage::remove_idempotency_record(&env, &idem_key);
+        }
 
         let mut stats = crate::storage::get_agent_stats(&env, &remittance.agent);
         stats.failed_settlements += 1;
@@ -2403,6 +2407,7 @@ impl SwiftRemitContract {
     /// Confirms payouts for multiple remittances in one transaction (#590).
     pub fn confirm_batch_payout(
         env: Env,
+        agent: Address,
         remittance_ids: Vec<u64>,
     ) -> Result<Vec<u64>, ContractError> {
         let batch_size = remittance_ids.len();
@@ -2412,7 +2417,7 @@ impl SwiftRemitContract {
         let mut confirmed = Vec::new(&env);
         for i in 0..batch_size {
             let id = remittance_ids.get_unchecked(i);
-            Self::confirm_payout(env.clone(), id, None, None)?;
+            Self::confirm_payout(env.clone(), agent.clone(), id, None, None)?;
             confirmed.push_back(id);
         }
         env.events().publish(

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -172,10 +172,12 @@ pub fn validate_cancel_remittance_request(
 /// Returns the fees amount to avoid re-reading in the caller.
 pub fn validate_withdraw_fees_request(
     env: &Env,
-    _to: &Address,
+    to: &Address,
 ) -> Result<i128, ContractError> {
-    // Address type is guaranteed valid by the Soroban SDK runtime; no further
-    // address validation is required or possible at the contract level.
+    // Prevent fees from being sent to the contract itself, which would lock them (#609)
+    if *to == env.current_contract_address() {
+        return Err(ContractError::InvalidAddress);
+    }
     let fees = crate::get_accumulated_fees(env)?;
     validate_fees_available(fees)?;
     Ok(fees)


### PR DESCRIPTION
## Summary

- **#608**: Add explicit assigned-agent check in `confirm_payout` — any registered agent could previously confirm any remittance; now the caller must match `remittance.agent` before auth or state changes proceed
- **#609**: Validate `to` address in `withdraw_fees` — reject `to == current_contract_address` to prevent fees from being permanently locked in the contract
- **#610**: Clear idempotency key on `Failed` state in `mark_failed` — allows the same idempotency key to be reused for a retry after a transient failure
- **#611**: Enforce per-sender daily limit atomically in `batch_create_remittances` — pre-validate the total batch amount in a single `enforce_daily_send_limit` call before creating any individual remittance

## Test plan

- [ ] `confirm_payout` rejects calls where the passed `agent` does not match the remittance's assigned agent (returns `Unauthorized`)
- [ ] `confirm_payout` still succeeds when the correct assigned agent calls it
- [ ] `confirm_batch_payout` correctly passes the agent through to each `confirm_payout` call
- [ ] `withdraw_fees` returns `InvalidAddress` when `to` is the contract's own address
- [ ] `withdraw_fees` succeeds when `to` is a valid external address
- [ ] After `mark_failed`, a new `create_remittance` with the same idempotency key creates a fresh remittance instead of returning the failed one
- [ ] `batch_create_remittances` with a total amount exceeding the daily limit is rejected before any remittance is created

closes #608
closes #609
closes #610
closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)