### PR TITLE
fix: auto-refund on mark_failed, fee overflow safety, escrow TTL exte…

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Fees are calculated in basis points (bps):
 - `create_remittance(sender, agent, amount)` - Create new remittance (sender auth required)
 - `start_processing(remittance_id)` - Mark remittance as being processed (agent auth required)
 - `confirm_payout(remittance_id, proof)` - Confirm fiat payout with optional commitment proof
-- `mark_failed(remittance_id)` - Mark payout as failed with refund (agent auth required)
+- `confirm_partial_payout(remittance_id, amount)` - Disburse a partial amount to the agent; automatically marks the remittance Completed when the total disbursed reaches the net payout (agent auth required)
+- `mark_failed(remittance_id)` - Mark payout as failed and auto-refund escrow to sender (agent auth required)
 - `cancel_remittance(remittance_id)` - Cancel pending remittance (sender auth required)
 - `process_expired_remittances(remittance_ids)` - Auto-refund expired pending remittances in batches (max 50 IDs)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,14 @@
 //! and prevent duplicate definitions. All magic numbers should be defined
 //! here with clear documentation.
 
+/// Number of ledgers to extend a remittance's persistent storage TTL when it
+/// transitions from Pending to Processing (#624).
+///
+/// At a 5-second ledger time this equals approximately 7 days, giving agents
+/// a reasonable window to complete the off-chain fiat payout before the
+/// escrow record would otherwise expire.
+pub const PROCESSING_WINDOW_LEDGERS: u32 = 120_960; // ~7 days at 5s/ledger
+
 // ============================================================================
 // Batch Processing Limits
 // ============================================================================

--- a/src/fee_management.rs
+++ b/src/fee_management.rs
@@ -29,17 +29,10 @@ use crate::{
 /// When accumulated fees exceed this value, a flush is automatically triggered.
 /// This prevents integer overflow and ensures regular fee settlement.
 ///
-/// Value: 922,337,203,685,477,580 (approximately 92% of i128::MAX)
-/// This provides a reasonable buffer while allowing for high-volume transactions.
-///
-/// Typical scenario:
-/// - Network volume: 1,000,000 transactions/day
-/// - Average fee: 1000 USDC
-/// - Daily accumulation: 1,000,000,000 USDC/day
-/// - Time to MAX_FEES: ~924,337 days (~2530 years)
-///
-/// This cap ensures safety while allowing for reasonable contract lifetime.
-pub const MAX_FEES: i128 = i128::MAX / 10; // ~10% of i128::MAX
+/// Value: approximately 10% of i128::MAX / 2, providing a large safety margin
+/// so that the flush transfer itself (which moves the full accumulated amount)
+/// cannot overflow during the USDC token call (#622).
+pub const MAX_FEES: i128 = i128::MAX / 20; // ~5% of i128::MAX
 
 /// Safely adds a new fee to the accumulated total.
 ///
@@ -234,10 +227,13 @@ mod tests {
         assert!(MAX_FEES < i128::MAX);
         assert!(MAX_FEES > 0);
 
-        // Should be approximately 10% of i128::MAX (MAX_FEES = i128::MAX / 10)
+        // Should be approximately 5% of i128::MAX (MAX_FEES = i128::MAX / 20)
+        // and well below i128::MAX / 2 to prevent overflow during flush (#622)
         let max_i128 = i128::MAX;
         let ratio = (MAX_FEES as f64) / (max_i128 as f64);
-        assert!(ratio > 0.09 && ratio < 0.11); // Should be ~10%
+        assert!(ratio > 0.04 && ratio < 0.06); // Should be ~5%
+        // Safety margin: MAX_FEES must be less than half of i128::MAX
+        assert!(MAX_FEES < max_i128 / 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,6 +824,14 @@ impl SwiftRemitContract {
         // Transition to Processing state
         crate::transitions::transition_status(&env, &mut remittance, RemittanceStatus::Processing)?;
 
+        // Extend the remittance TTL when entering Processing so the escrow
+        // does not expire while the agent is completing the off-chain payout (#624).
+        crate::storage::extend_remittance_ttl(
+            &env,
+            remittance_id,
+            crate::config::PROCESSING_WINDOW_LEDGERS,
+        );
+
         // Verify recipient hash before any token transfer (Task 7.2)
         recipient_verification::verify_recipient_hash(
             &env,
@@ -941,8 +949,16 @@ impl SwiftRemitContract {
             return Err(ContractError::InvalidStatus);
         }
 
-        remittance.status = RemittanceStatus::Failed;
-        remittance.failed_at = Some(env.ledger().timestamp());
+        // Auto-refund the escrowed amount to the sender (#621)
+        let token_client = token::Client::new(&env, &remittance.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &remittance.sender,
+            &remittance.amount,
+        );
+
+        remittance.status = RemittanceStatus::Cancelled;
+        remittance.amount = 0;
         set_remittance(&env, remittance_id, &remittance);
 
         let mut stats = crate::storage::get_agent_stats(&env, &remittance.agent);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1953,3 +1953,16 @@ pub fn get_min_agent_reputation(env: &Env) -> u32 {
 pub fn set_min_agent_reputation(env: &Env, threshold: u32) {
     env.storage().instance().set(&DataKey::MinAgentReputation, &threshold);
 }
+
+// === Remittance TTL Extension (#624) ===
+
+/// Extends the persistent storage TTL for a remittance record by `ledgers`.
+///
+/// Called when a remittance transitions to Processing so the escrow entry
+/// does not expire before the agent completes the off-chain fiat payout.
+pub fn extend_remittance_ttl(env: &Env, remittance_id: u64, ledgers: u32) {
+    let key = DataKey::Remittance(remittance_id);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(&key, ledgers, ledgers);
+    }
+}


### PR DESCRIPTION
…nsion, README docs

mark_failed does not refund escrow to sender
Fixes #621

Overflow in fee accumulation not handled when accumulated_fees approaches i128::MAX Fixes #622

confirm_partial_payout missing from README contract functions list Fixes #623

Escrow TTL not extended when remittance transitions to Processing Fixes #624