### PR TITLE
fix: resolve issues #604, #605, #606, #607

### DIFF
--- a/src/governance.rs
+++ b/src/governance.rs
@@ -315,6 +315,11 @@ pub fn cleanup_expired_proposals(
             if proposal.state == ProposalState::Expired
                 || proposal.state == ProposalState::Executed
             {
+                if let ProposalAction::UpdateFee(_) = &proposal.action {
+                    if get_active_fee_proposal(env) == Some(id) {
+                        set_active_fee_proposal(env, None);
+                    }
+                }
                 delete_proposal(env, id);
                 emit_proposal_cleaned_up(env, id);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2290,7 +2290,8 @@ impl SwiftRemitContract {
 
         // Compute net settlements.
         // Gas note: netting offsets opposing flows so fewer token transfer calls are executed.
-        let net_transfers = compute_net_settlements(&env, &remittances)?;
+        let netting_result = compute_net_settlements(&env, &remittances)?;
+        let net_transfers = netting_result.net_transfers;
 
         // Validate net settlement calculations
         validate_net_settlement(&remittances, &net_transfers)?;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -37,7 +37,7 @@
 
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Vec, xdr::ToXdr};
 
-use crate::{config::MAX_MIGRATION_BATCH_SIZE, ContractError, Remittance, RemittanceStatus};
+use crate::{config::MAX_MIGRATION_BATCH_SIZE, AgentStats, ContractError, Remittance, RemittanceStatus};
 
 // ─── Schema version ──────────────────────────────────────────────────────────
 
@@ -126,6 +126,15 @@ pub struct MigrationVerification {
     pub timestamp: u64,
 }
 
+/// Per-agent performance and cap data captured in a rollback snapshot.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AgentStatsSnapshot {
+    pub address: Address,
+    pub stats: AgentStats,
+    pub daily_cap: i128,
+}
+
 /// Pre-migration rollback snapshot stored in instance storage.
 ///
 /// Captured by `migrate()` before any writes so the state can be restored
@@ -139,6 +148,8 @@ pub struct RollbackSnapshot {
     pub ledger_sequence: u32,
     /// All agent records at the time of snapshot.
     pub agents: Vec<AgentRecord>,
+    /// Per-agent stats and daily cap — restored on rollback to prevent data loss.
+    pub agent_stats_snapshot: Vec<AgentStatsSnapshot>,
 }
 
 // ─── Instance key for schema version ─────────────────────────────────────────
@@ -294,17 +305,23 @@ pub fn migrate(env: &Env) -> Result<(), ContractError> {
     }
 
     // ── Step 1: capture rollback snapshot ────────────────────────────────────
-    let agent_list = crate::storage::get_admin_list(env);
+    let agent_list = crate::storage::get_agent_list(env);
     let mut snapshot_agents: Vec<AgentRecord> = Vec::new(env);
+    let mut stats_snapshot: Vec<AgentStatsSnapshot> = Vec::new(env);
 
     for i in 0..agent_list.len() {
         let addr = agent_list.get_unchecked(i);
         let registered = crate::storage::is_agent_registered(env, &addr);
         let kyc_hash = crate::storage::get_agent_kyc_hash(env, &addr);
         snapshot_agents.push_back(AgentRecord {
-            address: addr,
+            address: addr.clone(),
             registered,
             kyc_hash,
+        });
+        stats_snapshot.push_back(AgentStatsSnapshot {
+            address: addr.clone(),
+            stats: crate::storage::get_agent_stats(env, &addr),
+            daily_cap: crate::storage::get_agent_daily_cap(env, &addr),
         });
     }
 
@@ -312,6 +329,7 @@ pub fn migrate(env: &Env) -> Result<(), ContractError> {
         from_version: current_version,
         ledger_sequence: env.ledger().sequence(),
         agents: snapshot_agents.clone(),
+        agent_stats_snapshot: stats_snapshot,
     };
     save_rollback_snapshot(env, &rollback);
 
@@ -405,6 +423,13 @@ pub fn rollback_migration(env: &Env) -> Result<(), ContractError> {
         if let Some(ref hash) = record.kyc_hash {
             crate::storage::set_agent_kyc_hash(env, &record.address, hash);
         }
+    }
+
+    // Restore agent stats and daily caps.
+    for i in 0..snapshot.agent_stats_snapshot.len() {
+        let entry = snapshot.agent_stats_snapshot.get_unchecked(i);
+        crate::storage::set_agent_stats(env, &entry.address, &entry.stats);
+        crate::storage::set_agent_daily_cap(env, &entry.address, entry.daily_cap);
     }
 
     // Restore the schema version to what it was before the migration attempt.

--- a/src/netting.rs
+++ b/src/netting.rs
@@ -2,6 +2,17 @@ use soroban_sdk::{contracttype, Address, Env, Map, Vec};
 
 use crate::{ContractError, Remittance, RemittanceStatus, config::MAX_NETTING_BATCH_SIZE};
 
+/// Result of a netting computation, pairing net transfers with IDs that were
+/// excluded because they are in a non-nettable state (Failed or Disputed).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NettingResult {
+    /// Minimal set of net transfers to execute on-chain.
+    pub net_transfers: Vec<NetTransfer>,
+    /// Remittance IDs that were skipped due to Failed or Disputed status.
+    pub skipped_ids: Vec<u64>,
+}
+
 /// Represents a net transfer between two parties after offsetting opposing flows.
 /// This structure ensures deterministic ordering by always placing the party
 /// with the lexicographically smaller address as party_a.
@@ -57,17 +68,26 @@ struct DirectionalFlow {
 ///
 /// # Errors
 /// Returns `ContractError::InvalidBatchSize` if remittances.len() > MAX_NETTING_BATCH_SIZE
-pub fn compute_net_settlements(env: &Env, remittances: &Vec<Remittance>) -> Result<Vec<NetTransfer>, ContractError> {
+pub fn compute_net_settlements(env: &Env, remittances: &Vec<Remittance>) -> Result<NettingResult, ContractError> {
     // Validate batch size to prevent DoS via large remittance batches
     if remittances.len() > MAX_NETTING_BATCH_SIZE {
         return Err(ContractError::InvalidBatchSize);
     }
 
     let mut flows: Vec<DirectionalFlow> = Vec::new(env);
+    let mut skipped_ids: Vec<u64> = Vec::new(env);
 
     // Extract all directional flows from remittances
     for i in 0..remittances.len() {
         let remittance = remittances.get_unchecked(i);
+
+        // Track Failed/Disputed remittances so callers can reconcile them.
+        if remittance.status == RemittanceStatus::Failed
+            || remittance.status == RemittanceStatus::Disputed
+        {
+            skipped_ids.push_back(remittance.id);
+            continue;
+        }
 
         // Only process pending remittances
         if remittance.status != RemittanceStatus::Pending {
@@ -102,7 +122,7 @@ pub fn compute_net_settlements(env: &Env, remittances: &Vec<Remittance>) -> Resu
     }
 
     // Convert map to vector of NetTransfer structs
-    let mut result: Vec<NetTransfer> = Vec::new(env);
+    let mut net_transfers: Vec<NetTransfer> = Vec::new(env);
     let keys = net_map.keys();
 
     for i in 0..keys.len() {
@@ -112,7 +132,7 @@ pub fn compute_net_settlements(env: &Env, remittances: &Vec<Remittance>) -> Resu
         // Skip zero-value net positions — attempting a zero-value token transfer
         // would fail or produce unexpected behaviour (Issue #421).
         if net_amount != 0 {
-            result.push_back(NetTransfer {
+            net_transfers.push_back(NetTransfer {
                 party_a: key.0.clone(),
                 party_b: key.1.clone(),
                 net_amount,
@@ -121,7 +141,7 @@ pub fn compute_net_settlements(env: &Env, remittances: &Vec<Remittance>) -> Resu
         }
     }
 
-    Ok(result)
+    Ok(NettingResult { net_transfers, skipped_ids })
 }
 
 /// Normalizes a pair of addresses to ensure deterministic ordering.
@@ -267,7 +287,8 @@ mod tests {
             dispute_evidence: None,
         });
 
-        let net_transfers = compute_net_settlements(&env, &remittances).unwrap();
+        let result = compute_net_settlements(&env, &remittances).unwrap();
+        let net_transfers = result.net_transfers;
 
         assert_eq!(net_transfers.len(), 1);
         let transfer = net_transfers.get_unchecked(0);
@@ -323,7 +344,8 @@ mod tests {
             dispute_evidence: None,
         });
 
-        let net_transfers = compute_net_settlements(&env, &remittances).unwrap();
+        let result = compute_net_settlements(&env, &remittances).unwrap();
+        let net_transfers = result.net_transfers;
 
         // Complete offset should result in no transfers
         assert_eq!(net_transfers.len(), 0);
@@ -386,7 +408,8 @@ mod tests {
             dispute_evidence: None,
         });
 
-        let net_transfers = compute_net_settlements(&env, &remittances).unwrap();
+        let result = compute_net_settlements(&env, &remittances).unwrap();
+        let net_transfers = result.net_transfers;
 
         // Should have 3 net transfers (one for each pair)
         assert_eq!(net_transfers.len(), 3);
@@ -437,7 +460,8 @@ mod tests {
             dispute_evidence: None,
         });
 
-        let net_transfers = compute_net_settlements(&env, &remittances).unwrap();
+        let result = compute_net_settlements(&env, &remittances).unwrap();
+        let net_transfers = result.net_transfers;
 
         assert!(validate_net_settlement(&remittances, &net_transfers).is_ok());
     }
@@ -510,8 +534,8 @@ mod tests {
             dispute_evidence: None,
         });
 
-        let net1 = compute_net_settlements(&env, &remittances1).unwrap();
-        let net2 = compute_net_settlements(&env, &remittances2).unwrap();
+        let net1 = compute_net_settlements(&env, &remittances1).unwrap().net_transfers;
+        let net2 = compute_net_settlements(&env, &remittances2).unwrap().net_transfers;
 
         // Results should be identical regardless of input order
         assert_eq!(net1.len(), net2.len());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1585,8 +1585,9 @@ pub fn add_disbursed_amount(env: &Env, remittance_id: u64, amount: i128) -> Resu
 
 // === Per-Agent Daily Withdrawal Cap ===
 
-/// Rolling 24-hour window in seconds.
-pub const AGENT_CAP_WINDOW_SECONDS: u64 = 86_400;
+/// Rolling 24-hour window in seconds. Derives from the shared daily-limit constant
+/// so both limits always use the same window boundary.
+pub const AGENT_CAP_WINDOW_SECONDS: u64 = crate::config::DAILY_LIMIT_WINDOW_SECONDS;
 
 /// Returns the per-agent daily withdrawal cap (0 = no cap).
 pub fn get_agent_daily_cap(env: &Env, agent: &Address) -> i128 {

--- a/src/test_escrow.rs
+++ b/src/test_escrow.rs
@@ -345,7 +345,7 @@ fn test_zero_net_position_produces_no_transfer() {
         dispute_evidence: crate::MaybeBytes32::None,
     });
 
-    let net_transfers: Vec<NetTransfer> = compute_net_settlements(&env, &remittances).unwrap();
+    let net_transfers: Vec<NetTransfer> = compute_net_settlements(&env, &remittances).unwrap().net_transfers;
 
     // Zero net position must be skipped — no transfer entry produced
     assert_eq!(

--- a/src/test_property.rs
+++ b/src/test_property.rs
@@ -365,8 +365,8 @@ proptest! {
         }
 
         // Compute net settlements for both orders
-        let net_forward = crate::netting::compute_net_settlements(&env, &remittances_forward).unwrap();
-        let net_reverse = crate::netting::compute_net_settlements(&env, &remittances_reverse).unwrap();
+        let net_forward = crate::netting::compute_net_settlements(&env, &remittances_forward).unwrap().net_transfers;
+        let net_reverse = crate::netting::compute_net_settlements(&env, &remittances_reverse).unwrap().net_transfers;
 
         // Results should be identical
         prop_assert_eq!(net_forward.len(), net_reverse.len(),
@@ -674,7 +674,7 @@ proptest! {
         }
 
         // Compute net settlements
-        let net_transfers = crate::netting::compute_net_settlements(&env, &remittances).unwrap();
+        let net_transfers = crate::netting::compute_net_settlements(&env, &remittances).unwrap().net_transfers;
 
         // Sum fees from net transfers
         let mut net_total_fees = 0i128;


### PR DESCRIPTION
## Summary

- **#605** — Extended `RollbackSnapshot` in `migration.rs` to capture `AgentStats` and `AgentDailyCap` per-agent. A new `AgentStatsSnapshot` struct holds both fields; they are populated during `migrate()` and fully restored in `rollback_migration()`.
- **#606** — `compute_net_settlements` in `netting.rs` now returns a `NettingResult` struct containing both `net_transfers` and `skipped_ids`. `Failed` and `Disputed` remittance IDs are collected and surfaced to callers instead of being silently dropped. All call sites updated.
- **#607** — Replaced the hardcoded `86_400` in `AGENT_CAP_WINDOW_SECONDS` (`storage.rs`) with `crate::config::DAILY_LIMIT_WINDOW_SECONDS`, keeping the agent cap window in sync with the central daily-limit constant.
- **#604** — `cleanup_expired_proposals` in `governance.rs` now calls `set_active_fee_proposal(env, None)` when deleting a fee-update proposal, unblocking new fee proposals after an expired one is cleaned up.

## Test plan

- [ ] Confirm `cargo build` passes (pre-existing unrelated errors unchanged)
- [ ] Confirm existing netting tests pass (`test_simple_netting`, `test_complete_offset`, `test_multiple_parties`, `test_validation_success`, `test_order_independence`)
- [ ] Verify rollback snapshot includes agent stats/caps by inspecting snapshot fields after `migrate()`
- [ ] Verify a new fee proposal can be created after calling `cleanup_expired_proposals` on an expired fee proposal
- [ ] Verify `compute_net_settlements` returns non-empty `skipped_ids` when batch contains Failed/Disputed remittances

closes #604
closes #605
closes #606
closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)