### PR TITLE
feat(ci): add staging environment with automated deploy and smoke tests

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,181 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      skip_smoke:
+        description: "Skip smoke tests (useful for infrastructure-only changes)"
+        required: false
+        default: "false"
+        type: boolean
+
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false   # Never cancel an in-flight staging deploy
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  # ── Build and push Docker images ──────────────────────────────────────────
+  build-images:
+    name: Build & push images
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.meta.outputs.sha_short }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image metadata
+        id: meta
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/backend:staging
+            ghcr.io/${{ github.repository }}/backend:${{ steps.meta.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push api image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/api:staging
+            ghcr.io/${{ github.repository }}/api:${{ steps.meta.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/frontend:staging
+            ghcr.io/${{ github.repository }}/frontend:${{ steps.meta.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Deploy to staging VM via SSH ──────────────────────────────────────────
+  deploy:
+    name: Deploy to staging
+    runs-on: ubuntu-latest
+    needs: build-images
+    environment:
+      name: staging
+      url: ${{ vars.STAGING_API_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: staging
+          ref: ${{ github.sha }}
+
+      - name: Copy compose file to staging server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          source: "docker-compose.yml,docker-compose.override.yml,.env.testnet"
+          target: "~/swiftremit"
+
+      - name: Deploy via Docker Compose
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          script: |
+            set -euo pipefail
+            cd ~/swiftremit
+
+            # Log into GHCR
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+            # Export image tags so compose uses the freshly pushed images
+            export BACKEND_IMAGE=ghcr.io/${{ github.repository }}/backend:${{ needs.build-images.outputs.sha_short }}
+            export API_IMAGE=ghcr.io/${{ github.repository }}/api:${{ needs.build-images.outputs.sha_short }}
+            export FRONTEND_IMAGE=ghcr.io/${{ github.repository }}/frontend:${{ needs.build-images.outputs.sha_short }}
+
+            # Source testnet env overrides then deploy
+            set -a; source .env.testnet; set +a
+
+            docker compose pull
+            docker compose up -d --remove-orphans
+
+            # Give services a moment to start before smoke tests run
+            sleep 10
+            docker compose ps
+
+      - name: Mark deployment success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          state: success
+          environment-url: ${{ vars.STAGING_API_URL }}
+
+      - name: Mark deployment failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          state: failure
+
+  # ── Smoke tests against the live staging environment ──────────────────────
+  smoke-tests:
+    name: Smoke tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: ${{ github.event.inputs.skip_smoke != 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run smoke tests
+        env:
+          STAGING_API_URL: ${{ vars.STAGING_API_URL }}
+          STAGING_BACKEND_URL: ${{ vars.STAGING_BACKEND_URL }}
+        run: bash scripts/smoke-test-staging.sh
+
+      - name: Smoke test summary
+        if: always()
+        run: |
+          echo "### Smoke test results" >> $GITHUB_STEP_SUMMARY
+          echo "- API URL: \`${{ vars.STAGING_API_URL }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend URL: \`${{ vars.STAGING_BACKEND_URL }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: \`${{ needs.build-images.outputs.sha_short }}\`" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -270,6 +270,35 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for complete deployment instructions.
 
 For production readiness assessment, see [PRODUCTION_READINESS_REPORT.md](PRODUCTION_READINESS_REPORT.md).
 
+## Staging Environment
+
+Every merge to `main` automatically triggers a deployment to the staging environment (Stellar **testnet**) via `.github/workflows/deploy-staging.yml`.
+
+| Service  | Staging URL |
+|----------|-------------|
+| API      | `https://api.staging.swiftremit.io` |
+| Backend  | `https://backend.staging.swiftremit.io` |
+| Frontend | `https://staging.swiftremit.io` |
+
+> **Note:** The staging URLs above are placeholders. Configure the actual URLs as GitHub Actions variables `STAGING_API_URL` and `STAGING_BACKEND_URL` in the repository's *Settings → Environments → staging*.
+
+### How it works
+
+1. Docker images for `backend`, `api`, and `frontend` are built and pushed to **GHCR** (`ghcr.io/<owner>/SwiftRemit/<service>:staging`).
+2. The workflow SSH-es into the staging VM and runs `docker compose up -d` with the new image tags.
+3. **Smoke tests** (`scripts/smoke-test-staging.sh`) run immediately after deploy to verify health and key API endpoints. The workflow fails if any check returns an unexpected status code.
+
+### Required repository secrets / variables
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `STAGING_HOST` | Secret | IP or hostname of the staging VM |
+| `STAGING_USER` | Secret | SSH username |
+| `STAGING_SSH_KEY` | Secret | Private key for SSH access |
+| `STAGING_SSH_PORT` | Secret | SSH port (default: 22) |
+| `STAGING_API_URL` | Variable | Base URL for the API service |
+| `STAGING_BACKEND_URL` | Variable | Base URL for the backend service |
+
 ## Environment Validation
 
 A script checks that every env variable consumed in source code is present in the corresponding `.env.example` file. CI fails automatically if any are missing.

--- a/scripts/smoke-test-staging.sh
+++ b/scripts/smoke-test-staging.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Smoke tests run against the live staging environment after each deploy.
+# Exits non-zero on any failure so the CI workflow marks the deploy as failed.
+#
+# Required environment variables:
+#   STAGING_API_URL     – Base URL for the API service  (e.g. https://api.staging.swiftremit.io)
+#   STAGING_BACKEND_URL – Base URL for the backend service (e.g. https://backend.staging.swiftremit.io)
+set -euo pipefail
+
+API="${STAGING_API_URL:-http://localhost:3000}"
+BACKEND="${STAGING_BACKEND_URL:-http://localhost:3001}"
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1"
+  local url="$2"
+  local expected_status="${3:-200}"
+
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$url" || echo "000")
+
+  if [ "$status" = "$expected_status" ]; then
+    echo "  PASS  $label ($status)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $label — expected $expected_status, got $status  [$url]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== SwiftRemit staging smoke tests ==="
+echo "API:     $API"
+echo "BACKEND: $BACKEND"
+echo ""
+
+echo "--- API health ---"
+check "GET /health"                      "$API/health"
+check "GET /api/currencies"              "$API/api/currencies"
+check "GET /api/limits"                  "$API/api/limits"
+check "GET /api/docs (OpenAPI UI)"       "$API/api/docs"
+
+echo ""
+echo "--- Backend health ---"
+check "GET /health (backend)"            "$BACKEND/health"
+
+echo ""
+echo "--- 404 handling ---"
+check "GET /nonexistent returns 404"     "$API/nonexistent" "404"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "Smoke tests FAILED — $FAIL check(s) did not pass."
+  exit 1
+fi
+
+echo "All smoke tests passed."


### PR DESCRIPTION
## Summary

Closes #923

- **`deploy-staging.yml`** workflow triggered on every push to `main` (and `workflow_dispatch`):
  1. **`build-images`** job: builds `backend`, `api`, and `frontend` Docker images with Buildx layer caching, pushes to GHCR with both a `:staging` floating tag and a short-SHA immutable tag
  2. **`deploy`** job: SCP-copies `docker-compose.yml` to the staging VM, SSHes in and runs `docker compose up -d --remove-orphans`; creates a GitHub Deployment record so deploy status shows in the UI; marks it success or failure
  3. **`smoke-tests`** job: runs `scripts/smoke-test-staging.sh` against the live staging URLs immediately after deploy — blocks further merges if endpoints are unhealthy
- **`scripts/smoke-test-staging.sh`**: portable bash smoke-test that checks `/health`, `/api/currencies`, `/api/limits`, `/api/docs` on the API and `/health` on the backend service; exits non-zero on any failure
- **README.md**: new *Staging Environment* section with staging URLs table, pipeline description, and a table of required secrets/variables

## Required setup (one-time)

In repository **Settings → Secrets and variables → Actions**:

| Name | Kind | Value |
|------|------|-------|
| `STAGING_HOST` | Secret | Staging VM IP / hostname |
| `STAGING_USER` | Secret | SSH user |
| `STAGING_SSH_KEY` | Secret | SSH private key |
| `STAGING_SSH_PORT` | Secret | SSH port (default 22) |
| `STAGING_API_URL` | Variable | e.g. `https://api.staging.swiftremit.io` |
| `STAGING_BACKEND_URL` | Variable | e.g. `https://backend.staging.swiftremit.io` |

Also create a **`staging`** GitHub Environment in *Settings → Environments*.

## Test plan

- [ ] Merge a small change to `main` — confirm all three workflow jobs run successfully
- [ ] Confirm images appear in GHCR under `:staging` and `:<sha>` tags
- [ ] Check GitHub Deployments tab shows a `staging` deployment with the live URL
- [ ] Manually inspect staging endpoints listed in the smoke test
- [ ] Test `workflow_dispatch` with `skip_smoke: true` to verify infra-only path works

