### PR TITLE
fix(scheduler): add pg advisory locks to prevent duplicate job execution

### DIFF
--- a/backend/src/distributed-lock.ts
+++ b/backend/src/distributed-lock.ts
@@ -1,0 +1,47 @@
+import { Pool } from 'pg';
+
+/**
+ * Converts a string key to a stable 32-bit integer for use as a PostgreSQL
+ * advisory lock key. Uses a simple djb2-style hash.
+ */
+function keyToInt(key: string): number {
+  let h = 5381;
+  for (let i = 0; i < key.length; i++) {
+    h = ((h << 5) + h + key.charCodeAt(i)) >>> 0; // keep unsigned 32-bit
+  }
+  // pg_try_advisory_lock takes bigint; we use the value as-is (fits in int4 range via cast)
+  return h >>> 1; // ensure positive signed 32-bit
+}
+
+/**
+ * Acquires a session-level PostgreSQL advisory lock for the duration of `fn`.
+ * Uses pg_try_advisory_lock (non-blocking): if the lock is already held by
+ * another instance, `fn` is skipped for this run.
+ *
+ * @returns true if the job ran, false if it was skipped (lock not acquired).
+ */
+export async function withAdvisoryLock(
+  pool: Pool,
+  lockKey: string,
+  fn: () => Promise<void>,
+): Promise<boolean> {
+  const lockId = keyToInt(lockKey);
+  const client = await pool.connect();
+  try {
+    const { rows } = await client.query<{ acquired: boolean }>(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [lockId],
+    );
+    if (!rows[0].acquired) {
+      return false;
+    }
+    try {
+      await fn();
+    } finally {
+      await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
+    }
+    return true;
+  } finally {
+    client.release();
+  }
+}

--- a/backend/src/scheduler.ts
+++ b/backend/src/scheduler.ts
@@ -8,6 +8,7 @@ import { SorobanRpc, Keypair } from '@stellar/stellar-sdk';
 import { SwiftRemitClient } from '@swiftremit/sdk';
 import { KycExpiryNotifier } from './kyc-expiry-notifier';
 import { createWebhookStore } from './webhooks/store';
+import { withAdvisoryLock } from './distributed-lock';
 
 const verifier = new AssetVerifier();
 const kycService = new KycService();
@@ -23,32 +24,47 @@ export async function startBackgroundJobs() {
 
   // Run every 6 hours
   cron.schedule('0 */6 * * *', async () => {
-    console.log('Starting periodic asset revalidation...');
-    await revalidateStaleAssets();
+    const ran = await withAdvisoryLock(pool, 'revalidate-stale-assets', async () => {
+      console.log('Starting periodic asset revalidation...');
+      await revalidateStaleAssets();
+    });
+    if (!ran) console.log('revalidate-stale-assets: skipped (another instance holds the lock)');
   });
 
   // Run KYC polling every 30 minutes
   cron.schedule('*/30 * * * *', async () => {
-    console.log('Starting KYC status polling...');
-    await pollKycStatuses();
+    const ran = await withAdvisoryLock(pool, 'poll-kyc-statuses', async () => {
+      console.log('Starting KYC status polling...');
+      await pollKycStatuses();
+    });
+    if (!ran) console.log('poll-kyc-statuses: skipped (another instance holds the lock)');
   });
 
   // Run SEP-24 transaction polling every 2 minutes
   cron.schedule('*/2 * * * *', async () => {
-    console.log('Starting SEP-24 transaction polling...');
-    await pollSep24Transactions();
+    const ran = await withAdvisoryLock(pool, 'poll-sep24-transactions', async () => {
+      console.log('Starting SEP-24 transaction polling...');
+      await pollSep24Transactions();
+    });
+    if (!ran) console.log('poll-sep24-transactions: skipped (another instance holds the lock)');
   });
 
   // Extend contract storage TTLs daily to prevent data loss
   cron.schedule('0 0 * * *', async () => {
-    console.log('Starting contract storage TTL extension...');
-    await extendContractStorageTtl();
+    const ran = await withAdvisoryLock(pool, 'extend-contract-storage-ttl', async () => {
+      console.log('Starting contract storage TTL extension...');
+      await extendContractStorageTtl();
+    });
+    if (!ran) console.log('extend-contract-storage-ttl: skipped (another instance holds the lock)');
   });
 
   // Send KYC expiry warnings daily at 08:00 UTC
   cron.schedule('0 8 * * *', async () => {
-    console.log('Starting KYC expiry notification job...');
-    await notifyKycExpiries();
+    const ran = await withAdvisoryLock(pool, 'notify-kyc-expiries', async () => {
+      console.log('Starting KYC expiry notification job...');
+      await notifyKycExpiries();
+    });
+    if (!ran) console.log('notify-kyc-expiries: skipped (another instance holds the lock)');
   });
 
   console.log('Background jobs scheduled');


### PR DESCRIPTION
Fixes #640

## Changes
- Add `backend/src/distributed-lock.ts` — `withAdvisoryLock(pool, key, fn)` helper using `pg_try_advisory_lock` (non-blocking; skips the run if another instance holds the lock, releases on completion)
- Wrap all five cron jobs in `scheduler.ts` with the distributed lock

## How it works
Each job is assigned a stable string key (e.g. `poll-kyc-statuses`), hashed to a 32-bit int via djb2, and passed to `pg_try_advisory_lock`. Only one instance acquires the lock per run; others log a skip message and exit immediately. The lock is always released in a `finally` block.

Closes #654 
Closes #641 
Closes #649 