### PR TITLE
fix: record KYC poll failures in DB, lazy-init Sep24Service, coalesce…

### DIFF
--- a/backend/migrations/add_anchor_poll_failures.down.sql
+++ b/backend/migrations/add_anchor_poll_failures.down.sql
@@ -1,0 +1,2 @@
+-- Rollback: add_anchor_poll_failures.sql
+DROP TABLE IF EXISTS anchor_poll_failures;

--- a/backend/migrations/add_anchor_poll_failures.sql
+++ b/backend/migrations/add_anchor_poll_failures.sql
@@ -1,0 +1,12 @@
+-- Migration: add_anchor_poll_failures.sql
+-- Records per-anchor KYC poll failures for monitoring and alerting
+
+CREATE TABLE IF NOT EXISTS anchor_poll_failures (
+  id          BIGSERIAL    PRIMARY KEY,
+  anchor_id   VARCHAR(255) NOT NULL,
+  error_message TEXT        NOT NULL,
+  failed_at   TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_anchor_poll_failures_anchor_id ON anchor_poll_failures(anchor_id);
+CREATE INDEX IF NOT EXISTS idx_anchor_poll_failures_failed_at ON anchor_poll_failures(failed_at);

--- a/backend/src/__tests__/kyc-service.test.ts
+++ b/backend/src/__tests__/kyc-service.test.ts
@@ -70,6 +70,7 @@ describe('KycService', () => {
 
       expect(getUsersNeedingKycCheck).toHaveBeenCalledWith('anchor-1', 60);
     });
+
   });
 
   describe('queryAnchorKycStatus', () => {

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -513,6 +513,20 @@ export async function getApprovedUsers(): Promise<DbUserKycStatus[]> {
   }));
 }
 
+export interface AnchorPollFailureRecord {
+  anchor_id: string;
+  error_message: string;
+  failed_at?: Date;
+}
+
+export async function saveAnchorPollFailure(failure: AnchorPollFailureRecord): Promise<void> {
+  await pool.query(
+    `INSERT INTO anchor_poll_failures (anchor_id, error_message, failed_at)
+     VALUES ($1, $2, $3)`,
+    [failure.anchor_id, failure.error_message, failure.failed_at ?? new Date()]
+  );
+}
+
 // ========== SEP-24 Transaction Functions ==========
 
 /**

--- a/backend/src/fx-rate-cache.ts
+++ b/backend/src/fx-rate-cache.ts
@@ -33,6 +33,7 @@ export class FxRateCache {
   private externalApiKey: string;
   private staleAgeWarningThresholdSeconds: number;
   private refreshTimers: Map<string, NodeJS.Timeout>;
+  private inflight: Map<string, Promise<FxRateResponse>>;
 
   constructor(options: FxRateCacheOptions = {}) {
     this.ttlSeconds = options.ttlSeconds || 60;
@@ -41,6 +42,7 @@ export class FxRateCache {
     this.externalApiKey = options.externalApiKey || process.env.FX_API_KEY || '';
     this.refreshTimers = new Map();
     this.staleCache = new Map();
+    this.inflight = new Map();
 
     this.cache = new NodeCache({
       stdTTL: this.ttlSeconds,
@@ -73,17 +75,21 @@ export class FxRateCache {
       return { ...cached, cached: true };
     }
 
-    // Cache miss - fetch from external API
+    // Cache miss - deduplicate concurrent requests for the same pair
+    if (!this.inflight.has(cacheKey)) {
+      const fetch = this.fetchFromExternalApi(fromUpper, toUpper).then(rate => {
+        this.cache.set(cacheKey, rate);
+        this.staleCache.set(cacheKey, rate);
+        this.scheduleBackgroundRefresh(cacheKey, fromUpper, toUpper);
+        return rate;
+      }).finally(() => {
+        this.inflight.delete(cacheKey);
+      });
+      this.inflight.set(cacheKey, fetch);
+    }
+
     try {
-      const rate = await this.fetchFromExternalApi(fromUpper, toUpper);
-
-      // Store in both live cache and stale fallback
-      this.cache.set(cacheKey, rate);
-      this.staleCache.set(cacheKey, rate);
-
-      // Schedule background refresh
-      this.scheduleBackgroundRefresh(cacheKey, fromUpper, toUpper);
-
+      const rate = await this.inflight.get(cacheKey)!;
       return { ...rate, cached: false };
     } catch (error) {
       // On 429, serve stale rate if available
@@ -238,6 +244,7 @@ export class FxRateCache {
     this.staleCache.clear();
     this.refreshTimers.forEach(timer => clearTimeout(timer));
     this.refreshTimers.clear();
+    this.inflight.clear();
   }
 
   /**

--- a/backend/src/kyc-service.ts
+++ b/backend/src/kyc-service.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { KycStatus, DbUserKycStatus, AnchorKycConfig } from './types';
-import { getAnchorKycConfigs, getUsersNeedingKycCheck, saveUserKycStatus, getApprovedUsers, getPool } from './database';
+import { getAnchorKycConfigs, getUsersNeedingKycCheck, saveUserKycStatus, getApprovedUsers, getPool, saveAnchorPollFailure } from './database';
 import { getMetricsService } from './metrics';
 import { updateKycStatusOnChain } from './stellar';
 
@@ -52,7 +52,9 @@ export class KycService {
         await this.pollAnchorKycStatus(anchorId, config);
       } catch (error) {
         this.metricsService.recordKycPollFailure();
+        const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(`Failed to poll KYC status for anchor ${anchorId}:`, error);
+        await saveAnchorPollFailure({ anchor_id: anchorId, error_message: errorMessage }).catch(() => {});
       }
     }
   }

--- a/backend/src/stellar.ts
+++ b/backend/src/stellar.ts
@@ -13,6 +13,13 @@ import { getStellarRuntimeConfig } from './stellar-network';
 const { rpcUrl, networkPassphrase } = getStellarRuntimeConfig();
 const server = new SorobanRpc.Server(rpcUrl);
 
+export async function getBaseFee(): Promise<string> {
+  const envFee = process.env.STELLAR_BASE_FEE;
+  if (envFee) return envFee;
+  const baseFee = await server.fetchBaseFee();
+  return String(baseFee);
+}
+
 export async function storeVerificationOnChain(
   verification: AssetVerification
 ): Promise<void> {
@@ -47,7 +54,7 @@ export async function storeVerificationOnChain(
 
   // Build transaction
   const tx = new TransactionBuilder(account, {
-    fee: '1000',
+    fee: await getBaseFee(),
     networkPassphrase,
   })
     .addOperation(
@@ -174,7 +181,7 @@ export async function cancelRemittanceOnChain(remittanceId: number): Promise<voi
   const account = await server.getAccount(adminKeypair.publicKey());
 
   const tx = new TransactionBuilder(account, {
-    fee: '1000',
+    fee: await getBaseFee(),
     networkPassphrase,
   })
     .addOperation(
@@ -234,7 +241,7 @@ export async function updateKycStatusOnChain(
 
   // Build transaction
   const tx = new TransactionBuilder(account, {
-    fee: '1000',
+    fee: await getBaseFee(),
     networkPassphrase,
   })
     .addOperation(

--- a/backend/src/webhook-handler.ts
+++ b/backend/src/webhook-handler.ts
@@ -24,6 +24,7 @@ export class WebhookHandler {
   private stateManager: TransactionStateManager;
   private kycUpsertService: KycUpsertService;
   private sep24Service: Sep24Service;
+  private sep24Initialized = false;
   private dispatcher: WebhookDispatcher;
 
   constructor(private pool: Pool) {
@@ -400,6 +401,10 @@ export class WebhookHandler {
    * Handle SEP-24 deposit/withdrawal update webhook
    */
   private async handleSep24Update(payload: any): Promise<void> {
+    if (!this.sep24Initialized) {
+      await this.sep24Service.initialize();
+      this.sep24Initialized = true;
+    }
     await this.sep24Service.handleWebhookNotification({
       transaction_id: payload.transaction_id,
       status: payload.status,


### PR DESCRIPTION
… FX cache misses, dynamic Stellar fee

KycService.pollAllAnchors swallows errors silently with console.error Fixes #629

WebhookHandler does not initialize Sep24Service before use Fixes #630

FxRateCache does not handle concurrent cache misses (thundering herd) Fixes #631

stellar.ts hardcodes fee as '1000' stroops for all transactions Fixes #632