### PR TITLE
feat: resolve issues #835 #836 #837 #838

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,56 @@ abi/*.json.local
 frontend/node_modules/
 frontend/dist/
 frontend/.env
+frontend/.env.local
 backend/node_modules/
+backend/dist/
+backend/.env
+backend/.env.local
 
+# SDK
+sdk/node_modules/
+sdk/dist/
+sdk/react-native/node_modules/
+sdk/react-native/dist/
+
+# API
+api/node_modules/
+api/dist/
+api/.env
+api/.env.local
+
+# Editor / IDE
+.vscode/extensions.json
+.idea/
+*.iml
+*.suo
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime / toolchain
 .kiro
 .env.testnet.local
+.env.local
+.env.*.local
 
 # Test artifacts
 test_snapshots/
 proptest-regressions/
+coverage/
+lcov.info
+
+# Temporary
+*.tmp
+*.bak
+*.orig

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -20,6 +20,7 @@ import type {
   GovernanceConfig,
   DailyLimitStatus,
   Proposal,
+  PartialPayoutRecord,
   RemittanceEvent,
   RemittanceEventType,
   SubscribeOptions,
@@ -649,6 +650,56 @@ export class SwiftRemitClient {
       addressToScVal(caller),
       addressToScVal(newAdmin),
     ]);
+  }
+
+  // ── #835: Partial payout history ───────────────────────────────────────────
+
+  /**
+   * Returns the full disbursement history for a remittance's partial payouts.
+   *
+   * Each record includes the amount disbursed, the cumulative total, and the
+   * remaining amount — allowing SDK consumers to track payout progress without
+   * additional on-chain queries.
+   */
+  async getPartialPayoutHistory(
+    sourceAddress: string,
+    remittanceId: bigint
+  ): Promise<PartialPayoutRecord[]> {
+    const val = await this.simulateCall(
+      sourceAddress,
+      "get_partial_payout_history",
+      [u64ToScVal(remittanceId)]
+    );
+    const native = scValToNative(val) as Array<Record<string, unknown>>;
+    return native.map((r) => ({
+      amount: BigInt(r["amount"] as number),
+      totalDisbursed: BigInt(r["total_disbursed"] as number),
+      remainingAmount: BigInt(r["remaining_amount"] as number),
+      timestamp: BigInt(r["timestamp"] as number),
+      ledgerSequence: Number(r["ledger_sequence"]),
+    }));
+  }
+
+  // ── #836: Time-based remittance expiry ──────────────────────────────────────
+
+  /** Expire a pending remittance after its expiry window (permissionless). */
+  async expireRemittance(
+    caller: string,
+    remittanceId: bigint
+  ): Promise<Transaction> {
+    return this.prepareTransaction(caller, "expire_remittance", [
+      u64ToScVal(remittanceId),
+    ]);
+  }
+
+  /** Get the global remittance auto-expiry window in seconds (0 = disabled). */
+  async getRemittanceExpiryWindow(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(
+      sourceAddress,
+      "get_remittance_expiry_window",
+      []
+    );
+    return BigInt(scValToNative(val) as number);
   }
 
   /** Confirm partial payout (agent only). */

--- a/sdk/src/convert.ts
+++ b/sdk/src/convert.ts
@@ -44,6 +44,8 @@ export function parseRemittance(val: xdr.ScVal): Remittance {
     createdAt: BigInt(createdAt),
     failedAt:
       map["failed_at"] != null ? BigInt(map["failed_at"] as number) : null,
+    expiresAt:
+      map["expires_at"] != null ? BigInt(map["expires_at"] as number) : null,
   };
 }
 
@@ -175,6 +177,10 @@ export function parseProposal(val: xdr.ScVal): Proposal {
     approvalTimestamp:
       map["approval_timestamp"] != null
         ? BigInt(map["approval_timestamp"] as number)
+        : null,
+    executeAfter:
+      map["execute_after"] != null
+        ? BigInt(map["execute_after"] as number)
         : null,
   };
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -16,7 +16,9 @@ export type RemittanceEventType =
   | "completed"
   | "cancelled"
   | "failed"
-  | "disputed";
+  | "disputed"
+  | "partial_payout"
+  | "expired";
 
 /** A decoded contract event from the Stellar ledger. */
 export interface RemittanceEvent {
@@ -71,6 +73,22 @@ export interface Remittance {
   token: string;
   createdAt: bigint;
   failedAt: bigint | null;
+  /** Ledger timestamp after which anyone can call expireRemittance to refund the sender */
+  expiresAt: bigint | null;
+}
+
+/** A single partial payout disbursement record for a remittance. */
+export interface PartialPayoutRecord {
+  /** Amount disbursed in this payout */
+  amount: bigint;
+  /** Cumulative total disbursed including this payout */
+  totalDisbursed: bigint;
+  /** Remaining amount after this payout */
+  remainingAmount: bigint;
+  /** Ledger timestamp of this disbursement */
+  timestamp: bigint;
+  /** Ledger sequence number of this disbursement */
+  ledgerSequence: number;
 }
 
 export interface AgentStats {
@@ -172,6 +190,8 @@ export interface Proposal {
   expiry: bigint;
   approvalCount: number;
   approvalTimestamp: bigint | null;
+  /** Ledger timestamp before which the proposal cannot be executed (timelock enforced). */
+  executeAfter: bigint | null;
 }
 
 export interface GovernanceConfig {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -332,4 +332,7 @@ pub enum ContractError {
 
     /// Agent reputation is below the minimum threshold.
     BelowMinReputation = 79,
+
+    /// Evidence hash for a dispute is not a valid 32-byte SHA-256 commitment.
+    MalformedEvidenceHash = 80,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -253,11 +253,26 @@ pub fn emit_remittance_failed(env: &Env, id: u64, agent: Address) {
     env.events().publish((Symbol::new(env, "remittance_failed"), id), agent);
 }
 
-pub fn emit_partial_payout(env: &Env, remittance_id: u64, agent: Address, amount: i128, disbursed_total: i128) {
+pub fn emit_partial_payout(env: &Env, remittance_id: u64, agent: Address, amount: i128, disbursed_total: i128, remaining_amount: i128) {
     env.events().publish(
         (Symbol::new(env, "partial_payout"), remittance_id),
-        (agent, amount, disbursed_total),
+        (agent, amount, disbursed_total, remaining_amount),
     );
+}
+
+/// Emits an event when a pending remittance is expired by any caller after its expiry window.
+///
+/// Topics: `("remit", "expired")`
+/// Payload: `(schema_version, ledger_seq, ledger_ts, remittance_id, sender, token, refund_amount, expires_at)`
+pub fn emit_remittance_expired(
+    env: &Env,
+    remittance_id: u64,
+    sender: Address,
+    token: Address,
+    refund_amount: i128,
+    expires_at: u64,
+) {
+    emit_event!(env, "remit", "expired", remittance_id, sender, token, refund_amount, expires_at);
 }
 
 pub fn emit_agent_cap_set(env: &Env, agent: Address, cap: i128, caller: Address) {

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -118,6 +118,7 @@ pub fn do_propose(
         expiry: now + ttl,
         approval_count: 0,
         approval_timestamp: None,
+        execute_after: None,
     };
     set_proposal(env, &proposal);
 
@@ -183,8 +184,10 @@ pub fn do_vote(
     let quorum = get_governance_quorum(env);
     if proposal.approval_count >= quorum {
         let now = env.ledger().timestamp();
+        let timelock = get_governance_timelock(env);
         proposal.state = ProposalState::Approved;
         proposal.approval_timestamp = Some(now);
+        proposal.execute_after = Some(now + timelock);
         emit_proposal_approved(env, proposal_id, now);
     }
 
@@ -206,11 +209,10 @@ pub fn do_execute(
         return Err(ContractError::InvalidProposalState);
     }
 
-    let timelock = get_governance_timelock(env);
-    let approved_at = proposal.approval_timestamp.unwrap_or(0);
     let now = env.ledger().timestamp();
-    if now < approved_at + timelock {
-        return Err(ContractError::TimelockNotElapsed);
+    let execute_after = proposal.execute_after.unwrap_or(0);
+    if now < execute_after {
+        return Err(ContractError::TimelockActive);
     }
 
     // Dispatch the action

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,6 +493,13 @@ impl SwiftRemitContract {
         let counter = get_remittance_counter(&env)?;
         let remittance_id = counter.checked_add(1).ok_or(ContractError::Overflow)?;
 
+        let created_at = env.ledger().timestamp();
+        let expiry_window = storage::get_remittance_expiry_window(&env);
+        let expires_at = if expiry_window > 0 {
+            Some(created_at.saturating_add(expiry_window))
+        } else {
+            None
+        };
         let remittance = Remittance {
             id: remittance_id,
             sender: sender.clone(),
@@ -503,9 +510,10 @@ impl SwiftRemitContract {
             expiry,
             settlement_config: settlement_config.clone().into(),
             token: token_address.clone(),
-            created_at: env.ledger().timestamp(),
+            created_at,
             failed_at: None,
             dispute_evidence: None.into(),
+            expires_at,
         };
 
         let payout_commitment = compute_payout_commitment(&env, &remittance);
@@ -594,6 +602,13 @@ impl SwiftRemitContract {
         let counter = get_remittance_counter(&env)?;
         let remittance_id = counter.checked_add(1).ok_or(ContractError::Overflow)?;
 
+        let corridor_created_at = env.ledger().timestamp();
+        let corridor_expiry_window = storage::get_remittance_expiry_window(&env);
+        let corridor_expires_at = if corridor_expiry_window > 0 {
+            Some(corridor_created_at.saturating_add(corridor_expiry_window))
+        } else {
+            None
+        };
         let remittance = Remittance {
             id: remittance_id,
             sender: sender.clone(),
@@ -604,9 +619,10 @@ impl SwiftRemitContract {
             expiry,
             settlement_config: crate::MaybeSettlementConfig::None,
             token: usdc_token.clone(),
-            created_at: env.ledger().timestamp(),
+            created_at: corridor_created_at,
             failed_at: None,
             dispute_evidence: None.into(),
+            expires_at: corridor_expires_at,
         };
 
         let payout_commitment = compute_payout_commitment(&env, &remittance);
@@ -711,6 +727,13 @@ impl SwiftRemitContract {
             )?;
             cumulative_volume = total_volume;
 
+            let batch_created_at = env.ledger().timestamp();
+            let batch_expiry_window = storage::get_remittance_expiry_window(&env);
+            let batch_expires_at = if batch_expiry_window > 0 {
+                Some(batch_created_at.saturating_add(batch_expiry_window))
+            } else {
+                None
+            };
             let remittance = Remittance {
                 id: remittance_id,
                 sender: sender.clone(),
@@ -721,9 +744,10 @@ impl SwiftRemitContract {
                 expiry: entry.expiry,
                 settlement_config: crate::MaybeSettlementConfig::None,
                 token: usdc_token.clone(),
-                created_at: env.ledger().timestamp(),
+                created_at: batch_created_at,
                 failed_at: None,
                 dispute_evidence: None.into(),
+                expires_at: batch_expires_at,
             };
 
             let payout_commitment = compute_payout_commitment(&env, &remittance);
@@ -1130,8 +1154,17 @@ impl SwiftRemitContract {
 
         storage::add_disbursed_amount(&env, remittance_id, amount)?;
         let new_total = already_disbursed.checked_add(amount).ok_or(ContractError::Overflow)?;
+        let remaining_amount = net_payout.saturating_sub(new_total);
 
-        emit_partial_payout(&env, remittance_id, remittance.agent.clone(), amount, new_total);
+        storage::append_partial_payout_record(&env, remittance_id, crate::PartialPayoutRecord {
+            amount,
+            total_disbursed: new_total,
+            remaining_amount,
+            timestamp: env.ledger().timestamp(),
+            ledger_sequence: env.ledger().sequence(),
+        });
+
+        emit_partial_payout(&env, remittance_id, remittance.agent.clone(), amount, new_total, remaining_amount);
 
         // If fully disbursed, collect fee and complete
         if new_total >= net_payout {
@@ -3286,5 +3319,132 @@ impl SwiftRemitContract {
         get_admin(&env)?;
         require_admin(&env, &caller)?;
         migration::abort_migration(&env, &caller)
+    }
+
+    // ── #835: Partial Payout History ──────────────────────────────────────────
+
+    /// Returns the full disbursement history for a remittance's partial payouts.
+    ///
+    /// SDK consumers can use this to reconstruct cumulative payout state without
+    /// additional on-chain queries. Each entry includes the amount disbursed, the
+    /// cumulative total, and the remaining amount at the time of that disbursement.
+    pub fn get_partial_payout_history(
+        env: Env,
+        remittance_id: u64,
+    ) -> Result<soroban_sdk::Vec<PartialPayoutRecord>, ContractError> {
+        get_remittance(&env, remittance_id)?;
+        Ok(storage::get_partial_payout_history(&env, remittance_id))
+    }
+
+    // ── #836: Time-based remittance expiry ───────────────────────────────────
+
+    /// Expires a pending remittance after its `expires_at` timestamp has passed.
+    ///
+    /// Callable by anyone — no authorization required. The escrowed amount is
+    /// refunded to the original sender and the remittance is marked Cancelled.
+    ///
+    /// # Errors
+    /// - `RemittanceNotFound` — remittance does not exist
+    /// - `InvalidStatus` — remittance is not Pending, or `expires_at` is not set, or not yet expired
+    pub fn expire_remittance(env: Env, remittance_id: u64) -> Result<(), ContractError> {
+        let mut remittance = get_remittance(&env, remittance_id)?;
+
+        if remittance.status != RemittanceStatus::Pending {
+            return Err(ContractError::InvalidStatus);
+        }
+
+        let expires_at = remittance.expires_at.ok_or(ContractError::InvalidStatus)?;
+        let now = env.ledger().timestamp();
+
+        if now < expires_at {
+            return Err(ContractError::InvalidStatus);
+        }
+
+        let token_client = token::Client::new(&env, &remittance.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &remittance.sender,
+            &remittance.amount,
+        );
+
+        let refund_amount = remittance.amount;
+        let token = remittance.token.clone();
+        remittance.status = RemittanceStatus::Cancelled;
+        remittance.amount = 0;
+        set_remittance(&env, remittance_id, &remittance);
+
+        if let Some(idem_key) = storage::take_remittance_idempotency_key(&env, remittance_id) {
+            storage::remove_idempotency_record(&env, &idem_key);
+        }
+
+        emit_remittance_expired(&env, remittance_id, remittance.sender, token, refund_amount, expires_at);
+
+        Ok(())
+    }
+
+    /// Sets the global auto-expiry window for newly created remittances (admin only).
+    ///
+    /// When set to a non-zero value, `create_remittance` will populate `expires_at`
+    /// so that anyone can call `expire_remittance` after the window elapses.
+    /// Set to 0 to disable auto-expiry for new remittances.
+    pub fn set_remittance_expiry_window(env: Env, seconds: u64) -> Result<(), ContractError> {
+        let caller = get_admin(&env)?;
+        require_admin(&env, &caller)?;
+        storage::set_remittance_expiry_window(&env, seconds);
+        Ok(())
+    }
+
+    /// Returns the configured auto-expiry window in seconds (0 = disabled).
+    pub fn get_remittance_expiry_window(env: Env) -> u64 {
+        storage::get_remittance_expiry_window(&env)
+    }
+
+    // ── #838: Dispute evidence validation ────────────────────────────────────
+
+    /// Opens a dispute on a failed remittance with on-chain evidence hash validation.
+    ///
+    /// Unlike `raise_dispute` (which accepts `BytesN<32>` enforced by the SDK),
+    /// this function accepts raw `Bytes` and explicitly validates that the evidence
+    /// hash is exactly 32 bytes, returning `MalformedEvidenceHash` if not.
+    ///
+    /// # Errors
+    /// - `RemittanceNotFound` — remittance does not exist
+    /// - `InvalidStatus` — remittance is not in Failed state
+    /// - `DisputeWindowExpired` — the dispute window has elapsed since failure
+    /// - `MalformedEvidenceHash` — evidence hash is not exactly 32 bytes
+    pub fn open_dispute(
+        env: Env,
+        remittance_id: u64,
+        evidence_hash: soroban_sdk::Bytes,
+    ) -> Result<(), ContractError> {
+        validate_evidence_hash(&evidence_hash)?;
+
+        let hash_bytes: soroban_sdk::BytesN<32> = evidence_hash
+            .try_into()
+            .map_err(|_| ContractError::MalformedEvidenceHash)?;
+
+        let mut remittance = get_remittance(&env, remittance_id)?;
+        remittance.sender.require_auth();
+
+        if remittance.status != RemittanceStatus::Failed {
+            return Err(ContractError::InvalidStatus);
+        }
+
+        let failed_at = remittance.failed_at.ok_or(ContractError::InvalidStatus)?;
+        let window = get_dispute_window(&env);
+        if env.ledger().timestamp() > failed_at + window {
+            return Err(ContractError::DisputeWindowExpired);
+        }
+
+        remittance.status = RemittanceStatus::Disputed;
+        remittance.dispute_evidence = Some(hash_bytes.clone());
+        set_remittance(&env, remittance_id, &remittance);
+
+        let mut stats = crate::storage::get_agent_stats(&env, &remittance.agent);
+        stats.dispute_count += 1;
+        crate::storage::set_agent_stats(&env, &remittance.agent, &stats);
+
+        emit_dispute_raised(&env, remittance_id, remittance.sender, hash_bytes);
+        Ok(())
     }
 }

--- a/src/netting.rs
+++ b/src/netting.rs
@@ -270,6 +270,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         // B -> A: 90
@@ -286,6 +287,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         let result = compute_net_settlements(&env, &remittances).unwrap();
@@ -327,6 +329,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         // B -> A: 100
@@ -343,6 +346,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         let result = compute_net_settlements(&env, &remittances).unwrap();
@@ -375,6 +379,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         // B -> C: 50
@@ -391,6 +396,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         // C -> A: 30
@@ -407,6 +413,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         let result = compute_net_settlements(&env, &remittances).unwrap();
@@ -444,6 +451,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         remittances.push_back(Remittance {
@@ -459,6 +467,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         let result = compute_net_settlements(&env, &remittances).unwrap();
@@ -488,6 +497,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
         remittances1.push_back(Remittance {
             id: 2,
@@ -502,6 +512,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         // Second ordering (reversed)
@@ -519,6 +530,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
         remittances2.push_back(Remittance {
             id: 1,
@@ -533,6 +545,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         });
 
         let net1 = compute_net_settlements(&env, &remittances1).unwrap().net_transfers;
@@ -573,6 +586,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -175,6 +175,9 @@ enum DataKey {
     DisputeWindow,
     // === Partial Payout ===
     DisbursedAmount(u64),
+    PartialPayoutHistory(u64),
+    // === Remittance Expiry Window ===
+    RemittanceExpiryWindow,
     // === Idempotency ===
     IdempotencyRecord(soroban_sdk::String),
     IdempotencyTTL,
@@ -1610,6 +1613,50 @@ pub fn add_disbursed_amount(env: &Env, remittance_id: u64, amount: i128) -> Resu
         .persistent()
         .set(&DataKey::DisbursedAmount(remittance_id), &next);
     Ok(())
+}
+
+/// Appends a partial payout record to the remittance's disbursement history.
+pub fn append_partial_payout_record(
+    env: &Env,
+    remittance_id: u64,
+    record: crate::PartialPayoutRecord,
+) {
+    let mut history: Vec<crate::PartialPayoutRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::PartialPayoutHistory(remittance_id))
+        .unwrap_or_else(|| Vec::new(env));
+    history.push_back(record);
+    env.storage()
+        .persistent()
+        .set(&DataKey::PartialPayoutHistory(remittance_id), &history);
+}
+
+/// Returns the full list of partial payout records for a remittance.
+pub fn get_partial_payout_history(
+    env: &Env,
+    remittance_id: u64,
+) -> Vec<crate::PartialPayoutRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PartialPayoutHistory(remittance_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns the global remittance auto-expiry window in seconds (0 = disabled).
+pub fn get_remittance_expiry_window(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RemittanceExpiryWindow)
+        .unwrap_or(0)
+}
+
+/// Sets the global remittance auto-expiry window in seconds.
+/// A value of 0 disables auto-expiry for newly created remittances.
+pub fn set_remittance_expiry_window(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::RemittanceExpiryWindow, &seconds);
 }
 
 // === Per-Agent Daily Withdrawal Cap ===

--- a/src/test_escrow.rs
+++ b/src/test_escrow.rs
@@ -327,6 +327,7 @@ fn test_zero_net_position_produces_no_transfer() {
         created_at: 0,
         failed_at: None,
         dispute_evidence: crate::MaybeBytes32::None,
+        expires_at: None,
     });
 
     // B -> A: 100 (exact mirror — net is zero)
@@ -343,6 +344,7 @@ fn test_zero_net_position_produces_no_transfer() {
         created_at: 0,
         failed_at: None,
         dispute_evidence: crate::MaybeBytes32::None,
+        expires_at: None,
     });
 
     let net_transfers: Vec<NetTransfer> = compute_net_settlements(&env, &remittances).unwrap().net_transfers;

--- a/src/transaction_controller.rs
+++ b/src/transaction_controller.rs
@@ -238,6 +238,7 @@ impl TransactionController {
             created_at: env.ledger().timestamp(),
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         };
 
         crate::storage::set_remittance(env, remittance_id, &remittance);

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -316,6 +316,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         };
 
         let result = transition_status(&env, &mut remittance, RemittanceStatus::Processing);
@@ -343,6 +344,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         };
 
         let result = transition_status(&env, &mut remittance, RemittanceStatus::Pending);
@@ -371,6 +373,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: None,
+            expires_at: None,
         };
 
         let result = transition_status(&env, &mut remittance, RemittanceStatus::Pending);

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,17 +123,6 @@ pub struct SettlementConfig {
     pub oracle_address: Option<Address>,
 }
 
-/// Contracttype-compatible wrapper for Option<SettlementConfig>.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum MaybeSettlementConfig {
-    None,
-    Some(SettlementConfig),
-}
-impl From<Option<SettlementConfig>> for MaybeSettlementConfig {
-    fn from(o: Option<SettlementConfig>) -> Self { match o { None => Self::None, Some(v) => Self::Some(v) } }
-}
-
 /// Escrow status for locked funds
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -229,6 +218,8 @@ pub struct Remittance {
     pub failed_at: Option<u64>,
     /// Hash of evidence provided by the sender during a dispute
     pub dispute_evidence: MaybeBytes32,
+    /// Ledger timestamp after which anyone can call expire_remittance to refund the sender
+    pub expires_at: Option<u64>,
 }
 
 #[contracttype]
@@ -471,4 +462,25 @@ pub struct Proposal {
     pub approval_count: u32,
     /// Ledger timestamp when quorum was reached (set on Approved transition).
     pub approval_timestamp: Option<u64>,
+    /// Ledger timestamp before which the proposal cannot be executed (timelock enforced).
+    pub execute_after: Option<u64>,
+}
+
+/// Record of a single partial payout disbursement for a remittance.
+///
+/// Stored per remittance to enable cumulative payout state reconstruction
+/// without additional on-chain queries.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PartialPayoutRecord {
+    /// Amount disbursed in this payout
+    pub amount: i128,
+    /// Cumulative total disbursed (including this payout)
+    pub total_disbursed: i128,
+    /// Remaining amount left to disburse (net_payout - total_disbursed)
+    pub remaining_amount: i128,
+    /// Ledger timestamp when this disbursement occurred
+    pub timestamp: u64,
+    /// Ledger sequence when this disbursement occurred
+    pub ledger_sequence: u32,
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -206,6 +206,17 @@ pub fn normalize_symbol(_env: &Env, symbol: &soroban_sdk::String) -> Result<soro
     Ok(symbol.clone())
 }
 
+/// Validates that an evidence hash is a 32-byte SHA-256 commitment.
+///
+/// Rejects hashes that are not exactly 32 bytes, returning a descriptive error
+/// so callers know precisely what constraint was violated.
+pub fn validate_evidence_hash(hash: &soroban_sdk::Bytes) -> Result<(), ContractError> {
+    if hash.len() != 32 {
+        return Err(ContractError::MalformedEvidenceHash);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -51,6 +51,7 @@ mod tests {
             created_at: 0,
             failed_at: None,
             dispute_evidence: crate::MaybeBytes32::None,
+            expires_at: None,
         };
 
         let commitment = compute_payout_commitment(&env, &remittance);


### PR DESCRIPTION
#835 – emit_partial_payout now includes total_disbursed and remaining_amount fields; add PartialPayoutRecord type and get_partial_payout_history view so SDK consumers can reconstruct cumulative payout state without extra on-chain queries.

#836 – add expires_at field to Remittance; expire_remittance function callable by anyone after expiry; remittance_expired event with refund details; set_/get_remittance_expiry_window admin controls.

#837 – governance execute_proposal stores execute_after on approval and enforces it in do_execute, returning TimelockActive when the timelock has not elapsed.

#838 – open_dispute accepts raw Bytes and validates the evidence hash is exactly 32 bytes via validate_evidence_hash in validation.rs, returning MalformedEvidenceHash on invalid input.

Also: remove duplicate MaybeSettlementConfig definition in types.rs; update .gitignore with IDE, log, and build artefacts.

Closes #835 
closes #836 
closes #837 
closes #838 