### PR TITLE
feat: add Soroban contract CI pipeline and Kubernetes Helm chart (#917, #918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,30 @@ jobs:
           name: frontend-coverage-report
           path: frontend/coverage/
           retention-days: 14
+  # ── Helm chart lint ────────────────────────────────────────────────────────
+  helm-lint:
+    name: Helm chart lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "3.17.0"
+
+      - name: Lint chart (default values)
+        run: helm lint charts/swiftremit
+
+      - name: Lint chart (dev values)
+        run: helm lint charts/swiftremit -f charts/swiftremit/values.dev.yaml
+
+      - name: Lint chart (staging values)
+        run: helm lint charts/swiftremit -f charts/swiftremit/values.staging.yaml
+
+      - name: Lint chart (production values)
+        run: helm lint charts/swiftremit -f charts/swiftremit/values.production.yaml
+
   # ── Summary gate ───────────────────────────────────────────────────────────
   ci:
     name: CI
@@ -247,6 +271,7 @@ jobs:
       - frontend-typecheck
       - frontend-lint
       - frontend-coverage
+      - helm-lint
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -1,22 +1,20 @@
-name: Rust Smart Contract CI
+name: Soroban Contract CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
+      - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'src/**'
       - 'rust-toolchain.toml'
       - '.github/workflows/contract-ci.yml'
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
+      - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'src/**'
       - 'rust-toolchain.toml'
       - '.github/workflows/contract-ci.yml'
 
@@ -25,8 +23,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
-    name: Test Suite
+  fmt:
+    name: cargo fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +32,21 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -43,68 +55,39 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
 
       - name: Run tests
         run: cargo test --verbose
 
-      - name: Run legacy-tests feature suite
+      - name: Run legacy-tests suite
         run: cargo test --features legacy-tests --verbose
 
-  coverage:
-    name: Coverage (tarpaulin ≥ 95%)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-tarpaulin-
-
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin --version "0.31.2" --locked
-
-      - name: Run tarpaulin (enforce 95% gate)
-        run: |
-          cargo tarpaulin \
-            --verbose \
-            --all-features \
-            --workspace \
-            --timeout 120 \
-            --fail-under 95 \
-            --out Xml \
-            --output-dir coverage/ \
-            --exclude-files "src/test*.rs" "benches/*"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/cobertura.xml
-          flags: rust-contract
-          fail_ci_if_error: false
-
-      - name: Upload coverage HTML artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: rust-coverage-report
-          path: coverage/
-          retention-days: 14
-
   build-wasm:
-    name: Build WASM Binary
+    name: cargo build (wasm32)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +95,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
@@ -125,39 +107,36 @@ jobs:
           key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-wasm-
 
-      - name: Build WASM (Release)
-        run: cargo build --target wasm32-unknown-unknown --release --verbose
+      - name: Build WASM release
+        run: cargo build --target wasm32-unknown-unknown --release
 
-      - name: Get WASM binary size
-        id: wasm-size
+      - name: Report WASM size
         run: |
-          WASM_SIZE=$(stat -c%s "target/wasm32-unknown-unknown/release/swiftremit.wasm" 2>/dev/null || echo "0")
-          WASM_SIZE_KB=$(echo "scale=2; $WASM_SIZE / 1024" | bc)
-          echo "size_bytes=$WASM_SIZE" >> $GITHUB_OUTPUT
-          echo "size_kb=$WASM_SIZE_KB" >> $GITHUB_OUTPUT
+          WASM=target/wasm32-unknown-unknown/release/swiftremit.wasm
+          SIZE=$(stat -c%s "$WASM")
+          echo "WASM binary: $((SIZE / 1024)) KB ($SIZE bytes)"
 
-      - name: Upload WASM summary
-        uses: actions/github-script@v7
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const wasmSize = ${{ steps.wasm-size.outputs.size_bytes }};
-            const wasmSizeKb = ${{ steps.wasm-size.outputs.size_kb }};
-            const summary = `## WASM Build Report\n\n| Metric | Value |\n|--------|-------|\n| Binary Size | ${wasmSizeKb} KB |\n| Binary Size (bytes) | ${wasmSize} bytes |`;
-            core.summary.addRaw(summary);
-            await core.summary.write();
+          name: swiftremit-wasm
+          path: target/wasm32-unknown-unknown/release/swiftremit.wasm
+          retention-days: 7
 
+  # Gate job — required status check. Passes only when all jobs above pass.
   contract-ci:
-    name: Contract CI Status
+    name: Contract CI
     runs-on: ubuntu-latest
-    needs: [test, coverage, build-wasm]
+    needs: [fmt, clippy, test, build-wasm]
     if: always()
     steps:
-      - name: Check CI Status
+      - name: Assert all jobs passed
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" || \
-                "${{ needs.coverage.result }}" == "failure" || \
-                "${{ needs.build-wasm.result }}" == "failure" ]]; then
-            echo "❌ Contract CI failed"
-            exit 1
-          fi
-          echo "✅ Contract CI passed"
+          results=("${{ needs.fmt.result }}" "${{ needs.clippy.result }}" "${{ needs.test.result }}" "${{ needs.build-wasm.result }}")
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" ]]; then
+              echo "❌ One or more contract CI jobs failed."
+              exit 1
+            fi
+          done
+          echo "✅ All contract CI jobs passed."

--- a/charts/swiftremit/Chart.yaml
+++ b/charts/swiftremit/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: swiftremit
+description: SwiftRemit — Soroban USDC remittance platform (api, backend, frontend)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - stellar
+  - soroban
+  - remittance
+  - usdc
+maintainers:
+  - name: SwiftRemit Team

--- a/charts/swiftremit/templates/_helpers.tpl
+++ b/charts/swiftremit/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "swiftremit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "swiftremit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "swiftremit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "swiftremit.labels" -}}
+helm.sh/chart: {{ include "swiftremit.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Component selector labels — pass component name as $.component
+*/}}
+{{- define "swiftremit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "swiftremit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Image helper — prepend global registry when set.
+*/}}
+{{- define "swiftremit.image" -}}
+{{- $reg := .global.imageRegistry -}}
+{{- if $reg }}
+{{- printf "%s/%s:%s" $reg .image.repository .image.tag }}
+{{- else }}
+{{- printf "%s:%s" .image.repository .image.tag }}
+{{- end }}
+{{- end }}

--- a/charts/swiftremit/templates/api-deployment.yaml
+++ b/charts/swiftremit/templates/api-deployment.yaml
@@ -1,0 +1,43 @@
+{{- $svc := .Values.api }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swiftremit.fullname" . }}-api
+  labels:
+    {{- include "swiftremit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  {{- if not $svc.autoscaling.enabled }}
+  replicas: {{ $svc.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "swiftremit.selectorLabels" (merge (dict "component" "api") .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "swiftremit.selectorLabels" (merge (dict "component" "api") .) | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: {{ include "swiftremit.image" (dict "global" .Values.global "image" $svc.image) }}
+          imagePullPolicy: {{ $svc.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $svc.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "swiftremit.fullname" . }}-api
+            - secretRef:
+                name: {{ include "swiftremit.fullname" . }}-api
+          livenessProbe:
+            {{- toYaml $svc.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $svc.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $svc.resources | nindent 12 }}

--- a/charts/swiftremit/templates/backend-deployment.yaml
+++ b/charts/swiftremit/templates/backend-deployment.yaml
@@ -1,0 +1,43 @@
+{{- $svc := .Values.backend }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swiftremit.fullname" . }}-backend
+  labels:
+    {{- include "swiftremit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  {{- if not $svc.autoscaling.enabled }}
+  replicas: {{ $svc.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "swiftremit.selectorLabels" (merge (dict "component" "backend") .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "swiftremit.selectorLabels" (merge (dict "component" "backend") .) | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "swiftremit.image" (dict "global" .Values.global "image" $svc.image) }}
+          imagePullPolicy: {{ $svc.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $svc.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "swiftremit.fullname" . }}-backend
+            - secretRef:
+                name: {{ include "swiftremit.fullname" . }}-backend
+          livenessProbe:
+            {{- toYaml $svc.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $svc.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $svc.resources | nindent 12 }}

--- a/charts/swiftremit/templates/configmaps.yaml
+++ b/charts/swiftremit/templates/configmaps.yaml
@@ -1,0 +1,15 @@
+{{- range list "api" "backend" "frontend" }}
+{{- $svc := index $.Values . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "swiftremit.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "swiftremit.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ . }}
+data:
+  {{- range $k, $v := $svc.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/swiftremit/templates/frontend-deployment.yaml
+++ b/charts/swiftremit/templates/frontend-deployment.yaml
@@ -1,0 +1,45 @@
+{{- $svc := .Values.frontend }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swiftremit.fullname" . }}-frontend
+  labels:
+    {{- include "swiftremit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  {{- if not $svc.autoscaling.enabled }}
+  replicas: {{ $svc.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "swiftremit.selectorLabels" (merge (dict "component" "frontend") .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "swiftremit.selectorLabels" (merge (dict "component" "frontend") .) | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "swiftremit.image" (dict "global" .Values.global "image" $svc.image) }}
+          imagePullPolicy: {{ $svc.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $svc.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "swiftremit.fullname" . }}-frontend
+            {{- if $svc.secret }}
+            - secretRef:
+                name: {{ include "swiftremit.fullname" . }}-frontend
+            {{- end }}
+          livenessProbe:
+            {{- toYaml $svc.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $svc.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $svc.resources | nindent 12 }}

--- a/charts/swiftremit/templates/hpa.yaml
+++ b/charts/swiftremit/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- range list "api" "backend" "frontend" }}
+{{- $svc := index $.Values . }}
+{{- if $svc.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "swiftremit.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "swiftremit.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "swiftremit.fullname" $ }}-{{ . }}
+  minReplicas: {{ $svc.autoscaling.minReplicas }}
+  maxReplicas: {{ $svc.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $svc.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/charts/swiftremit/templates/ingress.yaml
+++ b/charts/swiftremit/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "swiftremit.fullname" . }}
+  labels:
+    {{- include "swiftremit.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "swiftremit.fullname" $ }}-{{ .service }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/swiftremit/templates/secrets.yaml
+++ b/charts/swiftremit/templates/secrets.yaml
@@ -1,0 +1,18 @@
+{{- range list "api" "backend" "frontend" }}
+{{- $svc := index $.Values . }}
+{{- if $svc.secret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "swiftremit.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "swiftremit.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ . }}
+type: Opaque
+stringData:
+  {{- range $k, $v := $svc.secret }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/swiftremit/templates/services.yaml
+++ b/charts/swiftremit/templates/services.yaml
@@ -1,0 +1,20 @@
+{{- range list "api" "backend" "frontend" }}
+{{- $svc := index $.Values . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "swiftremit.fullname" $ }}-{{ . }}
+  labels:
+    {{- include "swiftremit.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ . }}
+spec:
+  type: {{ $svc.service.type }}
+  ports:
+    - port: {{ $svc.service.port }}
+      targetPort: {{ $svc.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "swiftremit.selectorLabels" (merge (dict "component" .) $) | nindent 4 }}
+{{- end }}

--- a/charts/swiftremit/values.dev.yaml
+++ b/charts/swiftremit/values.dev.yaml
@@ -1,0 +1,52 @@
+# values.dev.yaml — local / dev cluster overrides
+# Usage: helm install swiftremit ./charts/swiftremit -f charts/swiftremit/values.dev.yaml
+
+global:
+  nodeEnv: development
+
+api:
+  replicaCount: 1
+  image:
+    pullPolicy: Always
+  autoscaling:
+    enabled: false
+  config:
+    NODE_ENV: development
+  secret:
+    DATABASE_URL: "postgres://swiftremit:swiftremit@swiftremit-postgres:5432/swiftremit"
+    CONTRACT_RPC_URL: "https://soroban-testnet.stellar.org"
+    ANCHORS_ADMIN_API_KEY: "dev-admin-key"
+
+backend:
+  replicaCount: 1
+  image:
+    pullPolicy: Always
+  autoscaling:
+    enabled: false
+  config:
+    NODE_ENV: development
+    STELLAR_NETWORK: testnet
+    HORIZON_URL: "https://horizon-testnet.stellar.org"
+    SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+    NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+  secret:
+    DATABASE_URL: "postgres://swiftremit:swiftremit@swiftremit-postgres:5432/swiftremit"
+    CONTRACT_ID: ""
+    ADMIN_SECRET_KEY: ""
+
+frontend:
+  replicaCount: 1
+  image:
+    pullPolicy: Always
+  config:
+    VITE_NETWORK: testnet
+    VITE_HORIZON_URL: "https://horizon-testnet.stellar.org"
+    VITE_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+    VITE_CONTRACT_ID: ""
+    VITE_USDC_ISSUER: ""
+    VITE_EURC_ISSUER: ""
+    VITE_USDC_TOKEN_ID: ""
+
+# Dev-only in-cluster postgres
+postgresql:
+  enabled: true

--- a/charts/swiftremit/values.production.yaml
+++ b/charts/swiftremit/values.production.yaml
@@ -1,0 +1,124 @@
+# values.production.yaml — production cluster overrides
+# Usage: helm install swiftremit ./charts/swiftremit -f charts/swiftremit/values.production.yaml
+#
+# All secret values MUST be injected at deploy time via --set or a secrets manager.
+# Never commit real credentials to this file.
+#
+#   helm upgrade --install swiftremit ./charts/swiftremit \
+#     -f charts/swiftremit/values.production.yaml \
+#     --set api.secret.DATABASE_URL="$DATABASE_URL" \
+#     --set api.secret.ANCHORS_ADMIN_API_KEY="$ANCHORS_ADMIN_API_KEY" \
+#     --set backend.secret.DATABASE_URL="$DATABASE_URL" \
+#     --set backend.secret.CONTRACT_ID="$CONTRACT_ID" \
+#     --set backend.secret.ADMIN_SECRET_KEY="$ADMIN_SECRET_KEY"
+
+global:
+  imageRegistry: "ghcr.io/your-org"
+  nodeEnv: production
+
+api:
+  replicaCount: 3
+  image:
+    tag: latest       # pin to a digest in real deployments, e.g. sha256:abc123
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 65
+  config:
+    NODE_ENV: production
+    RATE_LIMIT_WINDOW_MS: "900000"
+    RATE_LIMIT_MAX_REQUESTS: "100"
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_RPC_URL: "https://soroban-rpc.stellar.org"
+    ANCHORS_ADMIN_API_KEY: ""
+
+backend:
+  replicaCount: 3
+  image:
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 65
+  config:
+    NODE_ENV: production
+    STELLAR_NETWORK: mainnet
+    HORIZON_URL: "https://horizon.stellar.org"
+    SOROBAN_RPC_URL: "https://soroban-rpc.stellar.org"
+    NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+    ANCHOR_TIMEOUT_HOURS: "24"
+    VERIFICATION_INTERVAL_HOURS: "24"
+    API_KEY_RATE_LIMIT_WINDOW_MS: "60000"
+    API_KEY_RATE_LIMIT_MAX: "200"
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_ID: ""
+    ADMIN_SECRET_KEY: ""
+
+frontend:
+  replicaCount: 2
+  image:
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+  config:
+    VITE_NETWORK: mainnet
+    VITE_HORIZON_URL: "https://horizon.stellar.org"
+    VITE_SOROBAN_RPC_URL: "https://soroban-rpc.stellar.org"
+    VITE_CONTRACT_ID: ""
+    VITE_USDC_ISSUER: ""
+    VITE_EURC_ISSUER: ""
+    VITE_USDC_TOKEN_ID: ""
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: swiftremit.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: api
+        - path: /backend
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls:
+    - secretName: swiftremit-prod-tls
+      hosts:
+        - swiftremit.example.com

--- a/charts/swiftremit/values.staging.yaml
+++ b/charts/swiftremit/values.staging.yaml
@@ -1,0 +1,86 @@
+# values.staging.yaml — staging cluster overrides
+# Usage: helm install swiftremit ./charts/swiftremit -f charts/swiftremit/values.staging.yaml
+#
+# Secrets with empty values MUST be injected at deploy time, e.g.:
+#   helm upgrade --install swiftremit ./charts/swiftremit \
+#     -f charts/swiftremit/values.staging.yaml \
+#     --set api.secret.DATABASE_URL="$DATABASE_URL" \
+#     --set backend.secret.DATABASE_URL="$DATABASE_URL" \
+#     --set backend.secret.CONTRACT_ID="$CONTRACT_ID" \
+#     --set backend.secret.ADMIN_SECRET_KEY="$ADMIN_SECRET_KEY"
+
+global:
+  imageRegistry: "ghcr.io/your-org"
+  nodeEnv: staging
+
+api:
+  replicaCount: 2
+  image:
+    tag: staging
+    pullPolicy: Always
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+  config:
+    NODE_ENV: staging
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_RPC_URL: "https://soroban-testnet.stellar.org"
+    ANCHORS_ADMIN_API_KEY: ""
+
+backend:
+  replicaCount: 2
+  image:
+    tag: staging
+    pullPolicy: Always
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+  config:
+    NODE_ENV: staging
+    STELLAR_NETWORK: testnet
+    HORIZON_URL: "https://horizon-testnet.stellar.org"
+    SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+    NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_ID: ""
+    ADMIN_SECRET_KEY: ""
+
+frontend:
+  replicaCount: 2
+  image:
+    tag: staging
+    pullPolicy: Always
+  config:
+    VITE_NETWORK: testnet
+    VITE_HORIZON_URL: "https://horizon-testnet.stellar.org"
+    VITE_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+    VITE_CONTRACT_ID: ""
+    VITE_USDC_ISSUER: ""
+    VITE_EURC_ISSUER: ""
+    VITE_USDC_TOKEN_ID: ""
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  hosts:
+    - host: staging.swiftremit.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: api
+        - path: /backend
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls:
+    - secretName: swiftremit-staging-tls
+      hosts:
+        - staging.swiftremit.example.com

--- a/charts/swiftremit/values.yaml
+++ b/charts/swiftremit/values.yaml
@@ -1,0 +1,208 @@
+# Default values for swiftremit.
+# Override per environment with values.dev.yaml / values.staging.yaml / values.production.yaml
+
+global:
+  imageRegistry: ""      # e.g. ghcr.io/your-org — prepended to all image names
+  imagePullSecrets: []
+  nodeEnv: production
+
+# ─── PostgreSQL (managed externally; supply DATABASE_URL via secret) ───────────
+postgresql:
+  # Set to true to spin up an in-cluster postgres (dev only)
+  enabled: false
+  auth:
+    username: swiftremit
+    password: swiftremit
+    database: swiftremit
+
+# ─── API service ───────────────────────────────────────────────────────────────
+api:
+  replicaCount: 2
+
+  image:
+    repository: swiftremit-api
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 3000
+    targetPort: 3000
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+
+  config:
+    PORT: "3000"
+    NODE_ENV: production
+    RATE_LIMIT_WINDOW_MS: "900000"
+    RATE_LIMIT_MAX_REQUESTS: "100"
+    CURRENCY_CONFIG_PATH: "./config/currencies.json"
+
+  # Keys placed here end up in the api-secret Secret (base64-encoded by Helm)
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_RPC_URL: ""
+    ANCHORS_ADMIN_API_KEY: ""
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 3000
+    initialDelaySeconds: 15
+    periodSeconds: 20
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 3000
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# ─── Backend service ───────────────────────────────────────────────────────────
+backend:
+  replicaCount: 2
+
+  image:
+    repository: swiftremit-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 3001
+    targetPort: 3001
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+
+  config:
+    PORT: "3001"
+    NODE_ENV: production
+    STELLAR_NETWORK: mainnet
+    HORIZON_URL: "https://horizon.stellar.org"
+    SOROBAN_RPC_URL: "https://soroban-rpc.stellar.org"
+    NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+    VERIFICATION_INTERVAL_HOURS: "24"
+    ANCHOR_TIMEOUT_HOURS: "24"
+    RATE_LIMIT_WINDOW_MS: "900000"
+    RATE_LIMIT_MAX_REQUESTS: "100"
+    API_KEY_RATE_LIMIT_WINDOW_MS: "60000"
+    API_KEY_RATE_LIMIT_MAX: "200"
+    WEBHOOK_RETRY_BASE_MS: "1000"
+    WEBHOOK_RETRY_MAX_MS: "300000"
+    WEBHOOK_RETRY_JITTER_PERCENT: "20"
+
+  secret:
+    DATABASE_URL: ""
+    CONTRACT_ID: ""
+    ADMIN_SECRET_KEY: ""
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 3001
+    initialDelaySeconds: 30
+    periodSeconds: 20
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 3001
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
+# ─── Frontend service ──────────────────────────────────────────────────────────
+frontend:
+  replicaCount: 2
+
+  image:
+    repository: swiftremit-frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 5173
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  # Frontend does not autoscale by default (static assets; CDN preferred in prod)
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+
+  config:
+    VITE_NETWORK: mainnet
+    VITE_HORIZON_URL: "https://horizon.stellar.org"
+    VITE_SOROBAN_RPC_URL: "https://soroban-rpc.stellar.org"
+    VITE_CONTRACT_ID: ""
+    VITE_USDC_ISSUER: ""
+    VITE_EURC_ISSUER: ""
+    VITE_USDC_TOKEN_ID: ""
+
+  secret: {}
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 5173
+    initialDelaySeconds: 10
+    periodSeconds: 20
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 5173
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# ─── Ingress ───────────────────────────────────────────────────────────────────
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: swiftremit.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: api
+        - path: /backend
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls: []


### PR DESCRIPTION
## Summary

Closes #917 and #918.

## #917 — Soroban Contract CI

Rewrites `.github/workflows/contract-ci.yml` with all required steps:

- `cargo fmt --check` — enforces consistent formatting
- `cargo clippy -- -D warnings` — zero lint warnings allowed
- `cargo test` + `cargo test --features legacy-tests`
- `cargo build --target wasm32-unknown-unknown --release` — WASM artifact uploaded
- All jobs have dedicated cargo registry + target cache keyed on `Cargo.lock`
- Triggers on **push to `main`** and **PR targeting `main`** (path-filtered to contract files)
- `contract-ci` gate job fails the workflow if any step above fails — set as required status check to block merges

## #918 — Kubernetes Helm Chart

Adds `charts/swiftremit/` — a production-grade Helm chart for all three services.

**Templates:**
| Template | Resources |
|---|---|
| `api-deployment.yaml` | Deployment (api) |
| `backend-deployment.yaml` | Deployment (backend) |
| `frontend-deployment.yaml` | Deployment (frontend) |
| `services.yaml` | ClusterIP Services × 3 |
| `configmaps.yaml` | ConfigMaps × 3 (non-secret env vars) |
| `secrets.yaml` | Secrets × 3 (stringData, injected at deploy time) |
| `hpa.yaml` | HorizontalPodAutoscaler for api + backend (+ frontend when enabled) |
| `ingress.yaml` | Optional nginx Ingress |

**Values files:**
- `values.yaml` — base defaults
- `values.dev.yaml` — single replicas, testnet, in-cluster postgres
- `values.staging.yaml` — 2 replicas, testnet, staging cert-manager issuer
- `values.production.yaml` — 3+ replicas, mainnet, aggressive HPA, prod TLS

**Deploy:**
```bash
helm install swiftremit ./charts/swiftremit -f charts/swiftremit/values.production.yaml \
  --set api.secret.DATABASE_URL="$DATABASE_URL" \
  --set backend.secret.DATABASE_URL="$DATABASE_URL" \
  --set backend.secret.CONTRACT_ID="$CONTRACT_ID" \
  --set backend.secret.ADMIN_SECRET_KEY="$ADMIN_SECRET_KEY"
```

**Helm lint CI:** added `helm-lint` job to `ci.yml` — lints against all four values files, wired into the CI gate.

## Testing
- `helm lint charts/swiftremit` — ✅ 0 failures across all four values files

closes #917 
closes #918 