### PR TITLE
feat: add PostgreSQL pool tuning env vars and /health/db endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,12 @@
 # Database Configuration
 DATABASE_URL=postgresql://user:password@localhost:5432/swiftremit
 
+# PostgreSQL Connection Pool Tuning
+DB_POOL_MAX=20
+DB_POOL_MIN=2
+DB_POOL_IDLE_TIMEOUT_MS=30000
+DB_POOL_CONNECTION_TIMEOUT_MS=2000
+
 # Stellar Configuration
 STELLAR_NETWORK=testnet
 HORIZON_URL=https://horizon-testnet.stellar.org

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -147,6 +147,30 @@ app.get('/health', async (req: Request, res: Response) => {
   res.status(status).json({ status: dbStatus === 'healthy' ? 'ok' : 'degraded', db: dbStatus, timestamp: new Date().toISOString() });
 });
 
+app.get('/health/db', async (req: Request, res: Response) => {
+  try {
+    await Promise.race([
+      pool.query('SELECT 1'),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000)),
+    ]);
+    res.status(200).json({
+      status: 'ok',
+      pool: {
+        active: pool.totalCount - pool.idleCount,
+        idle: pool.idleCount,
+        waiting: pool.waitingCount,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  } catch {
+    res.status(503).json({
+      status: 'error',
+      error: 'Database unreachable',
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
 // Get asset verification status
 app.get('/api/verification/:assetCode/:issuer', async (req: Request, res: Response) => {
   try {

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -795,9 +795,10 @@ export function getPool(): Pool {
     }
     pool = new Pool({
       connectionString,
-      max: 20,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 2000,
+      max: parseInt(process.env.DB_POOL_MAX ?? '20', 10),
+      min: parseInt(process.env.DB_POOL_MIN ?? '2', 10),
+      idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT_MS ?? '30000', 10),
+      connectionTimeoutMillis: parseInt(process.env.DB_POOL_CONNECTION_TIMEOUT_MS ?? '2000', 10),
     });
   }
   return pool;

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -16,10 +16,12 @@ export class MetricsService {
     swiftremit_webhook_dead_letter_count: 0,
     swiftremit_kyc_poll_runs_total: 0,
     swiftremit_kyc_poll_failures_total: 0,
-    db_pool_available_connections: 0,
     kyc_poller_last_run_timestamp_seconds: 0,
     contract_event_indexer_lag_ledgers: 0,
     swiftremit_rate_limit_exceeded_total: {} as Record<string, number>,
+    db_pool_active_connections: 0,
+    db_pool_idle_connections: 0,
+    db_pool_waiting_connections: 0,
   };
 
   // FX rate staleness metrics
@@ -187,8 +189,10 @@ export class MetricsService {
    * Update all metrics
    */
   async updateAllMetrics(): Promise<void> {
-    // Pool available connections (totalCount - idleCount gives busy; idleCount = available)
-    this.metrics.db_pool_available_connections = (this.pool as any).idleCount ?? 0;
+    const p = this.pool as any;
+    this.metrics.db_pool_idle_connections = p.idleCount ?? 0;
+    this.metrics.db_pool_waiting_connections = p.waitingCount ?? 0;
+    this.metrics.db_pool_active_connections = (p.totalCount ?? 0) - (p.idleCount ?? 0);
 
     await Promise.all([
       this.updateSettlementMetrics(),
@@ -257,10 +261,18 @@ export class MetricsService {
     lines.push('# TYPE fx_rate_cache_misses_total counter');
     lines.push(`fx_rate_cache_misses_total ${this.fxCacheMissesTotal}`);
 
-    // DB pool available connections gauge
-    lines.push('# HELP db_pool_available_connections Number of idle (available) connections in the PostgreSQL pool');
-    lines.push('# TYPE db_pool_available_connections gauge');
-    lines.push(`db_pool_available_connections ${this.metrics.db_pool_available_connections}`);
+    // DB pool connection gauges
+    lines.push('# HELP db_pool_active_connections Number of active (checked-out) connections in the PostgreSQL pool');
+    lines.push('# TYPE db_pool_active_connections gauge');
+    lines.push(`db_pool_active_connections ${this.metrics.db_pool_active_connections}`);
+
+    lines.push('# HELP db_pool_idle_connections Number of idle connections in the PostgreSQL pool');
+    lines.push('# TYPE db_pool_idle_connections gauge');
+    lines.push(`db_pool_idle_connections ${this.metrics.db_pool_idle_connections}`);
+
+    lines.push('# HELP db_pool_waiting_connections Number of requests waiting for a connection from the PostgreSQL pool');
+    lines.push('# TYPE db_pool_waiting_connections gauge');
+    lines.push(`db_pool_waiting_connections ${this.metrics.db_pool_waiting_connections}`);
 
     // KYC poller last run timestamp
     lines.push('# HELP kyc_poller_last_run_timestamp_seconds Unix timestamp of the last successful KYC poller run');


### PR DESCRIPTION
Configure pg pool max/min/idle/connection timeouts via DB_POOL_* env vars instead of hardcoded values. Expand Prometheus pool metrics to expose active, idle, and waiting connection counts. Add GET /health/db that returns 200 with pool stats when reachable and 503 when the DB is down.

Closes #860