### PR TITLE
fix: toast auto-dismiss, dispute tx hash, test-utils export, address validation

### DIFF
--- a/api/src/routes/settlements.ts
+++ b/api/src/routes/settlements.ts
@@ -138,6 +138,7 @@ router.post('/simulate', (req: Request, res: Response) => {
   }
 
   // Basic input validation
+  const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
   for (const r of remittances) {
     if (
       typeof r !== 'object' ||
@@ -151,6 +152,18 @@ router.post('/simulate', (req: Request, res: Response) => {
         success: false,
         error: {
           message: 'Each remittance must have sender, agent (strings) and amount, fee (numbers)',
+          code: 'INVALID_INPUT',
+        },
+        timestamp: new Date().toISOString(),
+      };
+      return res.status(400).json(err);
+    }
+    const item = r as SimulateRemittanceInput;
+    if (!STELLAR_ADDRESS_RE.test(item.sender) || !STELLAR_ADDRESS_RE.test(item.agent)) {
+      const err: ErrorResponse = {
+        success: false,
+        error: {
+          message: 'sender and agent must be valid Stellar addresses (G... 56 characters)',
           code: 'INVALID_INPUT',
         },
         timestamp: new Date().toISOString(),

--- a/frontend/src/components/DisputeResolution.tsx
+++ b/frontend/src/components/DisputeResolution.tsx
@@ -72,6 +72,7 @@ export default function DisputeResolution() {
   const [auditLog, setAuditLog] = useState<AuditLogItem[]>([]);
   const [resolving, setResolving] = useState<string | number | null>(null);
   const [confirmOpen, setConfirmOpen] = useState<ConfirmState | null>(null);
+  const [resolvedTxHash, setResolvedTxHash] = useState<string | null>(null);
 
   useEffect(() => {
     void fetchDisputes();
@@ -122,6 +123,7 @@ export default function DisputeResolution() {
     setConfirmOpen(null);
     setResolving(id);
     setError(null);
+    setResolvedTxHash(null);
     try {
       const res = await fetch(`${API_URL}/api/disputes/${id}/resolve`, {
         method: 'POST',
@@ -129,6 +131,9 @@ export default function DisputeResolution() {
         body: JSON.stringify({ in_favour_of_sender: inFavourOfSender }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json() as Record<string, unknown>;
+      const txHash = typeof data.tx_hash === 'string' ? data.tx_hash : null;
+      setResolvedTxHash(txHash);
       await fetchDisputes();
       await fetchAuditLog();
     } catch (e: unknown) {
@@ -143,6 +148,21 @@ export default function DisputeResolution() {
       <h2>Dispute Resolution</h2>
 
       {error && <div className="error" role="alert">{error}</div>}
+
+      {resolvedTxHash && (
+        <div role="status" style={{ background: '#f0fff4', border: '1px solid #9ae6b4', borderRadius: '8px', padding: '12px 16px', marginBottom: '16px', fontSize: '0.85rem' }}>
+          ✅ Dispute resolved on-chain.{' '}
+          <strong>Tx:</strong>{' '}
+          <a
+            href={`https://stellar.expert/explorer/public/tx/${resolvedTxHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ wordBreak: 'break-all' }}
+          >
+            {resolvedTxHash}
+          </a>
+        </div>
+      )}
 
       {confirmOpen && (
         <div

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+
 import './Toast.css';
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
@@ -22,19 +23,45 @@ interface ToastItemProps {
   onDismiss: (id: string) => void;
 }
 
+const DEFAULT_DURATION: Record<ToastType, number> = {
+  error: 5000,
+  success: 3000,
+  info: 4000,
+  warning: 4000,
+};
+
 function ToastItem({ toast, onDismiss }: ToastItemProps) {
-  const duration = toast.duration ?? 4000;
+  const duration = toast.duration ?? DEFAULT_DURATION[toast.type];
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef(duration);
+  const startRef = useRef<number>(0);
+
+  const startTimer = useCallback(() => {
+    if (duration <= 0) return;
+    startRef.current = Date.now();
+    timerRef.current = setTimeout(() => onDismiss(toast.id), remainingRef.current);
+  }, [duration, toast.id, onDismiss]);
+
+  const pauseTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      remainingRef.current -= Date.now() - startRef.current;
+    }
+  }, []);
 
   useEffect(() => {
-    if (duration > 0) {
-      timerRef.current = setTimeout(() => onDismiss(toast.id), duration);
-    }
+    startTimer();
     return () => { if (timerRef.current) clearTimeout(timerRef.current); };
-  }, [toast.id, duration, onDismiss]);
+  }, [startTimer]);
 
   return (
-    <div className={`toast ${toast.type}`} role="alert" aria-live="polite">
+    <div
+      className={`toast ${toast.type}`}
+      role="alert"
+      aria-live="polite"
+      onMouseEnter={pauseTimer}
+      onMouseLeave={startTimer}
+    >
       <span className="toast-icon" aria-hidden="true">{ICONS[toast.type]}</span>
       <span className="toast-message">{toast.message}</span>
       <button

--- a/sdk/src/governance.test.ts
+++ b/sdk/src/governance.test.ts
@@ -1,24 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parseProposal } from "../src/convert.js";
 import type { Proposal } from "../src/types.js";
-import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function makeProposalScVal(overrides: Record<string, unknown> = {}): xdr.ScVal {
-  const base = {
-    id: 1,
-    proposer: "GABC",
-    action: { UpdateFee: 300 },
-    state: { Pending: {} },
-    created_at: 1000,
-    expiry: 2000,
-    approval_count: 1,
-    approval_timestamp: null,
-    ...overrides,
-  };
-  return nativeToScVal(base);
-}
+import { makeProposalScVal } from "../src/test-utils.js";
 
 // ─── parseProposal ────────────────────────────────────────────────────────────
 

--- a/sdk/src/test-utils.ts
+++ b/sdk/src/test-utils.ts
@@ -1,0 +1,16 @@
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+
+export function makeProposalScVal(overrides: Record<string, unknown> = {}): xdr.ScVal {
+  const base = {
+    id: 1,
+    proposer: "GABC",
+    action: { UpdateFee: 300 },
+    state: { Pending: {} },
+    created_at: 1000,
+    expiry: 2000,
+    approval_count: 1,
+    approval_timestamp: null,
+    ...overrides,
+  };
+  return nativeToScVal(base);
+}


### PR DESCRIPTION
## Summary

Fixes four independent issues across the frontend, SDK, and API.

closes #685 — Toast auto-dismiss for error toasts
- Added `DEFAULT_DURATION` map: `error=5000ms`, `success=3000ms`, `info/warning=4000ms`
- `ToastItem` now uses the type-based default when no explicit `duration` is passed
- Added pause-on-hover: `onMouseEnter` pauses the timer and records remaining time; `onMouseLeave` restarts from where it left off

closes #686 — DisputeResolution shows transaction hash after resolution
- `confirmResolve()` now reads `tx_hash` from the resolve API response
- A success banner with a [Stellar Expert](https://stellar.expert) link is displayed after a successful resolution

closes #687 — `makeProposalScVal` moved to shared test utilities
- Created `sdk/src/test-utils.ts` with the exported `makeProposalScVal` helper
- `governance.test.ts` now imports it from `../src/test-utils.js` instead of defining it locally

closes #688 — Stellar address validation in settlements route
- Added `STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/` regex
- Applied to `sender` and `agent` fields in the per-item validation loop before net settlement processing

## Testing
- All changes are minimal and targeted; no new dependencies introduced
- Existing tests continue to pass; `governance.test.ts` now uses the shared utility
