### PR TITLE
fix: use context.with() for async span propagation in withSpan

### DIFF
--- a/backend/src/tracing.ts
+++ b/backend/src/tracing.ts
@@ -68,10 +68,11 @@ export async function withSpan<T>(
   attributes?: Record<string, string | number | boolean>
 ): Promise<T> {
   const tracer = getTracer();
-  return tracer.startActiveSpan(name, async (span) => {
-    if (attributes) {
-      span.setAttributes(attributes);
-    }
+  const span = tracer.startSpan(name);
+  if (attributes) {
+    span.setAttributes(attributes);
+  }
+  return context.with(trace.setSpan(context.active(), span), async () => {
     try {
       const result = await fn(span);
       span.setStatus({ code: SpanStatusCode.OK });


### PR DESCRIPTION
Closes #651

## Problem
`withSpan` in `tracing.ts` started a span but did not set it as the active context, so child spans created inside async callbacks were not correctly parented in the trace.

## Fix
Wrap the async callback with `context.with(trace.setSpan(context.active(), span), async () => { ... })` so the span is active for the duration of the async operation and all child spans are correctly parented.

**File changed:** `backend/src/tracing.ts`