### PR TITLE
fix: resolve issues #612 #613 #615 #616 — storage TTL, circuit breaker, rate limit, WASM hash

### DIFF
--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -185,15 +185,19 @@ pub fn do_vote_unpause(env: &Env, caller: &Address) -> Result<(), ContractError>
         return Err(ContractError::AlreadyVoted);
     }
 
+    // Reject votes after quorum has already been reached to prevent spurious
+    // state writes and events in the same pause cycle.
+    let quorum = cb_storage::get_unpause_quorum(env);
+    if cb_storage::get_vote_count(env, pause_seq) >= quorum {
+        return Err(ContractError::AlreadyVoted);
+    }
+
     // Record the vote and increment the count.
     cb_storage::record_vote(env, pause_seq, caller);
     let new_count = cb_storage::get_vote_count(env, pause_seq)
         .checked_add(1)
         .ok_or(ContractError::Overflow)?;
     cb_storage::set_vote_count(env, pause_seq, new_count);
-
-    // Auto-unpause when quorum is reached (timelock still applies).
-    let quorum = cb_storage::get_unpause_quorum(env);
     if new_count >= quorum {
         // bypass_timelock_quorum = false: timelock is still enforced.
         do_emergency_unpause(env, caller, false)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,19 @@ pub const MAX_NETTING_BATCH_SIZE: u32 = 50;
 /// Caps the Vec size to prevent unbounded growth and O(n²) pruning behavior
 /// during high-activity periods. Timestamps older than the window are pruned
 /// in a single pass using retain-style filtering.
+///
+/// **Constraint**: must always be strictly greater than the largest per-window
+/// request limit (`MAX_QUERIES_PER_WINDOW`). If this invariant is violated the
+/// sliding-window cap would prune entries that are still inside the rate-limit
+/// window, silently lowering the effective limit below its configured value.
+/// The compile-time assertion below enforces this.
 pub const MAX_VEC_SIZE: usize = 1000;
+
+// Ensure the cap never silently reduces the effective rate limit.
+const _: () = assert!(
+    MAX_VEC_SIZE > MAX_QUERIES_PER_WINDOW as usize,
+    "MAX_VEC_SIZE must be strictly greater than MAX_QUERIES_PER_WINDOW to avoid silent data loss in the sliding-window rate limiter",
+);
 
 // ============================================================================
 // Fee Calculation Constants

--- a/src/contract_upgrade.rs
+++ b/src/contract_upgrade.rs
@@ -444,11 +444,18 @@ pub struct UpgradeSimulationResult {
 /// * `new_wasm_hash` - Hash of the candidate WASM binary
 ///
 /// # Returns
-/// * `UpgradeSimulationResult` with migration preview
+/// * `Ok(UpgradeSimulationResult)` with migration preview
+/// * `Err(ContractError::InvalidInput)` if the hash is the null (all-zero) hash,
+///   which cannot correspond to any uploaded WASM blob
 pub fn simulate_upgrade(
     env: &Env,
     new_wasm_hash: BytesN<32>,
-) -> UpgradeSimulationResult {
+) -> Result<UpgradeSimulationResult, ContractError> {
+    // Reject the null/all-zero hash — it cannot correspond to any uploaded WASM.
+    if new_wasm_hash.iter().all(|b| b == 0) {
+        return Err(ContractError::InvalidInput);
+    }
+
     // Read current schema version (stored by previous migrations, default 0)
     let current_schema_version: u32 = env
         .storage()
@@ -484,14 +491,14 @@ pub fn simulate_upgrade(
         affected_keys.push_back(&soroban_sdk::String::from_str(env, "UpgradeKey::PendingCount"));
     }
 
-    UpgradeSimulationResult {
+    Ok(UpgradeSimulationResult {
         current_schema_version,
         new_schema_version,
         schema_version_delta,
         estimated_migration_steps,
         affected_storage_keys: affected_keys,
         requires_migration,
-    }
+    })
 }
 
 // ============================================================================

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1910,6 +1910,32 @@ pub fn extend_critical_ttls(env: &Env, extend_by_ledgers: u32) {
                 .extend_ttl(&key, ledgers, ledgers);
         }
     }
+
+    // Bump per-agent persistent keys so agents never lose their registration status.
+    let agents = get_agent_list(env);
+    for i in 0..agents.len() {
+        let agent = agents.get_unchecked(i);
+
+        let key = DataKey::AgentRegistered(agent.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, ledgers, ledgers);
+        }
+
+        let key = DataKey::AgentKycHash(agent.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, ledgers, ledgers);
+        }
+
+        let key = DataKey::AgentStats(agent.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, ledgers, ledgers);
+        }
+
+        let key = DataKey::AgentDailyCap(agent.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, ledgers, ledgers);
+        }
+    }
 }
 
 // === 2-Step Admin Transfer (#365) ===


### PR DESCRIPTION
## Summary

- **#616** `contract_upgrade.rs` — `simulate_upgrade` now returns `Result<UpgradeSimulationResult, ContractError>` and rejects all-zero (null) WASM hashes with `InvalidInput`, catching non-existent-hash proposals at simulation time instead of failing silently at execution.
- **#615** `config.rs` — Added a compile-time `assert!` enforcing `MAX_VEC_SIZE > MAX_QUERIES_PER_WINDOW`; if the cap ever falls below the largest per-window limit the build fails rather than silently reducing the effective rate limit.
- **#612** `storage.rs` — `extend_critical_ttls` now iterates the `AgentList` and bumps TTLs for all four per-agent persistent keys (`AgentRegistered`, `AgentKycHash`, `AgentStats`, `AgentDailyCap`) so agents can never lose registration status due to ledger TTL expiry.
- **#613** `circuit_breaker.rs` — `do_vote_unpause` now rejects votes once the current vote count already meets quorum, preventing spurious storage writes and events in the same pause cycle.

## Test plan

- [ ] Verify `simulate_upgrade` returns `Err(InvalidInput)` when passed a 32-byte all-zero hash
- [ ] Confirm build fails at compile time if `MAX_VEC_SIZE` is reduced below `MAX_QUERIES_PER_WINDOW`
- [ ] Register an agent, call `extend_critical_ttls`, and confirm `AgentRegistered`/`AgentKycHash`/`AgentStats`/`AgentDailyCap` TTLs are extended
- [ ] Pause contract, cast votes up to quorum, confirm a subsequent `vote_unpause` returns `AlreadyVoted`

Closes #616
Closes #615
Closes #612
Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)