### PR TITLE
fix(#683): trap keyboard focus within AnchorSelector dropdown

### DIFF
--- a/frontend/src/components/AnchorSelector.tsx
+++ b/frontend/src/components/AnchorSelector.tsx
@@ -162,9 +162,14 @@ export const AnchorSelector: React.FC<AnchorSelectorProps> = ({
         triggerRef.current?.focus();
         break;
       case 'Tab':
-        // Close on tab and allow default behavior
-        setIsOpen(false);
-        setFocusedIndex(-1);
+        // Trap focus: cycle through options instead of leaving the dropdown
+        e.preventDefault();
+        if (anchors.length === 0) break;
+        if (e.shiftKey) {
+          setFocusedIndex(prev => (prev > 0 ? prev - 1 : anchors.length - 1));
+        } else {
+          setFocusedIndex(prev => (prev < anchors.length - 1 ? prev + 1 : 0));
+        }
         break;
     }
   }, [isOpen, focusedIndex, anchors, selectedAnchor]);


### PR DESCRIPTION
## Summary
Closes #683

## Changes
- `Tab` key now cycles focus forward through dropdown options (`e.preventDefault()`)
- `Shift+Tab` cycles focus backward
- Focus no longer escapes the open dropdown; `Escape` still closes it and returns focus to the trigger