### PR TITLE
feat(ci): add container image vulnerability scanning and SBOM generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,38 @@ updates:
       interval: weekly
     labels:
       - dependencies
+
+  # Keep GitHub Actions versions up to date (also keeps Trivy action current
+  # so vulnerability database stays fresh)
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+
+  # Docker base image updates
+  - package-ecosystem: docker
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: docker
+    directory: "/api"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: docker
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -1,0 +1,114 @@
+name: Container Security
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/Dockerfile"
+      - "docker-compose.yml"
+      - ".github/workflows/container-security.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Dockerfile"
+      - "docker-compose.yml"
+      - ".github/workflows/container-security.yml"
+  schedule:
+    # Weekly scan every Monday at 07:00 UTC to catch newly disclosed CVEs
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write  # required to upload SARIF to GitHub Security tab
+
+concurrency:
+  group: container-security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-scan:
+    name: Trivy scan (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+            image: swiftremit-backend
+          - service: api
+            context: ./api
+            dockerfile: ./api/Dockerfile
+            image: swiftremit-api
+          - service: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            image: swiftremit-frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.service }} image
+        run: |
+          docker build \
+            -f ${{ matrix.dockerfile }} \
+            -t ${{ matrix.image }}:scan \
+            ${{ matrix.context }}
+
+      # ── Vulnerability scan – fail on CRITICAL or HIGH CVEs ────────────────
+      - name: Scan ${{ matrix.service }} for CVEs
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: "${{ matrix.image }}:scan"
+          format: "sarif"
+          output: "trivy-${{ matrix.service }}.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: "1"
+          ignore-unfixed: true
+
+      # Upload SARIF even on failure so developers can inspect results
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-${{ matrix.service }}.sarif"
+          category: "trivy-${{ matrix.service }}"
+
+      # ── SBOM generation ───────────────────────────────────────────────────
+      - name: Generate SBOM for ${{ matrix.service }}
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: "${{ matrix.image }}:scan"
+          format: "cyclonedx"
+          output: "sbom-${{ matrix.service }}.cdx.json"
+          # SBOM generation should not fail the build
+          exit-code: "0"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.service }}
+          path: sbom-${{ matrix.service }}.cdx.json
+          retention-days: 90
+
+  sbom-summary:
+    name: SBOM summary
+    runs-on: ubuntu-latest
+    needs: trivy-scan
+    if: always()
+    steps:
+      - name: Download all SBOMs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sbom-*
+          merge-multiple: true
+
+      - name: List generated SBOMs
+        run: |
+          echo "### SBOM artifacts" >> $GITHUB_STEP_SUMMARY
+          for f in *.cdx.json; do
+            size=$(du -sh "$f" | cut -f1)
+            echo "- \`$f\` ($size)" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
## Summary

Closes #922

- **Trivy vulnerability scan** (`.github/workflows/container-security.yml`): Builds each Docker image (`backend`, `api`, `frontend`) in CI and runs [Trivy](https://github.com/aquasecurity/trivy) against it. The job exits with code 1 on any **CRITICAL** or **HIGH** CVE that has a fix available (`ignore-unfixed: true`), blocking the build. SARIF results are uploaded to the GitHub Security tab via `github/codeql-action/upload-sarif` so findings appear in the repository's security dashboard.
- **SBOM generation**: A second Trivy pass produces a **CycloneDX** SBOM for each image, stored as a 90-day GitHub Actions artifact. A summary job collects all SBOMs and writes a markdown table to the workflow step summary.
- **Trigger policy**: Runs on every PR / push touching a `Dockerfile` or `docker-compose.yml`, on a weekly cron (Monday 07:00 UTC) to catch newly disclosed CVEs in unchanged images, and on `workflow_dispatch`.
- **Dependabot updates** (`.github/dependabot.yml`):
  - `github-actions` ecosystem — weekly PRs keep the Trivy action version (and its bundled CVE database) current.
  - `docker` ecosystem for `backend`, `api`, and `frontend` — weekly PRs for `node:20-alpine` base image updates.

## Test plan

- [ ] Open a PR touching any Dockerfile — confirm `Container Security / Trivy scan (backend|api|frontend)` jobs run
- [ ] Verify SARIF file appears in repo **Security → Code scanning** tab
- [ ] Verify `sbom-backend`, `sbom-api`, `sbom-frontend` artifacts are uploaded
- [ ] Check weekly cron runs (verify in Actions → schedule history on Monday)
- [ ] Confirm Dependabot creates PRs for outdated GitHub Actions and Docker base images

