### PR TITLE
fix: SEP-24 retry, webhook HTTPS enforcement, audit-log index, and state-transition guard (#633 #634 #635 #636)

### DIFF
--- a/backend/migrations/add_admin_audit_log_purge_index.sql
+++ b/backend/migrations/add_admin_audit_log_purge_index.sql
@@ -1,0 +1,7 @@
+-- Migration: add_admin_audit_log_purge_index
+-- Adds a dedicated index on admin_audit_log(created_at) to support efficient
+-- purge operations (DELETE WHERE created_at < cutoff) without a full table scan.
+-- Idempotent: IF NOT EXISTS guard makes it safe to run on existing databases.
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created_at
+  ON admin_audit_log(created_at);

--- a/backend/src/sep24-service.ts
+++ b/backend/src/sep24-service.ts
@@ -473,32 +473,65 @@ export class Sep24Service {
   }
 
   /**
-   * Query transaction status from anchor
+   * Exponential backoff with ±10% jitter, capped at 16 s.
+   */
+  private calcBackoff(attempt: number): number {
+    const BASE_MS = 1000;
+    const MAX_MS = 16000;
+    const exponential = BASE_MS * Math.pow(2, attempt - 1);
+    const capped = Math.min(exponential, MAX_MS);
+    const jitter = capped * 0.1 * (Math.random() * 2 - 1);
+    return Math.round(capped + jitter);
+  }
+
+  /**
+   * Query transaction status from anchor with exponential backoff retry for
+   * transient errors (network failures and 5xx responses). 404 is treated as
+   * "not found" and returned immediately without retrying. 4xx client errors
+   * (other than 429) are also not retried.
    */
   private async queryTransactionStatus(
     sepServerUrl: string,
-    transactionId: string
+    transactionId: string,
+    maxRetries = 3
   ): Promise<Sep24TransactionStatusResponse | null> {
-    try {
-      const url = `${sepServerUrl}/transaction?id=${transactionId}`;
-      
-      const response: AxiosResponse<Sep24TransactionStatusResponse> = await this.httpClient.get(url, {
-        headers: {
-          'Accept': 'application/json',
-        },
-        timeout: 10000,
-      });
+    const url = `${sepServerUrl}/transaction?id=${transactionId}`;
 
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.response?.status === 404) {
-          return null;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const response: AxiosResponse<Sep24TransactionStatusResponse> = await this.httpClient.get(url, {
+          headers: { 'Accept': 'application/json' },
+          timeout: 10000,
+        });
+        return response.data;
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          const status = error.response?.status;
+
+          if (status === 404) {
+            return null;
+          }
+
+          // Non-transient 4xx errors (except 429 Too Many Requests) — do not retry
+          if (status && status >= 400 && status < 500 && status !== 429) {
+            console.error(`HTTP ${status} querying transaction ${transactionId}; not retrying`);
+            return null;
+          }
         }
-        console.error(`HTTP error querying transaction status: ${error.response?.status}`);
+
+        if (attempt < maxRetries) {
+          const delay = this.calcBackoff(attempt);
+          console.warn(
+            `Transient error polling transaction ${transactionId} (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms`
+          );
+          await new Promise(resolve => setTimeout(resolve, delay));
+        } else {
+          console.error(`Failed to query transaction ${transactionId} after ${maxRetries} attempts:`, error);
+        }
       }
-      return null;
     }
+
+    return null;
   }
 
   /**

--- a/backend/src/transaction-state.ts
+++ b/backend/src/transaction-state.ts
@@ -45,9 +45,27 @@ export class TransactionStateManager {
     kind: TransactionKind
   ): Promise<void> {
     const client = await this.pool.connect();
-    
+
     try {
       await client.query('BEGIN');
+
+      // Fetch the current status and lock the row to prevent concurrent updates
+      const current = await client.query<{ status: TransactionStatus }>(
+        'SELECT status FROM transactions WHERE transaction_id = $1 AND kind = $2 FOR UPDATE',
+        [update.transaction_id, kind]
+      );
+
+      if (current.rows.length === 0) {
+        throw new Error(`Transaction ${update.transaction_id} not found`);
+      }
+
+      const currentStatus = current.rows[0].status;
+      if (!this.validateTransition(currentStatus, update.status, kind)) {
+        throw new Error(
+          `Invalid state transition: '${currentStatus}' → '${update.status}' ` +
+          `for ${kind} transaction ${update.transaction_id}`
+        );
+      }
 
       // Update transaction record
       await client.query(

--- a/backend/src/webhook-dispatcher.ts
+++ b/backend/src/webhook-dispatcher.ts
@@ -45,10 +45,18 @@ export class WebhookDispatcher {
     }
   }
 
+  private validateUrl(url: string): void {
+    if (!url.startsWith('https://')) {
+      throw new Error(`Webhook delivery rejected: URL must use HTTPS (received: ${url})`);
+    }
+  }
+
   private async attemptDelivery(delivery: WebhookDelivery): Promise<void> {
     const nextAttempt = delivery.attempt_count + 1;
 
     try {
+      this.validateUrl(delivery.target_url);
+
       const response = await this.fetchImpl(delivery.target_url, {
         method: 'POST',
         headers: {

--- a/backend/src/webhooks/dispatcher.ts
+++ b/backend/src/webhooks/dispatcher.ts
@@ -145,6 +145,13 @@ export class WebhookDispatcher {
     deliveryRecord?: Partial<WebhookDeliveryRecord>,
     contentType: string = 'application/json'
   ): Promise<boolean> {
+    if (!url.startsWith('https://')) {
+      const msg = `Webhook delivery rejected: URL must use HTTPS (received: ${url})`;
+      this.logger.error(msg);
+      await this.store.updateDeliveryStatus(deliveryId, 'failed', attempt, msg);
+      return false;
+    }
+
     try {
       const isFormEncoded = contentType === 'application/x-www-form-urlencoded';
       const serialized = isFormEncoded

--- a/backend/src/webhooks/service.ts
+++ b/backend/src/webhooks/service.ts
@@ -45,6 +45,10 @@ export class WebhookService {
       throw new Error('Webhook URL is required');
     }
 
+    if (!request.url.startsWith('https://')) {
+      throw new Error('Webhook URL must use HTTPS');
+    }
+
     if (!request.events || request.events.length === 0) {
       throw new Error('At least one event must be subscribed');
     }


### PR DESCRIPTION
## Summary

Batch fix for four Stellar Wave issues. Each change is isolated to its own file and is independently safe to review.

---

### #633 — `Sep24Service` does not retry on transient network errors during polling

**File:** `backend/src/sep24-service.ts`

`queryTransactionStatus` previously made a single HTTP call and silently returned `null` on any error, causing a transaction to appear stalled after the first network hiccup.

**Fix:**
- Added a private `calcBackoff(attempt)` helper (mirrors `KycService.calcBackoff`) that implements exponential backoff with ±10% jitter, capped at 16 s.
- `queryTransactionStatus` now retries up to 3 times on transient failures (network errors, 5xx, 429).
- 404 ("transaction not found") and non-transient 4xx errors short-circuit immediately — no wasted retries.

```
attempt 1 → fail → wait ~1 s
attempt 2 → fail → wait ~2 s
attempt 3 → fail → return null (logged as error)
```

---

### #634 — `WebhookDispatcher` does not validate webhook URL scheme before delivery

**Files:** `backend/src/webhook-dispatcher.ts`, `backend/src/webhooks/dispatcher.ts`, `backend/src/webhooks/service.ts`

Webhook payloads could be sent over plain HTTP, exposing sensitive event data in transit.

**Fix:**
- **Registration gate** (`WebhookService.registerWebhook`): rejects any URL that does not start with `https://` before it ever reaches the store.
- **Delivery gate** (`WebhookDispatcher.attemptDelivery` — both implementations): validates the URL immediately before `fetch`/`axios.post`. A non-HTTPS URL marks the delivery as `failed` and logs a clear error rather than silently delivering over HTTP.

Both layers are required: the registration gate prevents persistence of insecure URLs, and the delivery gate provides defence-in-depth for URLs already in the store (e.g. migrated from an older schema).

---

### #635 — `purgeOlderThan` causes a full table scan on `admin_audit_log`

**File:** `backend/migrations/add_admin_audit_log_purge_index.sql` *(new)*

`AdminAuditLogService.purgeOlderThan` runs `DELETE FROM admin_audit_log WHERE created_at < NOW() - interval` on potentially millions of rows. Without an index on `created_at` Postgres performs a sequential scan.

**Fix:**
- New idempotent migration adds `idx_admin_audit_log_created_at ON admin_audit_log(created_at)`.
- Uses `CREATE INDEX IF NOT EXISTS` — safe to run on any existing database regardless of prior migration state.
- No application-code changes required; the query planner picks up the index automatically.

---

### #636 — `TransactionStateManager.updateTransactionState` does not validate state transitions

**File:** `backend/src/transaction-state.ts`

The existing `validateTransition` method was defined but never called from `updateTransactionState`, meaning any caller (webhook handler, polling loop, manual admin action) could persist an illegal transition such as `completed → pending_anchor`, corrupting the transaction record.

**Fix:**
- `updateTransactionState` now fetches the current row with `SELECT … FOR UPDATE` inside the open transaction (preventing concurrent race conditions).
- Throws immediately with a descriptive message if `validateTransition` returns `false`, and rolls back via the existing `ROLLBACK` in the catch block.
- If the transaction row is not found, also throws — preventing silent no-ops.

Existing `validateTransition` unit tests continue to pass unchanged; the method's logic is unmodified.

---

## Test plan

- [x] `transaction-state.test.ts` — all 5 existing `validateTransition` tests pass (valid/invalid deposit & withdrawal transitions, error recovery)
- [x] `webhook-dispatcher.test.ts` — both existing dispatcher tests pass (success path, retry/failure path)
- [x] No regressions in `repositories.test.ts` or `sanitizer.test.ts`
- [ ] Manual: attempt to register a webhook with `http://` URL → expect `400` with "must use HTTPS"
- [ ] Manual: initiate a SEP-24 flow against an anchor that returns 503 → observe retry log lines and eventual graceful failure after 3 attempts
- [ ] Manual: run `purgeOlderThan` migration on staging DB, confirm `EXPLAIN` shows index scan on `admin_audit_log`
- [ ] Manual: attempt a `completed → pending_anchor` update via the webhook handler → expect the request to fail with a transition error and the DB row to remain unchanged

Closes #633
Closes #634
Closes #635
Closes #636

