### PR TITLE
feat: resolve issues #843 #844 #845 #846

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,25 @@ backend/node_modules/
 # Test artifacts
 test_snapshots/
 proptest-regressions/
+
+# IDE and editor files
+.idea/
+*.swp
+*.swo
+*~
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Coverage output
+backend/coverage/
+frontend/coverage/
+
+# Local env overrides (beyond .env)
+.env.local
+.env.*.local
+
+# Scratch / temp files
+*.tmp
+*.bak

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -238,3 +238,59 @@ Update off-chain services to point to `<DEST_CONTRACT_ID>`.
   writes.  The snapshot is cleared only after successful validation.
 - The source contract stays locked until you explicitly clear the flag (or
   redeploy), preventing new state from being created after the snapshot.
+
+---
+
+## Post-Upgrade Hash Verification (#846)
+
+After any upgrade, verify that payout commitment hashes are unchanged to confirm
+no state corruption occurred during the WASM swap or migration step.
+
+### Automated (unit tests — no network required)
+
+```bash
+cargo test test_migrate_preserves_commitment_hashes -- --nocapture
+```
+
+This test:
+1. Creates remittances and records their commitment hashes.
+2. Runs `migration::migrate()` directly.
+3. Re-fetches each hash and asserts byte-for-byte equality.
+
+### Manual (testnet)
+
+For every in-flight remittance ID known prior to the upgrade:
+
+```bash
+# Before upgrade — save to file
+soroban contract invoke --id <CONTRACT_ID> \
+  -- get_settlement_hash --remittance_id <ID> > hash_before_$ID.json
+
+# After upgrade + migrate — compare
+soroban contract invoke --id <CONTRACT_ID> \
+  -- get_settlement_hash --remittance_id <ID> > hash_after_$ID.json
+
+diff hash_before_$ID.json hash_after_$ID.json
+```
+
+A non-empty diff means state corruption — initiate rollback immediately.
+
+### Post-Unpause Cooldown
+
+After calling `emergency_unpause`, the contract automatically enters a 1-hour
+cooldown window during which per-sender rate limits are halved.  The default
+period is configurable:
+
+```bash
+# Set cooldown to 30 minutes (admin required)
+soroban contract invoke --id <CONTRACT_ID> \
+  -- set_cooldown_period \
+  --caller <ADMIN_ADDRESS> \
+  --seconds 1800
+
+# Check current cooldown and last-unpause timestamp
+soroban contract invoke --id <CONTRACT_ID> -- get_circuit_breaker_status
+```
+
+The cooldown period can also be changed via governance proposal
+(`UpdateCooldownPeriod` action) without requiring a contract upgrade.

--- a/backend/migrations/add_fee_breakdown_to_contract_events.down.sql
+++ b/backend/migrations/add_fee_breakdown_to_contract_events.down.sql
@@ -1,0 +1,6 @@
+-- Rollback: remove fee breakdown columns from contract_events (#844)
+
+ALTER TABLE contract_events
+  DROP COLUMN IF EXISTS platform_fee,
+  DROP COLUMN IF EXISTS protocol_fee,
+  DROP COLUMN IF EXISTS net_amount;

--- a/backend/migrations/add_fee_breakdown_to_contract_events.sql
+++ b/backend/migrations/add_fee_breakdown_to_contract_events.sql
@@ -1,0 +1,8 @@
+-- Migration: add fee breakdown columns to contract_events (#844)
+-- Adds platform_fee, protocol_fee, and net_amount so analytics can query
+-- the full fee split without re-deriving it from on-chain config.
+
+ALTER TABLE contract_events
+  ADD COLUMN IF NOT EXISTS platform_fee NUMERIC(30, 7),
+  ADD COLUMN IF NOT EXISTS protocol_fee NUMERIC(30, 7),
+  ADD COLUMN IF NOT EXISTS net_amount   NUMERIC(30, 7);

--- a/backend/src/__tests__/webhook-handler-remittance.test.ts
+++ b/backend/src/__tests__/webhook-handler-remittance.test.ts
@@ -20,24 +20,44 @@ vi.mock('../database', () => ({
 import { WebhookHandler } from '../webhook-handler';
 
 function buildMockPool(secret: string): Pool {
-  return {
-    query: vi.fn(async (sql: string) => {
-      const normalized = sql.toUpperCase();
-      if (normalized.includes('FROM ANCHORS')) {
-        return { rows: [{ public_key: null, webhook_secret: secret }] } as any;
-      }
-      if (normalized.includes('INSERT INTO WEBHOOK_LOGS')) {
-        return { rows: [{ id: 'wh-log-1' }] } as any;
-      }
-      if (normalized.includes('FROM WEBHOOK_LOGS')) {
-        return { rows: [{ count: '0' }] } as any;
-      }
-      if (normalized.includes('SUSPICIOUS_WEBHOOKS')) {
-        return { rows: [] } as any;
-      }
+  const querySpy = vi.fn(async (sql: string) => {
+    const normalized = sql.toUpperCase();
+    if (normalized.includes('FROM ANCHORS')) {
+      return { rows: [{ public_key: null, webhook_secret: secret }] } as any;
+    }
+    if (normalized.includes('INSERT INTO WEBHOOK_LOGS')) {
+      return { rows: [{ id: 'wh-log-1' }] } as any;
+    }
+    if (normalized.includes('FROM WEBHOOK_LOGS')) {
+      return { rows: [{ count: '0' }] } as any;
+    }
+    if (normalized.includes('SUSPICIOUS_WEBHOOKS')) {
       return { rows: [] } as any;
-    }),
-  } as unknown as Pool;
+    }
+    return { rows: [] } as any;
+  });
+  return { query: querySpy } as unknown as Pool;
+}
+
+function buildRequest(body: Record<string, unknown>, secret: string) {
+  const rawBody = JSON.stringify(body);
+  const signature = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  return {
+    req: {
+      headers: {
+        'x-signature': signature,
+        'x-timestamp': new Date().toISOString(),
+        'x-nonce': crypto.randomUUID(),
+        'x-anchor-id': 'anchor-test',
+      },
+      body,
+      rawBody,
+    } as any,
+    res: {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as any,
+  };
 }
 
 describe('WebhookHandler remittance created flow', () => {
@@ -55,37 +75,126 @@ describe('WebhookHandler remittance created flow', () => {
       expiry: '1777777777',
     };
 
-    const rawBody = JSON.stringify(body);
-    const signature = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
-
-    const req: any = {
-      headers: {
-        'x-signature': signature,
-        'x-timestamp': new Date().toISOString(),
-        'x-nonce': crypto.randomUUID(),
-        'x-anchor-id': 'anchor-test',
-      },
-      body,
-      rawBody,
-    };
-
-    const res: any = {
-      status: vi.fn().mockReturnThis(),
-      json: vi.fn().mockReturnThis(),
-    };
-
+    const { req, res } = buildRequest(body, secret);
     const handler = new WebhookHandler(buildMockPool(secret));
     await handler.handleWebhook(req, res);
 
     expect(dispatchRemittanceCreated).toHaveBeenCalledTimes(1);
-    expect(dispatchRemittanceCreated).toHaveBeenCalledWith({
-      remittance_id: '99',
-      sender: 'GSENDERADDRESS',
-      agent: 'GAGENTADDRESS',
-      amount: '10000000',
-      fee: '100000',
-      expiry: '1777777777',
-    });
+    expect(dispatchRemittanceCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remittance_id: '99',
+        sender: 'GSENDERADDRESS',
+        agent: 'GAGENTADDRESS',
+        amount: '10000000',
+        fee: '100000',
+        expiry: '1777777777',
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('includes fee breakdown fields when present in the event', async () => {
+    dispatchRemittanceCreated.mockReset();
+
+    const secret = 'handler-remittance-secret-breakdown';
+    const body = {
+      event_type: 'contract_created',
+      remittance_id: '42',
+      sender: 'GSENDER2',
+      agent: 'GAGENT2',
+      amount: '5000000',
+      fee: '50000',
+      expiry: '1999999999',
+      platform_fee: '50000',
+      protocol_fee: '5000',
+      net_amount: '4945000',
+    };
+
+    const { req, res } = buildRequest(body, secret);
+    const pool = buildMockPool(secret);
+    const handler = new WebhookHandler(pool);
+    await handler.handleWebhook(req, res);
+
+    expect(dispatchRemittanceCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remittance_id: '42',
+        platform_fee: '50000',
+        protocol_fee: '5000',
+        net_amount: '4945000',
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('persists fee breakdown to contract_events table', async () => {
+    dispatchRemittanceCreated.mockReset();
+
+    const secret = 'handler-persist-secret';
+    const body = {
+      event_type: 'contract_created',
+      remittance_id: '77',
+      sender: 'GSENDER3',
+      agent: 'GAGENT3',
+      amount: '2000000',
+      fee: '20000',
+      expiry: '1888888888',
+      platform_fee: '20000',
+      protocol_fee: '2000',
+      net_amount: '1978000',
+    };
+
+    const { req, res } = buildRequest(body, secret);
+    const pool = buildMockPool(secret);
+    const handler = new WebhookHandler(pool);
+    await handler.handleWebhook(req, res);
+
+    const querySpy = (pool as any).query as ReturnType<typeof vi.fn>;
+    const insertCall = querySpy.mock.calls.find(
+      (call: any[]) =>
+        typeof call[0] === 'string' &&
+        call[0].toUpperCase().includes('INSERT INTO CONTRACT_EVENTS')
+    );
+
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as any[];
+    expect(params[0]).toBe('remittance_created');
+    expect(params[5]).toBe('20000');   // platform_fee
+    expect(params[6]).toBe('2000');    // protocol_fee
+    expect(params[7]).toBe('1978000'); // net_amount
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('omits breakdown fields from contract_events when not present in event', async () => {
+    dispatchRemittanceCreated.mockReset();
+
+    const secret = 'handler-no-breakdown-secret';
+    const body = {
+      event_type: 'contract_created',
+      remittance_id: '55',
+      sender: 'GSENDER4',
+      agent: 'GAGENT4',
+      amount: '3000000',
+      fee: '30000',
+      expiry: '1666666666',
+    };
+
+    const { req, res } = buildRequest(body, secret);
+    const pool = buildMockPool(secret);
+    const handler = new WebhookHandler(pool);
+    await handler.handleWebhook(req, res);
+
+    const querySpy = (pool as any).query as ReturnType<typeof vi.fn>;
+    const insertCall = querySpy.mock.calls.find(
+      (call: any[]) =>
+        typeof call[0] === 'string' &&
+        call[0].toUpperCase().includes('INSERT INTO CONTRACT_EVENTS')
+    );
+
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1] as any[];
+    expect(params[5]).toBeNull(); // platform_fee
+    expect(params[6]).toBeNull(); // protocol_fee
+    expect(params[7]).toBeNull(); // net_amount
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -114,6 +114,9 @@ export interface RemittanceCreatedWebhookPayload {
   fee: string;
   expiry: string;
   memo?: string;
+  platform_fee?: string;
+  protocol_fee?: string;
+  net_amount?: string;
 }
 
 export interface Sep24ExpiredRefundWebhookPayload {

--- a/backend/src/webhook-handler.ts
+++ b/backend/src/webhook-handler.ts
@@ -194,6 +194,9 @@ export class WebhookHandler {
 
   /**
    * Handle contract-created event and fan out remittance.created webhook.
+   *
+   * Also persists the full fee breakdown to contract_events so analytics can
+   * query platform_fee, protocol_fee, and net_amount without re-deriving them.
    */
   private async handleRemittanceCreated(payload: any): Promise<void> {
     const requiredFields = ['remittance_id', 'sender', 'agent', 'amount', 'fee', 'expiry'];
@@ -210,7 +213,28 @@ export class WebhookHandler {
       amount: String(payload.amount),
       fee: String(payload.fee),
       expiry: String(payload.expiry),
+      platform_fee: payload.platform_fee != null ? String(payload.platform_fee) : undefined,
+      protocol_fee: payload.protocol_fee != null ? String(payload.protocol_fee) : undefined,
+      net_amount: payload.net_amount != null ? String(payload.net_amount) : undefined,
     };
+
+    // Persist fee breakdown to contract_events for downstream analytics.
+    await this.pool.query(
+      `INSERT INTO contract_events
+         (event_type, remittance_id, actor, amount, fee, platform_fee, protocol_fee, net_amount, raw_data)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        'remittance_created',
+        payload.remittance_id,
+        payload.sender,
+        payload.amount,
+        payload.fee,
+        payload.platform_fee ?? null,
+        payload.protocol_fee ?? null,
+        payload.net_amount ?? null,
+        JSON.stringify(payload),
+      ]
+    );
 
     await this.dispatcher.dispatchRemittanceCreated(remittancePayload);
   }

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -152,6 +152,9 @@ pub fn do_emergency_unpause(
     };
     cb_storage::save_unpause_record(env, &unpause_record);
 
+    // Record unpause timestamp so the rate-limiter can apply the cooldown window.
+    cb_storage::set_last_unpause_at(env, timestamp);
+
     // Emit the circuit-breaker unpaused event.
     emit_circuit_breaker_unpaused(env, caller.clone(), timestamp);
 
@@ -238,5 +241,7 @@ pub fn build_status(env: &Env) -> CircuitBreakerStatus {
             env,
             cb_storage::get_active_pause_seq(env).unwrap_or(0),
         ),
+        last_unpause_at: cb_storage::get_last_unpause_at(env),
+        cooldown_period_seconds: cb_storage::get_cooldown_period(env),
     }
 }

--- a/src/circuit_breaker_storage.rs
+++ b/src/circuit_breaker_storage.rs
@@ -40,6 +40,10 @@ enum CbKey {
     UnpauseVoteCount(u64),
     PauseTimelockSeconds,
     UnpauseQuorum,
+    /// Ledger timestamp of the most recent emergency unpause.
+    LastUnpauseAt,
+    /// Cooldown window in seconds after an unpause during which rate limits are halved.
+    CooldownPeriod,
 }
 
 // ─── Pause Sequence Counter ───────────────────────────────────────────────────
@@ -180,4 +184,36 @@ pub fn record_vote(env: &Env, pause_seq: u64, voter: &Address) {
     env.storage()
         .persistent()
         .set(&CbKey::UnpauseVote(pause_seq, voter.clone()), &true);
+}
+
+// ─── Post-Unpause Cooldown ────────────────────────────────────────────────────
+
+/// Returns the ledger timestamp of the most recent emergency unpause, if any.
+pub fn get_last_unpause_at(env: &Env) -> Option<u64> {
+    env.storage().instance().get(&CbKey::LastUnpauseAt)
+}
+
+/// Persists the ledger timestamp of the most recent emergency unpause.
+pub fn set_last_unpause_at(env: &Env, timestamp: u64) {
+    env.storage()
+        .instance()
+        .set(&CbKey::LastUnpauseAt, &timestamp);
+}
+
+/// Returns the configured post-unpause cooldown period in seconds.
+///
+/// During this window after an unpause, per-sender rate limits are halved.
+/// Defaults to [`crate::config::DEFAULT_COOLDOWN_PERIOD_SECONDS`] (1 hour).
+pub fn get_cooldown_period(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&CbKey::CooldownPeriod)
+        .unwrap_or(crate::config::DEFAULT_COOLDOWN_PERIOD_SECONDS)
+}
+
+/// Persists the post-unpause cooldown period in seconds.
+pub fn set_cooldown_period(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&CbKey::CooldownPeriod, &seconds);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,6 +195,16 @@ pub const SETTLEMENT_EVENT_EMITTED_FLAG: u32 = 1 << 1;
 /// breaking changes to migration data structures.
 pub const MIGRATION_SNAPSHOT_VERSION: u32 = 1;
 
+// ============================================================================
+// Circuit Breaker Cooldown
+// ============================================================================
+
+/// Default post-unpause cooldown period in seconds (1 hour).
+///
+/// During this window after an emergency unpause, per-sender rate limits are
+/// halved to throttle traffic and prevent immediate exploitation.
+pub const DEFAULT_COOLDOWN_PERIOD_SECONDS: u64 = 3_600;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/events.rs
+++ b/src/events.rs
@@ -106,6 +106,10 @@ pub fn emit_admin_removed(env: &Env, caller: Address, removed_admin: Address) {
 // ── Remittance Events ──────────────────────────────────────────────
 
 /// Emits an event when a new remittance is created.
+///
+/// Includes the full fee breakdown so downstream analytics and the SDK can
+/// distinguish platform fee, protocol fee, and net payout amount without
+/// re-deriving them from on-chain config.
 pub fn emit_remittance_created(
     env: &Env,
     remittance_id: u64,
@@ -114,8 +118,16 @@ pub fn emit_remittance_created(
     amount: i128,
     fee: i128,
     integrator_fee: i128,
+    platform_fee: i128,
+    protocol_fee: i128,
+    net_amount: i128,
 ) {
-    emit_event!(env, "remit", "created", remittance_id, sender, agent, amount, fee, integrator_fee);
+    emit_event!(
+        env, "remit", "created",
+        remittance_id, sender, agent,
+        amount, fee, integrator_fee,
+        platform_fee, protocol_fee, net_amount
+    );
 }
 
 /// Emits an event when a remittance payout is completed.

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -103,6 +103,7 @@ pub fn do_propose(
             }
         }
         ProposalAction::UpdateTimelock(_) => {}
+        ProposalAction::UpdateCooldownPeriod(_) => {}
     }
 
     let id = next_proposal_id(env);
@@ -399,6 +400,9 @@ fn dispatch_action(
         ProposalAction::UpdateTimelock(s) => {
             set_governance_timelock(env, *s);
         }
+        ProposalAction::UpdateCooldownPeriod(secs) => {
+            crate::circuit_breaker_storage::set_cooldown_period(env, *secs);
+        }
     }
     Ok(())
 }
@@ -416,5 +420,6 @@ fn action_type_symbol(env: &Env, action: &ProposalAction) -> Symbol {
         ProposalAction::RemoveAdmin(_) => Symbol::new(env, "rem_admin"),
         ProposalAction::UpdateQuorum(_) => Symbol::new(env, "upd_quorum"),
         ProposalAction::UpdateTimelock(_) => Symbol::new(env, "upd_tlock"),
+        ProposalAction::UpdateCooldownPeriod(_) => Symbol::new(env, "upd_cool"),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,10 @@ mod test_governance_property;
 mod test_dispute;
 #[cfg(test)]
 mod test_features_589_592;
+#[cfg(test)]
+mod test_state_machine_property;
+#[cfg(test)]
+mod test_contract_upgrade;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_circuit_breaker;
 
@@ -1890,6 +1894,29 @@ impl SwiftRemitContract {
         require_role_admin(&env, &caller)?;
         circuit_breaker_storage::set_unpause_quorum(&env, quorum);
         Ok(())
+    }
+
+    /// Sets the post-unpause cooldown period in seconds (0 disables cooldown).
+    ///
+    /// During this window after an emergency unpause, per-sender rate limits are
+    /// halved to throttle traffic. Max 7 days. Requires Admin role.
+    pub fn set_cooldown_period(
+        env: Env,
+        caller: Address,
+        seconds: u64,
+    ) -> Result<(), ContractError> {
+        if seconds > 604_800 {
+            return Err(ContractError::InvalidTimelockDuration);
+        }
+        caller.require_auth();
+        require_role_admin(&env, &caller)?;
+        circuit_breaker_storage::set_cooldown_period(&env, seconds);
+        Ok(())
+    }
+
+    /// Returns the current post-unpause cooldown period in seconds.
+    pub fn get_cooldown_period(env: Env) -> u64 {
+        circuit_breaker_storage::get_cooldown_period(&env)
     }
 
     // ── Circuit Breaker View Entry Points ──────────────────────────────────────

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -100,6 +100,21 @@ pub fn check_rate_limit(env: &Env, address: &Address) -> Result<(), ContractErro
     }
 
     let current_time = env.ledger().timestamp();
+
+    // During the post-unpause cooldown window, halve per-sender rate limits to
+    // prevent immediate exploitation after an emergency unpause.
+    let effective_max = match crate::circuit_breaker_storage::get_last_unpause_at(env) {
+        Some(last_unpause) => {
+            let cooldown = crate::circuit_breaker_storage::get_cooldown_period(env);
+            if current_time.saturating_sub(last_unpause) < cooldown {
+                (config.max_requests / 2).max(1)
+            } else {
+                config.max_requests
+            }
+        }
+        None => config.max_requests,
+    };
+
     let key = RateLimitKey::Entry(address.clone());
 
     let mut entry: RateLimitEntry = env
@@ -116,7 +131,7 @@ pub fn check_rate_limit(env: &Env, address: &Address) -> Result<(), ContractErro
         entry.request_count = 1;
         entry.window_start = current_time;
     } else {
-        if entry.request_count >= config.max_requests {
+        if entry.request_count >= effective_max {
             return Err(ContractError::RateLimitExceeded);
         }
         entry.request_count = entry.request_count.saturating_add(1);

--- a/src/test_contract_upgrade.rs
+++ b/src/test_contract_upgrade.rs
@@ -1,101 +1,188 @@
-//! Tests for Contract Upgrade Module
+//! Integration tests for contract upgrade migration (#846).
 //!
-//! Tests cover:
-//! - Proposal creation
-//! - Multi-sig approval
-//! - Timelock enforcement
-//! - Execution after timelock
+//! Verifies that `migration::migrate()` preserves 100% of contract state —
+//! remittance records, agent registrations, payout commitment hashes, and fee
+//! configuration — across a simulated schema upgrade.
+//!
+//! A real on-chain WASM upgrade would call `env.deployer().update_current_contract_wasm()`
+//! followed by `migrate()`.  Because Soroban's test harness does not support
+//! live WASM swaps, these unit tests cover the migration module directly.
+//!
+//! The testnet integration path (actual WASM upgrade on a running network) is
+//! documented in MIGRATION.md.
 
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Env, BytesN};
+extern crate std;
 
-use crate::contract_upgrade::{
-    ContractUpgrade, UpgradeProposal, UpgradeStatus,
-    propose_upgrade, approve_upgrade, execute_upgrade,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
 
-// Test utilities
-fn generate_wasm_hash(env: &Env) -> BytesN<32> {
-    // Generate a test WASM hash
-    let mut hash: BytesN<32> = BytesN::from_array(env, &[0u8; 32]);
-    hash
+use crate::{migration, SwiftRemitContract, SwiftRemitContractClient};
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+fn create_token(env: &Env, admin: &Address) -> token::StellarAssetClient {
+    let id = env.register_stellar_asset_contract_v2(admin.clone());
+    token::StellarAssetClient::new(env, &id.address())
 }
 
-#[test]
-fn test_propose_upgrade_success() {
+fn setup() -> (Env, SwiftRemitContractClient<'static>, Address, Address, Address) {
     let env = Env::default();
-    let admin = Address::from_string(&"GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5JBF3ULETJ2MYBP2LQJ".parse::<Address>().unwrap());
-    
-    let wasm_hash = generate_wasm_hash(&env);
-    let result = contract.propose_upgrade(&admin, &wasm_hash);
-    
-    assert!(result.is_ok());
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token(&env, &token_admin);
+    let agent = Address::generate(&env);
+    let sender = Address::generate(&env);
+
+    let client =
+        SwiftRemitContractClient::new(&env, &env.register_contract(None, SwiftRemitContract {}));
+
+    client.initialize(&admin, &token.address, &250, &0, &0, &admin);
+    client.register_agent(&agent, &None);
+    token.mint(&sender, &100_000);
+
+    (env, client, admin, agent, sender)
 }
 
+// ─── State preservation tests ─────────────────────────────────────────────────
+
+/// `migrate()` is idempotent: calling it twice at the same schema version is safe.
 #[test]
-fn test_propose_upgrade_unauthorized() {
-    let env = Env::default();
-    let non_admin = Address::from_string(&"GA7QYNF7SOWQ6XLQJ33AHP6ARJLZDHFIZTFQOFJCAZBLW3V6FWLLTM7D2C4".parse::<Address>().unwrap());
-    
-    let wasm_hash = generate_wasm_hash(&env);
-    let result = contract.propose_upgrade(&non_admin, &wasm_hash);
-    
-    assert!(result.is_err());
+fn test_migrate_is_idempotent() {
+    let (env, _client, _, _, _) = setup();
+    let result1 = migration::migrate(&env);
+    assert!(result1.is_ok(), "first migrate failed: {:?}", result1);
+    let result2 = migration::migrate(&env);
+    assert!(result2.is_ok(), "second migrate failed (not idempotent): {:?}", result2);
 }
 
+/// Remittance records are fully intact after migration.
 #[test]
-fn test_approve_upgrade_success() {
-    let env = Env::default();
-    let admin1 = Address::from_string(&"GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5JBF3ULETJ2MYBP2LQJ".parse::<Address>().unwrap());
-    let admin2 = Address::from_string(&"GA7QYNF7SOWQ6XLQJ33AHP6ARJLZDHFIZTFQOFJCAZBLW3V6FWLLTM7D2C4".parse::<Address>().unwrap());
-    
-    // Propose
-    let wasm_hash = generate_wasm_hash(&env);
-    let proposal_id = contract.propose_upgrade(&admin1, &wasm_hash).unwrap();
-    
-    // Approve
-    let result = contract.approve_upgrade(&admin2, &proposal_id);
-    assert!(result.is_ok());
+fn test_migrate_preserves_remittance_state() {
+    let (env, client, _, agent, sender) = setup();
+
+    env.mock_all_auths();
+    let id1 = client.create_remittance(&sender, &agent, &5_000, &None, &None, &None, &None, &None);
+    let id2 = client.create_remittance(&sender, &agent, &3_000, &None, &None, &None, &None, &None);
+
+    // Snapshot state before migration.
+    let before1 = client.get_remittance(&id1).expect("remittance 1 not found");
+    let before2 = client.get_remittance(&id2).expect("remittance 2 not found");
+
+    // Run migration (simulates post-WASM-upgrade migration step).
+    migration::migrate(&env).expect("migrate failed");
+
+    // Verify every field is identical after migration.
+    let after1 = client.get_remittance(&id1).expect("remittance 1 missing after migrate");
+    let after2 = client.get_remittance(&id2).expect("remittance 2 missing after migrate");
+
+    assert_eq!(after1.id, before1.id);
+    assert_eq!(after1.amount, before1.amount);
+    assert_eq!(after1.fee, before1.fee);
+    assert_eq!(after1.status, before1.status);
+    assert_eq!(after1.sender, before1.sender);
+    assert_eq!(after1.agent, before1.agent);
+
+    assert_eq!(after2.id, before2.id);
+    assert_eq!(after2.amount, before2.amount);
+    assert_eq!(after2.fee, before2.fee);
+    assert_eq!(after2.status, before2.status);
 }
 
+/// Agent registrations survive migration.
 #[test]
-fn test_timelock_enforced() {
-    let env = Env::default();
-    let admin1 = Address::from_string(&"GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5JBF3ULETJ2MYBP2LQJ".parse::<Address>().unwrap());
-    let admin2 = Address::from_string(&"GA7QYNF7SOWQ6XLQJ33AHP6ARJLZDHFIZTFQOFJCAZBLW3V6FWLLTM7D2C4".parse::<Address>().unwrap());
-    let admin3 = Address::from_string(&"GCJ2T4R7BZHK4K5GQ6TQZY7QCMCMSQ6C3J7LQVLRIJJGZLW7RQ7CQZJ".parse::<Address>().unwrap());
-    
-    // Propose
-    let wasm_hash = generate_wasm_hash(&env);
-    let proposal_id = contract.propose_upgrade(&admin1, &wasm_hash).unwrap();
-    
-    // Approve from enough admins for quorum
-    contract.approve_upgrade(&admin2, &proposal_id);
-    contract.approve_upgrade(&admin3, &proposal_id);
-    
-    // Try to execute immediately - should fail (timelock active)
-    let result = contract.execute_upgrade(&admin1, &proposal_id);
-    assert!(result.is_err());
-    
-    // Simulate 48 hours passing
-    // In real test, would mock ledger timestamp
-    
-    // After timelock, should succeed
-    let result = contract.execute_upgrade(&admin1, &proposal_id);
-    assert!(result.is_ok());
+fn test_migrate_preserves_agent_registrations() {
+    let (env, client, admin, agent, _) = setup();
+    let agent2 = Address::generate(&env);
+    client.register_agent(&agent2, &None);
+
+    assert!(client.is_agent_registered(&agent));
+    assert!(client.is_agent_registered(&agent2));
+
+    migration::migrate(&env).expect("migrate failed");
+
+    assert!(
+        client.is_agent_registered(&agent),
+        "agent1 lost after migration"
+    );
+    assert!(
+        client.is_agent_registered(&agent2),
+        "agent2 lost after migration"
+    );
+    assert!(client.is_admin(&admin), "admin lost after migration");
 }
 
+/// Settlement commitment hash is unchanged after migration — the core
+/// hash-verification step required for safe upgrades.
+///
+/// `compute_settlement_hash` derives the hash deterministically from the
+/// remittance record, so any field corruption after migration would cause a
+/// mismatch.
 #[test]
-fn test_upgrade_proposal_events() {
-    let env = Env::default();
-    let admin = Address::from_string(&"GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5JBF3ULETJ2MYBP2LQJ".parse::<Address>().unwrap());
-    
-    let wasm_hash = generate_wasm_hash(&env);
-    let proposal_id = contract.propose_upgrade(&admin, &wasm_hash).unwrap();
-    
-    // Verify event would be emitted (checked via test events)
-    // Events: UpgradeProposed(proposal_id, wasm_hash)
-    //         -> UpgradeApproved(proposal_id, 1) 
-    //         -> UpgradeExecuted(proposal_id)
+fn test_migrate_preserves_commitment_hashes() {
+    let (env, client, _, agent, sender) = setup();
+
+    env.mock_all_auths();
+    let id =
+        client.create_remittance(&sender, &agent, &10_000, &None, &None, &None, &None, &None);
+
+    // Compute deterministic commitment hash before migration.
+    let hash_before = client
+        .compute_settlement_hash(&id)
+        .expect("hash computation failed before migrate");
+
+    migration::migrate(&env).expect("migrate failed");
+
+    // Re-compute after migration — must be byte-for-byte identical.
+    let hash_after = client
+        .compute_settlement_hash(&id)
+        .expect("hash computation failed after migrate");
+
+    assert_eq!(
+        hash_before, hash_after,
+        "settlement commitment hash changed after migration — state corruption detected"
+    );
+}
+
+/// Accumulated fee balance is preserved across migration.
+#[test]
+fn test_migrate_preserves_accumulated_fees() {
+    let (env, client, _, agent, sender) = setup();
+
+    env.mock_all_auths();
+    client.create_remittance(&sender, &agent, &8_000, &None, &None, &None, &None, &None);
+
+    let fees_before = client.get_accumulated_fees().expect("fee query failed");
+    assert!(fees_before > 0, "expected non-zero accumulated fees");
+
+    migration::migrate(&env).expect("migrate failed");
+
+    let fees_after = client.get_accumulated_fees().expect("fee query after migrate failed");
+    assert_eq!(
+        fees_after, fees_before,
+        "accumulated fee balance changed after migration"
+    );
+}
+
+/// Total remittance count is unchanged after migration.
+#[test]
+fn test_migrate_preserves_remittance_count() {
+    let (env, client, _, agent, sender) = setup();
+
+    env.mock_all_auths();
+    client.create_remittance(&sender, &agent, &1_000, &None, &None, &None, &None, &None);
+    client.create_remittance(&sender, &agent, &2_000, &None, &None, &None, &None, &None);
+    client.create_remittance(&sender, &agent, &3_000, &None, &None, &None, &None, &None);
+
+    let count_before = client.get_remittance_count();
+
+    migration::migrate(&env).expect("migrate failed");
+
+    assert_eq!(
+        client.get_remittance_count(),
+        count_before,
+        "remittance count changed after migration"
+    );
 }

--- a/src/test_state_machine_property.rs
+++ b/src/test_state_machine_property.rs
@@ -1,0 +1,196 @@
+//! Property-based tests for RemittanceStatus state machine transitions (#845).
+//!
+//! Covers two key contracts:
+//! - `validate_transition` returns `Err(ContractError::InvalidStateTransition)` for
+//!   every invalid edge and `Ok(())` for every valid edge.
+//! - `transition_status` correctly updates the `Remittance` struct status field
+//!   after a valid transition.
+//!
+//! These tests run under `cargo test` (no feature gate) and are therefore included
+//! in the property-tests CI job (`cargo test prop_`).
+
+#![cfg(test)]
+
+extern crate std;
+
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, Env};
+
+use crate::{
+    errors::ContractError,
+    transitions::{transition_status, validate_transition},
+    types::RemittanceStatus,
+    MaybeBytes32, MaybeSettlementConfig,
+};
+
+// ─── Strategies ──────────────────────────────────────────────────────────────
+
+fn arb_status() -> impl Strategy<Value = RemittanceStatus> {
+    prop_oneof![
+        Just(RemittanceStatus::Pending),
+        Just(RemittanceStatus::Processing),
+        Just(RemittanceStatus::Completed),
+        Just(RemittanceStatus::Cancelled),
+        Just(RemittanceStatus::Failed),
+        Just(RemittanceStatus::Disputed),
+    ]
+}
+
+/// All valid (non-idempotent) state machine edges.
+fn arb_valid_transition() -> impl Strategy<Value = (RemittanceStatus, RemittanceStatus)> {
+    prop_oneof![
+        Just((RemittanceStatus::Pending, RemittanceStatus::Processing)),
+        Just((RemittanceStatus::Pending, RemittanceStatus::Cancelled)),
+        Just((RemittanceStatus::Pending, RemittanceStatus::Failed)),
+        Just((RemittanceStatus::Processing, RemittanceStatus::Completed)),
+        Just((RemittanceStatus::Processing, RemittanceStatus::Cancelled)),
+        Just((RemittanceStatus::Processing, RemittanceStatus::Failed)),
+        Just((RemittanceStatus::Failed, RemittanceStatus::Disputed)),
+    ]
+}
+
+/// Transitions that must always be rejected (non-idempotent, non-edge pairs).
+fn arb_invalid_transition() -> impl Strategy<Value = (RemittanceStatus, RemittanceStatus)> {
+    prop_oneof![
+        // Terminal states cannot leave to a different state
+        Just((RemittanceStatus::Completed, RemittanceStatus::Pending)),
+        Just((RemittanceStatus::Completed, RemittanceStatus::Processing)),
+        Just((RemittanceStatus::Completed, RemittanceStatus::Cancelled)),
+        Just((RemittanceStatus::Completed, RemittanceStatus::Failed)),
+        Just((RemittanceStatus::Completed, RemittanceStatus::Disputed)),
+        Just((RemittanceStatus::Cancelled, RemittanceStatus::Pending)),
+        Just((RemittanceStatus::Cancelled, RemittanceStatus::Processing)),
+        Just((RemittanceStatus::Cancelled, RemittanceStatus::Completed)),
+        Just((RemittanceStatus::Cancelled, RemittanceStatus::Failed)),
+        Just((RemittanceStatus::Cancelled, RemittanceStatus::Disputed)),
+        // Skip-step transitions
+        Just((RemittanceStatus::Pending, RemittanceStatus::Completed)),
+        Just((RemittanceStatus::Pending, RemittanceStatus::Disputed)),
+        Just((RemittanceStatus::Processing, RemittanceStatus::Pending)),
+        // Backwards from Failed
+        Just((RemittanceStatus::Failed, RemittanceStatus::Pending)),
+        Just((RemittanceStatus::Failed, RemittanceStatus::Processing)),
+        Just((RemittanceStatus::Failed, RemittanceStatus::Completed)),
+        Just((RemittanceStatus::Failed, RemittanceStatus::Cancelled)),
+        // Backwards from Disputed
+        Just((RemittanceStatus::Disputed, RemittanceStatus::Pending)),
+        Just((RemittanceStatus::Disputed, RemittanceStatus::Processing)),
+        Just((RemittanceStatus::Disputed, RemittanceStatus::Failed)),
+    ]
+}
+
+fn make_remittance(env: &Env, status: RemittanceStatus) -> crate::Remittance {
+    crate::Remittance {
+        id: 1,
+        sender: soroban_sdk::Address::generate(env),
+        agent: soroban_sdk::Address::generate(env),
+        amount: 1_000,
+        fee: 10,
+        status,
+        expiry: None,
+        settlement_config: MaybeSettlementConfig::None,
+        token: soroban_sdk::Address::generate(env),
+        created_at: 0,
+        failed_at: None,
+        dispute_evidence: MaybeBytes32::None,
+    }
+}
+
+// ─── Property Tests ───────────────────────────────────────────────────────────
+
+proptest! {
+    /// Every invalid transition must return exactly `ContractError::InvalidStateTransition`.
+    #[test]
+    fn prop_invalid_transitions_return_error_variant(
+        (from, to) in arb_invalid_transition()
+    ) {
+        let result = validate_transition(&from, &to);
+        prop_assert!(
+            matches!(result, Err(ContractError::InvalidStateTransition)),
+            "Expected InvalidStateTransition for {:?} -> {:?}, got {:?}",
+            from, to, result
+        );
+    }
+
+    /// Every valid transition must return `Ok(())`.
+    #[test]
+    fn prop_valid_transitions_return_ok(
+        (from, to) in arb_valid_transition()
+    ) {
+        let result = validate_transition(&from, &to);
+        prop_assert!(
+            result.is_ok(),
+            "Expected Ok for {:?} -> {:?}, got {:?}",
+            from, to, result
+        );
+    }
+
+    /// After a valid `transition_status` call the remittance status is updated to `to`.
+    #[test]
+    fn prop_valid_transitions_update_storage(
+        (from, to) in arb_valid_transition()
+    ) {
+        let env = Env::default();
+        let mut rem = make_remittance(&env, from.clone());
+
+        let result = transition_status(&env, &mut rem, to.clone());
+        prop_assert!(result.is_ok(), "transition_status failed: {:?}", result);
+        prop_assert_eq!(
+            rem.status, to,
+            "Status not updated after {:?} -> {:?}", from, to
+        );
+    }
+
+    /// Idempotent transitions (same state → same state) always succeed and leave status unchanged.
+    #[test]
+    fn prop_idempotent_transitions_preserve_status(status in arb_status()) {
+        let env = Env::default();
+        let mut rem = make_remittance(&env, status.clone());
+
+        let result = transition_status(&env, &mut rem, status.clone());
+        prop_assert!(result.is_ok(), "Idempotent transition failed for {:?}", status);
+        prop_assert_eq!(rem.status, status);
+    }
+
+    /// Terminal states (Completed, Cancelled) must reject every non-idempotent transition.
+    #[test]
+    fn prop_terminal_states_reject_non_idempotent(
+        from in prop_oneof![
+            Just(RemittanceStatus::Completed),
+            Just(RemittanceStatus::Cancelled),
+        ],
+        to in arb_status(),
+    ) {
+        if from != to {
+            let result = validate_transition(&from, &to);
+            prop_assert!(
+                matches!(result, Err(ContractError::InvalidStateTransition)),
+                "Terminal {:?} must reject {:?}, got {:?}", from, to, result
+            );
+        }
+    }
+
+    /// Disputed is only reachable from Failed; no other state may transition to it.
+    #[test]
+    fn prop_disputed_only_reachable_from_failed(from in arb_status()) {
+        if from != RemittanceStatus::Failed && from != RemittanceStatus::Disputed {
+            let result = validate_transition(&from, &RemittanceStatus::Disputed);
+            prop_assert!(
+                matches!(result, Err(ContractError::InvalidStateTransition)),
+                "Only Failed may transition to Disputed; {:?} should be rejected", from
+            );
+        }
+    }
+
+    /// Pending is the sole initial state; no other state may return to Pending.
+    #[test]
+    fn prop_pending_is_initial_only(from in arb_status()) {
+        if from != RemittanceStatus::Pending {
+            let result = validate_transition(&from, &RemittanceStatus::Pending);
+            prop_assert!(
+                matches!(result, Err(ContractError::InvalidStateTransition)),
+                "{:?} should not transition back to Pending", from
+            );
+        }
+    }
+}

--- a/src/test_transitions.rs
+++ b/src/test_transitions.rs
@@ -179,7 +179,6 @@ fn arb_invalid_transition() -> impl Strategy<Value = (RemittanceStatus, Remittan
         Just((RemittanceStatus::Pending, RemittanceStatus::Completed)),
         Just((RemittanceStatus::Pending, RemittanceStatus::Disputed)),
         Just((RemittanceStatus::Processing, RemittanceStatus::Pending)),
-        Just((RemittanceStatus::Processing, RemittanceStatus::Processing)),
         Just((RemittanceStatus::Failed, RemittanceStatus::Pending)),
         Just((RemittanceStatus::Failed, RemittanceStatus::Processing)),
         Just((RemittanceStatus::Failed, RemittanceStatus::Completed)),

--- a/src/transaction_controller.rs
+++ b/src/transaction_controller.rs
@@ -243,7 +243,8 @@ impl TransactionController {
         crate::storage::set_remittance(env, remittance_id, &remittance);
         crate::storage::set_remittance_counter(env, remittance_id);
 
-        // Emit event
+        // Emit event with full fee breakdown for analytics/SDK consumers.
+        let net_amount = amount.saturating_sub(fee);
         crate::events::emit_remittance_created(
             env,
             remittance_id,
@@ -251,7 +252,10 @@ impl TransactionController {
             agent.clone(),
             amount,
             fee,
-            0, // integrator_fee (not used in transaction controller)
+            0,          // integrator_fee (not tracked in transaction controller)
+            fee,        // platform_fee
+            0,          // protocol_fee (not tracked in transaction controller)
+            net_amount,
         );
 
         Ok(remittance_id)

--- a/src/types.rs
+++ b/src/types.rs
@@ -382,6 +382,10 @@ pub struct CircuitBreakerStatus {
     pub unpause_quorum: u32,
     /// Number of votes cast for the current pause instance.
     pub current_vote_count: u32,
+    /// Ledger timestamp of the most recent unpause, or `None` if never unpaused.
+    pub last_unpause_at: Option<u64>,
+    /// Post-unpause cooldown period in seconds; rate limits are halved during this window.
+    pub cooldown_period_seconds: u64,
 }
 
 /// Idempotency record for duplicate remittance prevention.
@@ -424,6 +428,8 @@ pub enum ProposalAction {
     UpdateQuorum(u32),
     /// Update the governance execution timelock in seconds.
     UpdateTimelock(u64),
+    /// Update the post-unpause cooldown period in seconds (0 = disabled).
+    UpdateCooldownPeriod(u64),
 }
 
 /// Lifecycle state of a governance proposal.


### PR DESCRIPTION
#843 — Circuit breaker cooldown after unpause
- Add LastUnpauseAt and CooldownPeriod keys to CbKey in circuit_breaker_storage.rs
- Record last_unpause_at timestamp in do_emergency_unpause
- Halve per-sender rate limits in check_rate_limit during the cooldown window
- Add UpdateCooldownPeriod(u64) to ProposalAction and wire dispatch/symbol
- Expose set_cooldown_period / get_cooldown_period entry points in lib.rs
- Extend CircuitBreakerStatus with last_unpause_at and cooldown_period_seconds
- Add DEFAULT_COOLDOWN_PERIOD_SECONDS = 3600 constant in config.rs

#844 — Emit structured fee breakdown on every remittance_created event
- Add platform_fee, protocol_fee, net_amount params to emit_remittance_created
- Update transaction_controller.rs call site to pass breakdown values
- Extend RemittanceCreatedWebhookPayload in backend/src/types.ts
- Parse and forward breakdown fields in webhook-handler handleRemittanceCreated
- Persist fee breakdown to contract_events table via INSERT
- Add migration add_fee_breakdown_to_contract_events.sql (.down.sql)
- Expand webhook-handler-remittance.test.ts with breakdown and persistence tests

#845 — Property-based tests for state machine transitions
- New src/test_state_machine_property.rs (no feature gate, runs in CI)
  * prop_invalid_transitions_return_error_variant: asserts ContractError::InvalidStateTransition
  * prop_valid_transitions_return_ok
  * prop_valid_transitions_update_storage: asserts remittance.status updated
  * prop_idempotent_transitions_preserve_status
  * prop_terminal_states_reject_non_idempotent
  * prop_disputed_only_reachable_from_failed
  * prop_pending_is_initial_only
- Fix bug in test_transitions.rs arb_invalid_transition: remove (Processing, Processing) which is actually a valid idempotent transition

#846 — Contract upgrade migration test + MIGRATION.md
- Rewrite test_contract_upgrade.rs with proper Soroban test harness
  * test_migrate_is_idempotent
  * test_migrate_preserves_remittance_state
  * test_migrate_preserves_agent_registrations
  * test_migrate_preserves_commitment_hashes (hash verification step)
  * test_migrate_preserves_accumulated_fees
  * test_migrate_preserves_remittance_count
- Register test_contract_upgrade and test_state_machine_property in lib.rs
- Append post-upgrade hash verification and cooldown docs to MIGRATION.md

.gitignore: add IDE files, OS metadata, coverage dirs, temp files
Closes #843 
Closes #844 
Closes #845 
Closes #846 