### PR TITLE
fix: resolve issues #600 #601 #602 #603 — fee floor, batch limit, circuit breaker, README state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SwiftRemit is an escrow-based remittance system that enables secure cross-border
 - **Escrow-Based Transfers**: Secure USDC deposits held in contract until payout confirmation
 - **Agent Network**: Registered agents handle fiat distribution off-chain
 - **Automated Fee Collection**: Platform fees calculated and accumulated automatically
-- **Lifecycle State Management**: Remittances tracked through 4 states (Pending, Processing, Completed, Cancelled) with enforced transitions via a single canonical `RemittanceStatus` enum
+- **Lifecycle State Management**: Remittances tracked through 6 states (Pending, Processing, Completed, Cancelled, Failed, Disputed) with enforced transitions via a single canonical `RemittanceStatus` enum
 - **Authorization Security**: Role-based access control for all operations
 - **Event Emission**: Comprehensive event logging for off-chain monitoring
 - **Cancellation Support**: Senders can cancel pending remittances with full refund
@@ -401,19 +401,22 @@ All remittance lifecycle state is tracked by a single canonical `RemittanceStatu
 │ Pending │  ← initial state (funds locked in escrow)
 └────┬────┘
      │
-     ├──────────────────────┐
-     │                      │
-     ▼                      ▼
-┌────────────┐        ┌───────────┐
-│ Processing │        │ Cancelled │ (Terminal)
-└─────┬──────┘        └───────────┘
-      │                      ▲
-      ├──────────────────────┤
-      │                      │
-      ▼                      │
-┌───────────┐                │
-│ Completed │ (Terminal)     │
-└───────────┘                │
+     ├──────────────────────┬──────────────────────┐
+     │                      │                      │
+     ▼                      ▼                      ▼
+┌────────────┐        ┌───────────┐          ┌────────┐
+│ Processing │        │ Cancelled │(Terminal) │ Failed │
+└─────┬──────┘        └───────────┘          └───┬────┘
+      │                      ▲                   │
+      ├──────────────────────┤                   │
+      │                      │                   ▼
+      ▼                      │            ┌──────────┐
+┌───────────┐                │            │ Disputed │
+│ Completed │(Terminal)      │            └────┬─────┘
+└───────────┘                │                 │
+                             │    Cancelled ◄──┤
+                             │                 │
+                             └──── Completed ◄─┘
 ```
 
 ### Valid Transitions
@@ -421,11 +424,16 @@ All remittance lifecycle state is tracked by a single canonical `RemittanceStatu
 | From       | To         | Trigger                        |
 |------------|------------|--------------------------------|
 | Pending    | Processing | Contract enters processing during `confirm_payout` |
-| Pending    | Cancelled  | Sender calls `cancel_remittance` |
+| Pending    | Cancelled  | Sender calls `cancel_remittance` or expiry processed |
+| Pending    | Failed     | Agent calls `mark_failed` |
 | Processing | Completed  | `confirm_payout` completes successfully and releases USDC |
-| Processing | Cancelled  | Documented internal failure/refund path; no separate public `mark_failed` entrypoint |
+| Processing | Cancelled  | Expiry or internal failure/refund path |
+| Processing | Failed     | Agent calls `mark_failed` |
+| Failed     | Disputed   | Sender calls `raise_dispute` within dispute window |
+| Disputed   | Cancelled  | Admin calls `resolve_dispute` in favour of sender |
+| Disputed   | Completed  | Admin calls `resolve_dispute` in favour of agent |
 
-Terminal states (`Completed`, `Cancelled`) cannot transition further.
+Terminal states (`Completed`, `Cancelled`) cannot transition further. `Failed` and `Disputed` are transient — further transitions are permitted from both.
 
 
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -255,6 +255,7 @@ pub enum ContractError {
     InvalidOracleAddress = 53,
 
     /// Contract is already paused.
+    /// Cause: Calling emergency_pause when the contract is already in paused state.
     AlreadyPaused = 54,
 
     /// Contract is not currently paused.

--- a/src/fee_service.rs
+++ b/src/fee_service.rs
@@ -371,8 +371,7 @@ fn calculate_fee_by_strategy(amount: i128, strategy: &FeeStrategy) -> Result<i12
             Ok(fee.max(MIN_FEE))
         }
         FeeStrategy::Flat(fee_amount) => {
-            // Fixed fee regardless of amount
-            Ok(*fee_amount)
+            Ok((*fee_amount).max(MIN_FEE))
         }
         FeeStrategy::Dynamic(base_fee_bps) => {
             // Dynamic tiered fee: decreases for larger amounts
@@ -496,6 +495,14 @@ mod tests {
 
         let fee = calculate_fee_by_strategy(amount, &strategy).unwrap();
         assert_eq!(fee, 100);
+    }
+
+    #[test]
+    fn test_calculate_fee_flat_zero_applies_min_fee_floor() {
+        // A Flat(0) fee must still return at least MIN_FEE (1 stroop)
+        let strategy = FeeStrategy::Flat(0);
+        let fee = calculate_fee_by_strategy(1_000, &strategy).unwrap();
+        assert_eq!(fee, MIN_FEE);
     }
 
     #[test]

--- a/src/test_features_589_592.rs
+++ b/src/test_features_589_592.rs
@@ -108,6 +108,33 @@ fn remit(f: &F, amount: i128) -> u64 {
     assert_eq!(f.c.get_remittance(&ids.get(1).unwrap()).status, crate::RemittanceStatus::Completed);
 }
 
+// ── #602 process_expired_remittances batch size limit ────────────────────────
+
+#[test] fn test_602_process_expired_remittances_over_limit_rejected() {
+    let f = setup();
+    // Build a Vec of 51 dummy IDs — all non-existent, so none would be processed
+    // even if the size check were not present. The enforcement must fire first.
+    let mut ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&f.env);
+    for i in 0..51u64 {
+        ids.push_back(i);
+    }
+    assert_eq!(
+        f.c.try_process_expired_remittances(&ids),
+        Err(Ok(ContractError::InvalidBatchSize)),
+    );
+}
+
+#[test] fn test_602_process_expired_remittances_at_limit_allowed() {
+    let f = setup();
+    // Exactly 50 IDs is within the limit; all are non-existent so returns empty Vec.
+    let mut ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&f.env);
+    for i in 0..50u64 {
+        ids.push_back(i);
+    }
+    let processed = f.c.process_expired_remittances(&ids);
+    assert_eq!(processed.len(), 0);
+}
+
 // ── #591 Agent reputation ─────────────────────────────────────────────────────
 
 #[test] fn test_591_new_agent_max_reputation() {
@@ -134,6 +161,19 @@ fn remit(f: &F, amount: i128) -> u64 {
     // New agent has reputation 100, should pass
     let r = f.c.try_create_remittance(&f.sender, &f.agent, &1_000, &None, &None, &None, &None, &None);
     assert!(r.is_ok());
+}
+
+// ── #601 AlreadyPaused circuit-breaker error ─────────────────────────────────
+
+#[test] fn test_601_emergency_pause_already_paused_returns_already_paused() {
+    let f = setup();
+    // First pause succeeds
+    f.c.emergency_pause(&f.admin, &crate::PauseReason::MaintenanceWindow);
+    // Second pause on an already-paused contract must return AlreadyPaused
+    assert_eq!(
+        f.c.try_emergency_pause(&f.admin, &crate::PauseReason::SecurityIncident),
+        Err(Ok(ContractError::AlreadyPaused)),
+    );
 }
 
 // ── #592 Dispute resolution ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#603** — Applied `MIN_FEE` floor to `FeeStrategy::Flat` branch in `fee_service.rs`; all strategy paths now consistently enforce the minimum fee. Added `test_calculate_fee_flat_zero_applies_min_fee_floor`.
- **#602** — Confirmed `process_expired_remittances` already enforces `MAX_EXPIRED_BATCH_SIZE` (50) at `lib.rs:1240`. Added two tests: >50 IDs returns `ContractError::InvalidBatchSize`, exactly 50 IDs is accepted.
- **#601** — `ContractError::AlreadyPaused = 54` was already defined in `errors.rs`; added a cause doc-comment and a test that exercises the double-pause code path in `circuit_breaker.rs`.
- **#600** — Updated `README.md` state machine diagram from 4 states to all 6 (`Pending`, `Processing`, `Completed`, `Cancelled`, `Failed`, `Disputed`), with the complete valid-transitions table including the dispute flow.

## Test plan

- [ ] `cargo test` passes for all non-feature-gated tests (dispute, features-589-592)
- [ ] `test_calculate_fee_flat_zero_applies_min_fee_floor` passes — Flat(0) returns MIN_FEE
- [ ] `test_602_process_expired_remittances_over_limit_rejected` passes — 51 IDs → `InvalidBatchSize`
- [ ] `test_602_process_expired_remittances_at_limit_allowed` passes — 50 IDs → empty result
- [ ] `test_601_emergency_pause_already_paused_returns_already_paused` passes — double pause → `AlreadyPaused`
- [ ] README state machine diagram visually reflects 6 states and all valid transitions

closes #603
closes #602
closes #601
closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)