### PR TITLE
fix(#831-834): wire transaction_controller hooks, multi-currency governance, agent reputation enforcement, net settlement execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,23 @@ backend/node_modules/
 # Test artifacts
 test_snapshots/
 proptest-regressions/
+
+# IDE / editor artifacts
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Node artifacts (api, sdk, examples)
+api/node_modules/
+sdk/node_modules/
+examples/node_modules/
+
+# Build outputs
+dist/
+out/
+

--- a/FEE_SERVICE_ARCHITECTURE.md
+++ b/FEE_SERVICE_ARCHITECTURE.md
@@ -434,3 +434,59 @@ The refactored architecture provides:
 - ✅ Comprehensive fee transparency
 - ✅ Flexible corridor support
 - ✅ Production-ready implementation
+
+---
+
+## Net Settlement Execution (#834)
+
+### Overview
+
+`execute_net_settlement` is the on-chain execution path for netting.rs. It moves only
+the **net difference** between opposing agent flows instead of executing every individual
+remittance transfer, dramatically reducing on-chain token transfer count.
+
+### Authorization
+
+Only addresses holding the **Admin role** (settlement operators) may call this function.
+The caller must `require_auth()` and pass `require_role_admin()` before any state changes.
+
+### Flow
+
+```
+operator calls execute_net_settlement(operator, [id1, id2, ...])
+    │
+    ├─ 1. Auth: operator.require_auth() + require_role_admin()
+    ├─ 2. Guard: contract not paused, batch size 1–50
+    ├─ 3. Load: fetch all Pending remittances, reject expired/settled
+    │
+    ├─ 4. Compute: netting::compute_net_settlements()
+    │       Groups flows by (party_a, party_b) pair (address-sorted for determinism)
+    │       Offsets opposing flows — e.g. A→B 100 and B→A 90 → net 10 A→B
+    │
+    ├─ 5. Validate: netting::validate_net_settlement() — fees must be conserved
+    │
+    ├─ 6. Execute net token transfers (contract → recipient, payout = net - fees)
+    │       Accumulate fees into platform fee pool
+    │       Emit settlement_completed event per net transfer
+    │
+    └─ 7. Finalize: mark each remittance Completed, set settlement hash,
+              emit remittance_completed per remittance
+              return BatchSettlementResult { settled_ids }
+```
+
+### Example
+
+| Remittance | Direction | Amount | Fee |
+|-----------|-----------|--------|-----|
+| #1        | A → B     | 100    | 2   |
+| #2        | B → A     | 90     | 1   |
+
+**Result:** Single net transfer of **9** (= 10 net − 1 fee) from A to B.
+Total fees collected: **3** (2 + 1).
+
+### Key Properties
+
+- **Single call**: all net transfers execute atomically in one contract invocation.
+- **Deterministic**: address-pair ordering is canonical; same input always produces same output.
+- **Fee-preserving**: total fees in = total fees out (validated before execution).
+- **DoS-safe**: batch capped at `MAX_NETTING_BATCH_SIZE` (50).

--- a/src/events.rs
+++ b/src/events.rs
@@ -514,6 +514,26 @@ pub fn emit_proposal_cleaned_up(env: &Env, proposal_id: u64) {
     );
 }
 
+/// Emits when an agent's reputation score falls below the minimum threshold (#833).
+/// Fired during the reputation gate check in `create_remittance`.
+pub fn emit_agent_suspended(env: &Env, agent: Address, reputation: u32, min_threshold: u32) {
+    emit_event!(env, "agent", "suspnded", agent, reputation, min_threshold);
+}
+
+/// Emits when an agent's reputation score drops below the minimum threshold (#833).
+///
+/// Fired at the point of the failed eligibility check inside `create_remittance`
+/// so off-chain systems can detect and flag low-reputation agents automatically.
+///
+/// # Topics
+/// `("agent", "suspended")`
+///
+/// # Payload
+/// `(schema_version, ledger_sequence, ledger_timestamp, agent, reputation_score, min_threshold)`
+pub fn emit_agent_suspended(env: &Env, agent: Address, reputation: u32, min_threshold: u32) {
+    emit_event!(env, "agent", "suspnded", agent, reputation, min_threshold);
+}
+
 /// Emits when a cross-contract migration is aborted and state is reset to Idle.
 pub fn emit_migration_aborted(env: &Env, caller: Address) {
     env.events().publish(

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -103,6 +103,18 @@ pub fn do_propose(
             }
         }
         ProposalAction::UpdateTimelock(_) => {}
+        // #832: validate token is not already whitelisted
+        ProposalAction::WhitelistAsset(token) => {
+            if storage::is_token_whitelisted(env, token) {
+                return Err(ContractError::TokenAlreadyWhitelisted);
+            }
+        }
+        // #833: validate threshold is in valid range
+        ProposalAction::AdjustReputationThreshold(threshold) => {
+            if *threshold > 100 {
+                return Err(ContractError::InvalidReputationScore);
+            }
+        }
     }
 
     let id = next_proposal_id(env);
@@ -399,6 +411,28 @@ fn dispatch_action(
         ProposalAction::UpdateTimelock(s) => {
             set_governance_timelock(env, *s);
         }
+        // #832: Whitelist a new token asset for multi-currency remittances.
+        ProposalAction::WhitelistAsset(token) => {
+            if storage::is_token_whitelisted(env, token) {
+                return Err(ContractError::TokenAlreadyWhitelisted);
+            }
+            storage::set_token_whitelisted(env, token, true);
+            env.events().publish(
+                (soroban_sdk::symbol_short!("gov"), soroban_sdk::symbol_short!("wl_asset")),
+                (token.clone(), proposal_id),
+            );
+        }
+        // #833: Adjust the minimum reputation threshold via DAO governance.
+        ProposalAction::AdjustReputationThreshold(threshold) => {
+            if *threshold > 100 {
+                return Err(ContractError::InvalidReputationScore);
+            }
+            storage::set_min_agent_reputation(env, *threshold);
+            env.events().publish(
+                (soroban_sdk::symbol_short!("gov"), soroban_sdk::symbol_short!("rep_thr")),
+                (*threshold, proposal_id),
+            );
+        }
     }
     Ok(())
 }
@@ -416,5 +450,7 @@ fn action_type_symbol(env: &Env, action: &ProposalAction) -> Symbol {
         ProposalAction::RemoveAdmin(_) => Symbol::new(env, "rem_admin"),
         ProposalAction::UpdateQuorum(_) => Symbol::new(env, "upd_quorum"),
         ProposalAction::UpdateTimelock(_) => Symbol::new(env, "upd_tlock"),
+        ProposalAction::WhitelistAsset(_) => Symbol::new(env, "wl_asset"),
+        ProposalAction::AdjustReputationThreshold(_) => Symbol::new(env, "rep_thr"),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,8 @@ impl SwiftRemitContract {
         if min_rep > 0 {
             let rep = storage::compute_agent_reputation(&storage::get_agent_stats(&env, &agent));
             if rep < min_rep {
+                // #833: emit agent_suspended event so off-chain monitors can react
+                events::emit_agent_suspended(&env, agent.clone(), rep, min_rep);
                 return Err(ContractError::BelowMinReputation);
             }
         }
@@ -789,6 +791,10 @@ impl SwiftRemitContract {
         if agent != remittance.agent {
             return Err(ContractError::Unauthorized);
         }
+
+        // #831: Pre-confirm lifecycle hook — validates sender eligibility and KYC
+        // before any state mutation occurs.
+        transaction_controller::TransactionController::pre_confirm_validation(&env, &remittance)?;
 
         // Validate proof against settlement config if required
         if let crate::MaybeSettlementConfig::Some(ref config) = remittance.settlement_config {
@@ -1256,6 +1262,10 @@ impl SwiftRemitContract {
         if let Some(idem_key) = storage::take_remittance_idempotency_key(&env, remittance_id) {
             storage::remove_idempotency_record(&env, &idem_key);
         }
+
+        // #831: Post-cancel cleanup — removes controller-layer bookkeeping entries
+        // so stale transaction records and anchor mappings do not persist after cancellation.
+        transaction_controller::TransactionController::post_cancel_cleanup(&env, remittance_id)?;
 
         Ok(())
     }
@@ -3286,5 +3296,106 @@ impl SwiftRemitContract {
         get_admin(&env)?;
         require_admin(&env, &caller)?;
         migration::abort_migration(&env, &caller)
+    }
+
+    /// Executes net settlement for a batch of remittances in a single contract call (#834).
+    ///
+    /// Computes the minimal set of net token transfers between agents by offsetting
+    /// opposing flows (e.g. A→B 100 and B→A 90 produce a single net transfer of 10
+    /// from A to B). Only the net difference moves on-chain, reducing transfer volume.
+    ///
+    /// # Authorization
+    /// Caller must be a registered admin (settlement operator).
+    ///
+    /// # Parameters
+    /// - `operator`: Admin/operator address — must authenticate and hold Admin role.
+    /// - `remittance_ids`: IDs of Pending remittances to net and settle (max 50).
+    ///
+    /// # Returns
+    /// `BatchSettlementResult` with the list of settled remittance IDs.
+    ///
+    /// # Errors
+    /// - `Unauthorized` / `NotInitialized` — operator is not an admin
+    /// - `ContractPaused` — contract is paused
+    /// - `InvalidBatchSize` — empty or over-limit batch
+    /// - `RemittanceNotFound` — unknown remittance ID
+    /// - `InvalidStatus` — remittance is not Pending
+    /// - `DuplicateSettlement` — already settled
+    /// - `SettlementExpired` — remittance has expired
+    /// - `NetSettlementValidationFailed` — netting math error
+    pub fn execute_net_settlement(
+        env: Env,
+        operator: Address,
+        remittance_ids: Vec<u64>,
+    ) -> Result<BatchSettlementResult, ContractError> {
+        // Operator must authenticate and hold Admin role
+        operator.require_auth();
+        require_role_admin(&env, &operator)?;
+
+        if is_paused(&env) {
+            return Err(ContractError::ContractPaused);
+        }
+
+        let batch_size = remittance_ids.len();
+        if batch_size == 0 || batch_size > MAX_NETTING_BATCH_SIZE {
+            return Err(ContractError::InvalidBatchSize);
+        }
+
+        // Load and validate all remittances upfront
+        let mut remittances = Vec::new(&env);
+        for i in 0..batch_size {
+            let id = remittance_ids.get_unchecked(i);
+            let remittance = get_remittance(&env, id)?;
+
+            if remittance.status != RemittanceStatus::Pending {
+                return Err(ContractError::InvalidStatus);
+            }
+            if has_settlement_hash(&env, id) {
+                return Err(ContractError::DuplicateSettlement);
+            }
+            if let Some(expiry) = remittance.expiry {
+                if env.ledger().timestamp() > expiry {
+                    return Err(ContractError::SettlementExpired);
+                }
+            }
+            remittances.push_back(remittance);
+        }
+
+        // Compute and validate net transfers
+        let netting_result = compute_net_settlements(&env, &remittances)?;
+        validate_net_settlement(&remittances, &netting_result.net_transfers)?;
+
+        let usdc_token = get_usdc_token(&env)?;
+        let token_client = token::Client::new(&env, &usdc_token);
+
+        // Execute each net transfer
+        for i in 0..netting_result.net_transfers.len() {
+            let transfer = netting_result.net_transfers.get_unchecked(i);
+            if transfer.net_amount == 0 {
+                continue;
+            }
+            let (from, to, amount) = if transfer.net_amount > 0 {
+                (transfer.party_a.clone(), transfer.party_b.clone(), transfer.net_amount)
+            } else {
+                (transfer.party_b.clone(), transfer.party_a.clone(), -transfer.net_amount)
+            };
+            let payout = amount.checked_sub(transfer.total_fees).ok_or(ContractError::Overflow)?;
+            token_client.transfer(&env.current_contract_address(), &to, &payout);
+            safe_add_accumulated_fee(&env, transfer.total_fees)?;
+            emit_settlement_completed(&env, 0, from, to, usdc_token.clone(), payout);
+        }
+
+        // Mark all remittances completed
+        let mut settled_ids = Vec::new(&env);
+        for i in 0..remittances.len() {
+            let mut remittance = remittances.get_unchecked(i);
+            remittance.status = RemittanceStatus::Completed;
+            set_remittance(&env, remittance.id, &remittance);
+            set_settlement_hash(&env, remittance.id);
+            emit_remittance_completed(&env, remittance.id, remittance.sender, remittance.agent);
+            settled_ids.push_back(remittance.id);
+        }
+
+        Ok(BatchSettlementResult { settled_ids })
     }
 }

--- a/src/transaction_controller.rs
+++ b/src/transaction_controller.rs
@@ -376,6 +376,36 @@ impl TransactionController {
             .wrapping_add(timestamp)
     }
 
+    /// Pre-confirm lifecycle hook: validates user eligibility and KYC before payout confirmation.
+    ///
+    /// Called at the start of `confirm_payout` to ensure the remittance sender still
+    /// meets all eligibility requirements before any state mutation occurs.
+    pub fn pre_confirm_validation(env: &Env, remittance: &Remittance) -> Result<(), ContractError> {
+        Self::validate_eligibility(env, &remittance.sender)?;
+        Self::confirm_kyc(env, &remittance.sender)?;
+        Ok(())
+    }
+
+    /// Post-cancel cleanup hook: removes any controller-layer bookkeeping when a
+    /// remittance is cancelled so stale records do not persist.
+    ///
+    /// Called at the end of `cancel_remittance` after the refund transfer succeeds.
+    pub fn post_cancel_cleanup(env: &Env, remittance_id: u64) -> Result<(), ContractError> {
+        // Remove the transaction record if one was stored by the controller
+        if let Ok(mut record) = crate::storage::get_transaction_record(env, remittance_id) {
+            record.state = TransactionState::RolledBack;
+            // Persist the updated state so audit trails remain accurate
+            let _ = crate::storage::set_transaction_record(env, remittance_id, &record);
+        }
+        // Cancel any pending anchor operation
+        if let Ok(remittance_id_mapped) =
+            crate::storage::get_anchor_transaction(env, remittance_id)
+        {
+            let _ = Self::cancel_anchor_operation(env, remittance_id_mapped);
+        }
+        Ok(())
+    }
+
     /// Get transaction status
     pub fn get_transaction_status(
         env: &Env,

--- a/src/types.rs
+++ b/src/types.rs
@@ -424,6 +424,12 @@ pub enum ProposalAction {
     UpdateQuorum(u32),
     /// Update the governance execution timelock in seconds.
     UpdateTimelock(u64),
+    /// Add the given token address to the asset allowlist (#832).
+    /// Enables remittances denominated in that Stellar-native asset.
+    WhitelistAsset(Address),
+    /// Adjust the minimum agent reputation threshold (#833).
+    /// Agents with a score below this value cannot accept new remittances.
+    AdjustReputationThreshold(u32),
 }
 
 /// Lifecycle state of a governance proposal.


### PR DESCRIPTION
#831: Add pre_confirm_validation and post_cancel_cleanup lifecycle hooks to TransactionController; wire them into confirm_payout (pre) and cancel_remittance (post) in lib.rs.

#832: Add WhitelistAsset(Address) and AdjustReputationThreshold(u32) variants to ProposalAction enum; wire dispatch_action, action_type_symbol, and do_propose validation in governance.rs. Per-token fee storage (TokenFeeBps) was already in place.

#833: Add emit_agent_suspended event (topics: agent/suspnded) to events.rs; emit it in create_remittance when an agent's reputation score falls below the configured minimum threshold.

#834: Add execute_net_settlement contract function with operator auth (require_auth + require_role_admin), pause guard, batch-size guard (max 50), netting computation via compute_net_settlements, fee accumulation, and per-remittance completion. Document the netting flow in FEE_SERVICE_ARCHITECTURE.md.

closes #831 
closes #832 
closes #833 
closes #834 