### PR TITLE
chore: add dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: "/api"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: "/sdk"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies


### PR DESCRIPTION
## Description
Adds `.github/dependabot.yml` to enable automated weekly dependency update PRs for all package ecosystems in the repository.

## Changes
- Added `.github/dependabot.yml` with weekly update schedules for:
  - Cargo (Rust smart contract at root)
  - npm for `/backend`
  - npm for `/api`
  - npm for `/frontend`
  - npm for `/sdk`

## Related Issues
Closes #712

## Type of Change
- [x] Chore (dependency/tooling update)