### PR TITLE
fix: resolve security issues #697 #698 #699 #700

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -326,7 +326,81 @@ Recommended: run a scheduled job (weekly) to bump TTL on all active remittances 
 
 ---
 
-## 7. Escalation Contacts and SLA Targets
+## 7. Rotate ADMIN_SECRET_KEY (Service-Level Key)
+
+The `ADMIN_SECRET_KEY` environment variable holds the Stellar keypair used by `backend/src/stellar.ts` to sign Soroban transactions. Because it lives in an environment variable, a compromised key cannot be revoked without a service redeployment. Follow this procedure to rotate it safely.
+
+### Recommended: Use a Secrets Manager
+
+Store `ADMIN_SECRET_KEY` in **AWS Secrets Manager** or **HashiCorp Vault** instead of a plain environment variable. Both support automatic rotation and instant revocation without redeployment:
+
+- **AWS Secrets Manager**: create a secret of type `Other`, enable automatic rotation with a Lambda rotator, and inject the value at runtime via the AWS SDK or the ECS/EKS secrets injection mechanism.
+- **HashiCorp Vault**: use the `transit` or `kv-v2` secret engine; rotate with `vault kv put` and have the service read the secret at startup via the Vault Agent sidecar or SDK.
+
+### Manual Rotation Procedure
+
+**Step 1 — generate a new Stellar keypair:**
+
+```bash
+stellar keys generate new-admin --network mainnet
+stellar keys address new-admin   # note the new public key
+```
+
+**Step 2 — authorize the new key on-chain** (add it as an admin via governance; see Section 3):
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  propose \
+  --proposer $CURRENT_ADMIN_ADDRESS \
+  --action '{"AddAdmin": "<NEW_ADMIN_PUBLIC_KEY>"}'
+# vote and execute as described in Section 3
+```
+
+**Step 3 — update the secret in your secrets manager or deployment config:**
+
+```bash
+# AWS Secrets Manager example
+aws secretsmanager put-secret-value \
+  --secret-id swiftremit/admin-secret-key \
+  --secret-string '{"ADMIN_SECRET_KEY":"<new_secret_key>"}'
+```
+
+**Step 4 — redeploy or restart the backend service** so it picks up the new key.
+
+**Step 5 — revoke the old key on-chain** (RemoveAdmin via governance; see Section 3):
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  propose \
+  --proposer $NEW_ADMIN_ADDRESS \
+  --action '{"RemoveAdmin": "<OLD_ADMIN_PUBLIC_KEY>"}'
+# vote and execute as described in Section 3
+```
+
+**Step 6 — verify** the old key no longer has admin rights:
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_IDENTITY \
+  --network $NETWORK \
+  -- \
+  get_admin_count
+```
+
+Confirm the count reflects only the new key. Post a rotation notice in `#incidents` with the ledger sequence of the RemoveAdmin execution.
+
+---
+
+## 8. Escalation Contacts and SLA Targets
 
 | Severity | Definition | Response SLA | Resolution SLA | Escalation Path |
 |----------|-----------|-------------|----------------|-----------------|

--- a/api/src/schemas/requestValidation.ts
+++ b/api/src/schemas/requestValidation.ts
@@ -104,17 +104,30 @@ export const withdrawFeesSchema = Joi.object({
 }).unknown(false);
 
 /**
+ * Validate memo field (Stellar text memo: max 28 bytes per Stellar spec)
+ */
+export const memoSchema = Joi.string()
+  .max(28)
+  .optional()
+  .messages({
+    'string.max': 'memo must not exceed 28 characters (Stellar text memo limit)',
+  });
+
+/**
  * Remittance: Create remittance request validation
  */
 export const createRemittanceSchema = Joi.object({
   sender: stellarAddressSchema,
   agent: stellarAddressSchema,
   amount: positiveAmountSchema,
+  memo: memoSchema,
   token: Joi.string()
     .pattern(STELLAR_ADDRESS_PATTERN)
+    .max(56)
     .optional()
     .messages({
       'string.pattern.base': 'token must be a valid Stellar address if provided',
+      'string.max': 'token must not exceed 56 characters',
     }),
 }).unknown(false);
 

--- a/api/src/websocket/middleware/auth.ts
+++ b/api/src/websocket/middleware/auth.ts
@@ -30,12 +30,18 @@ declare module 'socket.io' {
 function extractToken(socket: Socket): string | null {
   const authToken = socket.handshake.auth?.token;
   if (typeof authToken === 'string' && authToken.length > 0) {
-    return authToken.replace(/^Bearer\s+/i, '');
+    if (authToken.toLowerCase().startsWith('bearer ')) {
+      return authToken.slice(7);
+    }
+    return authToken;
   }
 
   const queryToken = socket.handshake.query?.token;
   if (typeof queryToken === 'string' && queryToken.length > 0) {
-    return queryToken.replace(/^Bearer\s+/i, '');
+    if (queryToken.toLowerCase().startsWith('bearer ')) {
+      return queryToken.slice(7);
+    }
+    return queryToken;
   }
 
   return null;

--- a/backend/src/webhooks/service.ts
+++ b/backend/src/webhooks/service.ts
@@ -27,6 +27,8 @@ export interface WebhookRegistrationResponse {
   createdAt?: Date;
 }
 
+const MAX_WEBHOOKS_PER_ACCOUNT = 10;
+
 export class WebhookService {
   private store: IWebhookStore;
   private dispatcher: WebhookDispatcher;
@@ -67,6 +69,12 @@ export class WebhookService {
       if (!validEvents.includes(event)) {
         throw new Error(`Invalid event type: ${event}`);
       }
+    }
+
+    // Enforce maximum webhook count per account
+    const existing = await this.store.getAllWebhooks();
+    if (existing.length >= MAX_WEBHOOKS_PER_ACCOUNT) {
+      throw new Error(`Maximum webhook limit of ${MAX_WEBHOOKS_PER_ACCOUNT} webhooks per account reached`);
     }
 
     // Register in store


### PR DESCRIPTION
## Summary

This PR resolves four security and validation issues across the API and backend services.

---

### #697 — Bearer token case sensitivity in WebSocket auth middleware

**File:** `api/src/websocket/middleware/auth.ts`

The `extractToken` function previously stripped the `Bearer ` prefix using a case-insensitive regex (`/^Bearer\s+/i`). The fix replaces this with an explicit `toLowerCase().startsWith('bearer ')` check followed by a fixed-length `slice(7)`, making the case normalization unambiguous and matching the approach described in the issue.

```ts
// Before
return authToken.replace(/^Bearer\s+/i, '');

// After
if (authToken.toLowerCase().startsWith('bearer ')) {
  return authToken.slice(7);
}
return authToken;
```

Closes #697

---

### #698 — ADMIN_SECRET_KEY stored without rotation mechanism

**File:** `RUNBOOK.md`

Added a new **Section 7: Rotate ADMIN_SECRET_KEY (Service-Level Key)** covering:
- Recommendation to store `ADMIN_SECRET_KEY` in **AWS Secrets Manager** or **HashiCorp Vault** with automatic rotation instead of a plain environment variable.
- Step-by-step manual rotation procedure: generate new keypair → authorize new key on-chain via governance → update the secret → redeploy service → revoke old key on-chain → verify removal.

Closes #698

---

### #699 — No rate limiting on webhook registration endpoint

**File:** `backend/src/webhooks/service.ts`

Added a `MAX_WEBHOOKS_PER_ACCOUNT = 10` constant and enforced it inside `registerWebhook` before writing to the store. If the total registered webhook count is already at the limit, the method throws with a descriptive error, preventing an attacker from registering thousands of webhook URLs that would trigger mass outbound HTTP requests per event.

```ts
const existing = await this.store.getAllWebhooks();
if (existing.length >= MAX_WEBHOOKS_PER_ACCOUNT) {
  throw new Error(`Maximum webhook limit of ${MAX_WEBHOOKS_PER_ACCOUNT} webhooks per account reached`);
}
```

Closes #699

---

### #700 — No input length limits on string fields in request validation

**File:** `api/src/schemas/requestValidation.ts`

- Added `memoSchema` with `.max(28)` per the Stellar text memo specification (28-byte limit).
- Added `memo: memoSchema` to `createRemittanceSchema` so memo is validated at the schema layer.
- Added explicit `.max(56)` to the `token` field in `createRemittanceSchema` to complement the existing pattern constraint.

```ts
export const memoSchema = Joi.string()
  .max(28)
  .optional()
  .messages({
    'string.max': 'memo must not exceed 28 characters (Stellar text memo limit)',
  });
```

Closes #700

---

## Test plan
- [ ] WebSocket clients sending `bearer <token>`, `BEARER <token>`, and `Bearer <token>` all authenticate successfully
- [ ] Attempting to register an 11th webhook returns a 400/422 error with the limit message
- [ ] API requests with a `memo` longer than 28 characters are rejected with a validation error
- [ ] `ADMIN_SECRET_KEY` rotation runbook steps are verified in a staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)