### PR TITLE
feat(testing): add k6 load testing suite targeting 500 RPS

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,117 @@
+name: Load Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target environment"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - staging
+      create_vus:
+        description: "VUs for remittance-create scenario"
+        required: false
+        default: "150"
+        type: string
+      list_vus:
+        description: "VUs for remittance-list scenario"
+        required: false
+        default: "300"
+        type: string
+      ws_vus:
+        description: "VUs for WebSocket scenario"
+        required: false
+        default: "50"
+        type: string
+
+  # Optional: run after every successful staging deploy
+  # Uncomment if you want automatic load tests on staging after each merge:
+  # workflow_run:
+  #   workflows: ["Deploy to Staging"]
+  #   types: [completed]
+  #   branches: [main]
+
+permissions:
+  contents: write   # for uploading results as release assets
+
+concurrency:
+  group: load-tests-${{ github.event.inputs.target }}
+  cancel-in-progress: true
+
+jobs:
+  load-test:
+    name: k6 load test (${{ github.event.inputs.target }})
+    runs-on: ubuntu-latest
+    # Prevent accidental runs against production
+    if: ${{ github.event.inputs.target != 'production' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve target URLs
+        id: urls
+        run: |
+          if [ "${{ github.event.inputs.target }}" = "staging" ]; then
+            echo "api_url=${{ vars.STAGING_API_URL }}"       >> "$GITHUB_OUTPUT"
+            echo "backend_url=${{ vars.STAGING_BACKEND_URL }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] \
+            https://dl.k6.io/deb stable main" | \
+            sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update -q && sudo apt-get install -q k6
+
+      - name: Create results directory
+        run: mkdir -p tests/load/results
+
+      - name: Run k6 load tests
+        env:
+          API_URL:     ${{ steps.urls.outputs.api_url }}
+          BACKEND_URL: ${{ steps.urls.outputs.backend_url }}
+          CREATE_VUS:  ${{ github.event.inputs.create_vus || '150' }}
+          LIST_VUS:    ${{ github.event.inputs.list_vus   || '300' }}
+          WS_VUS:      ${{ github.event.inputs.ws_vus     || '50'  }}
+        run: |
+          k6 run tests/load/main.js \
+            -e API_URL="$API_URL" \
+            -e BACKEND_URL="$BACKEND_URL" \
+            -e CREATE_VUS="$CREATE_VUS" \
+            -e LIST_VUS="$LIST_VUS" \
+            -e WS_VUS="$WS_VUS" \
+            --out json=tests/load/results/metrics.json
+
+      - name: Upload load test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results-${{ github.run_id }}
+          path: tests/load/results/
+          retention-days: 30
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "### Load test results — ${{ github.event.inputs.target }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| API URL | \`${{ steps.urls.outputs.api_url }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend URL | \`${{ steps.urls.outputs.backend_url }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| create VUs | ${{ github.event.inputs.create_vus }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| list VUs | ${{ github.event.inputs.list_vus }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ws VUs | ${{ github.event.inputs.ws_vus }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f tests/load/results/summary.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat tests/load/results/summary.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,9 @@ frontend/coverage/
 # Soroban CLI identity files (contain private keys)
 .soroban-identity/
 identity/
+
+# k6 load test results
+tests/load/results/*.html
+tests/load/results/*.json
+tests/load/results/*.txt
+

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,95 @@
+# SwiftRemit Load Tests (k6)
+
+Performance load tests targeting 500 RPS sustained for 5 minutes with p99 < 500 ms.
+
+## Prerequisites
+
+Install [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/):
+
+```bash
+# macOS
+brew install k6
+
+# Linux
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | \
+  sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+```
+
+## Running the tests
+
+### Full suite (all scenarios in parallel)
+
+```bash
+k6 run tests/load/main.js \
+  -e API_URL=https://api.staging.swiftremit.io \
+  -e BACKEND_URL=https://backend.staging.swiftremit.io
+```
+
+### Individual scenarios
+
+```bash
+# Remittance creation only
+k6 run tests/load/scenarios/remittance-create.js \
+  -e BACKEND_URL=https://backend.staging.swiftremit.io \
+  --vus 150 --duration 5m
+
+# Remittance listing only
+k6 run tests/load/scenarios/remittance-list.js \
+  -e API_URL=https://api.staging.swiftremit.io \
+  --vus 300 --duration 5m
+
+# WebSocket connections only
+k6 run tests/load/scenarios/websocket.js \
+  -e API_URL=https://api.staging.swiftremit.io \
+  --vus 50 --duration 5m
+```
+
+### Local quick smoke (lower load)
+
+```bash
+k6 run tests/load/main.js \
+  -e API_URL=http://localhost:3000 \
+  -e BACKEND_URL=http://localhost:3001 \
+  -e CREATE_VUS=5 \
+  -e LIST_VUS=10 \
+  -e WS_VUS=2
+```
+
+## Scenarios
+
+| Scenario | Endpoint | Default VUs | Threshold |
+|----------|----------|-------------|-----------|
+| `remittance_create` | `POST /api/remittance` (backend :3001) | 150 | p99 < 500 ms, errors < 1 % |
+| `remittance_list` | `GET /api/remittances` (api :3000) | 300 | p99 < 500 ms, errors < 1 % |
+| `websocket_connections` | Socket.IO ws (api :3000) | 50 | p95 connect < 200 ms, errors < 5 % |
+
+## Load profile
+
+Each scenario ramps up over **1 minute**, sustains for **5 minutes**, then ramps down over **1 minute**.
+
+```
+VUs
+ ▲
+ │         ┌────────────────────────┐
+ │        /                          \
+ │       /                            \
+ └──────────────────────────────────────── time
+     1min       5min sustained       1min
+```
+
+## Results
+
+After each run, `tests/load/results/` contains:
+- `report.html` — visual HTML report
+- `summary.txt` — plain-text summary suitable for CI logs
+
+## CI (optional manual trigger)
+
+The workflow `.github/workflows/load-test.yml` can be triggered manually from
+**Actions → Load Tests → Run workflow** with custom VU counts and a target URL.
+It runs only against staging (never production) and requires the
+`STAGING_API_URL` and `STAGING_BACKEND_URL` Actions variables.

--- a/tests/load/main.js
+++ b/tests/load/main.js
@@ -1,0 +1,100 @@
+/**
+ * SwiftRemit k6 load test suite — combined entry point
+ *
+ * Runs three scenarios in parallel:
+ *   • remittance-create  – POST /api/remittance (backend)
+ *   • remittance-list    – GET  /api/remittances (api)
+ *   • websocket          – Socket.IO real-time connections (api)
+ *
+ * Target: 500 RPS sustained for 5 minutes with p99 < 500 ms.
+ *
+ * Usage:
+ *   k6 run tests/load/main.js \
+ *     -e API_URL=https://api.staging.swiftremit.io \
+ *     -e BACKEND_URL=https://backend.staging.swiftremit.io
+ *
+ * Override VU counts via environment variables:
+ *   CREATE_VUS     (default: 150)
+ *   LIST_VUS       (default: 300)
+ *   WS_VUS         (default: 50)
+ */
+
+import { htmlReport } from 'https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js';
+import { textSummary }  from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
+
+import createRemittance from './scenarios/remittance-create.js';
+import listRemittances  from './scenarios/remittance-list.js';
+import webSocketLoad    from './scenarios/websocket.js';
+
+const CREATE_VUS = parseInt(__ENV.CREATE_VUS || '150');
+const LIST_VUS   = parseInt(__ENV.LIST_VUS   || '300');
+const WS_VUS     = parseInt(__ENV.WS_VUS     || '50');
+
+// Ramp profile: 1 min warm-up → 5 min sustained → 1 min cool-down
+const RAMP_UP_SECS   = 60;
+const SUSTAIN_SECS   = 300;
+const RAMP_DOWN_SECS = 60;
+
+export const options = {
+  scenarios: {
+    remittance_create: {
+      executor:          'ramping-vus',
+      exec:              'createRemittance',
+      startVUs:          0,
+      stages: [
+        { duration: `${RAMP_UP_SECS}s`,   target: CREATE_VUS },
+        { duration: `${SUSTAIN_SECS}s`,   target: CREATE_VUS },
+        { duration: `${RAMP_DOWN_SECS}s`, target: 0 },
+      ],
+    },
+    remittance_list: {
+      executor:          'ramping-vus',
+      exec:              'listRemittances',
+      startVUs:          0,
+      stages: [
+        { duration: `${RAMP_UP_SECS}s`,   target: LIST_VUS },
+        { duration: `${SUSTAIN_SECS}s`,   target: LIST_VUS },
+        { duration: `${RAMP_DOWN_SECS}s`, target: 0 },
+      ],
+    },
+    websocket_connections: {
+      executor:          'ramping-vus',
+      exec:              'webSocketLoad',
+      startVUs:          0,
+      stages: [
+        { duration: `${RAMP_UP_SECS}s`,   target: WS_VUS },
+        { duration: `${SUSTAIN_SECS}s`,   target: WS_VUS },
+        { duration: `${RAMP_DOWN_SECS}s`, target: 0 },
+      ],
+    },
+  },
+
+  thresholds: {
+    // Overall latency gate: p99 across all HTTP requests < 500 ms
+    http_req_duration: ['p(99)<500'],
+
+    // Per-scenario latency tracking
+    remittance_create_duration: ['p(99)<500'],
+    remittance_list_duration:   ['p(99)<500'],
+    ws_connect_duration:        ['p(95)<200'],
+
+    // Error rate gates
+    remittance_create_errors: ['rate<0.01'],   // < 1 % errors
+    remittance_list_errors:   ['rate<0.01'],
+    ws_errors:                ['rate<0.05'],   // < 5 % WebSocket errors (handshake + upgrade)
+
+    // Minimum throughput gate: at least 450 RPS on HTTP endpoints
+    http_reqs: [`rate>450`],
+  },
+};
+
+// Re-export scenario functions so k6 can call them by name
+export { createRemittance, listRemittances, webSocketLoad };
+
+export function handleSummary(data) {
+  return {
+    'tests/load/results/report.html': htmlReport(data),
+    'tests/load/results/summary.txt': textSummary(data, { indent: ' ', enableColors: false }),
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}

--- a/tests/load/scenarios/remittance-create.js
+++ b/tests/load/scenarios/remittance-create.js
@@ -1,0 +1,76 @@
+/**
+ * k6 scenario: Create Remittance
+ *
+ * Exercises POST /api/remittance on the backend service at sustained load.
+ * Acceptance: p99 < 500 ms at 500 RPS for 5 minutes.
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { randomString, randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+// Custom metrics
+export const remittanceCreateDuration = new Trend('remittance_create_duration', true);
+export const remittanceCreateErrors  = new Rate('remittance_create_errors');
+export const remittanceCreateCount   = new Counter('remittance_create_count');
+
+// Stellar testnet addresses used as realistic fixtures
+const AGENT_ADDRESSES = [
+  'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBWE4Q86HFOR',
+  'GDRXE2BQUC3AZNPVFSCEZ76NJ3BJP335ZIPHENQ4QQVOA2FZY3LKIKR',
+  'GB5OSGVMOFR6F5MZ7M3XMXQYARQHZBBNRXXVDEHHJAKME4RQCQWKIIG7',
+];
+
+function randomStellarAddress() {
+  return AGENT_ADDRESSES[randomIntBetween(0, AGENT_ADDRESSES.length - 1)];
+}
+
+function randomAmount() {
+  // Amounts in stroops (1 XLM = 10_000_000 stroops); range: $1–$1000 equivalent
+  return String(randomIntBetween(10_000_000, 10_000_000_000));
+}
+
+export default function createRemittance() {
+  const backendUrl = __ENV.BACKEND_URL || 'http://localhost:3001';
+  const userId     = `load-test-user-${__VU}`;
+
+  const payload = JSON.stringify({
+    sender: randomStellarAddress(),
+    agent:  randomStellarAddress(),
+    amount: randomAmount(),
+    memo:   `load-test-${randomString(8)}`,
+  });
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-user-id':    userId,
+    },
+    tags: { scenario: 'remittance_create' },
+  };
+
+  const res = http.post(`${backendUrl}/api/remittance`, payload, params);
+
+  remittanceCreateDuration.add(res.timings.duration);
+  remittanceCreateCount.add(1);
+
+  const ok = check(res, {
+    'status is 201': (r) => r.status === 201,
+    'has remittance_id': (r) => {
+      try {
+        return JSON.parse(r.body).remittance?.remittance_id !== undefined;
+      } catch {
+        return false;
+      }
+    },
+    'p99 < 500 ms': (r) => r.timings.duration < 500,
+  });
+
+  if (!ok) {
+    remittanceCreateErrors.add(1);
+  }
+
+  sleep(0.001); // minimal sleep to prevent tight spin-loops
+}

--- a/tests/load/scenarios/remittance-list.js
+++ b/tests/load/scenarios/remittance-list.js
@@ -1,0 +1,67 @@
+/**
+ * k6 scenario: List Remittances
+ *
+ * Exercises GET /api/remittances on the API service with cursor-based
+ * pagination and various filter combinations at sustained load.
+ * Acceptance: p99 < 500 ms at 500 RPS for 5 minutes.
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export const remittanceListDuration = new Trend('remittance_list_duration', true);
+export const remittanceListErrors   = new Rate('remittance_list_errors');
+export const remittanceListCount    = new Counter('remittance_list_count');
+
+const STATUSES    = ['Pending', 'Processing', 'Completed', 'Cancelled', 'Failed'];
+const CORRIDORS   = ['USD-NG', 'USD-GH', 'EUR-NG', 'GBP-KE', 'USD-KE'];
+const PAGE_LIMITS = [10, 20, 50, 100];
+
+function randomQueryString() {
+  const params = new URLSearchParams();
+  params.set('limit', String(PAGE_LIMITS[randomIntBetween(0, PAGE_LIMITS.length - 1)]));
+
+  // Randomly apply optional filters to mimic realistic traffic patterns
+  if (Math.random() < 0.3) {
+    params.set('status', STATUSES[randomIntBetween(0, STATUSES.length - 1)]);
+  }
+  if (Math.random() < 0.2) {
+    params.set('corridor', CORRIDORS[randomIntBetween(0, CORRIDORS.length - 1)]);
+  }
+  if (Math.random() < 0.15) {
+    const from = new Date(Date.now() - randomIntBetween(1, 30) * 24 * 60 * 60 * 1000);
+    params.set('from_date', from.toISOString());
+  }
+
+  return params.toString();
+}
+
+export default function listRemittances() {
+  const apiUrl = __ENV.API_URL || 'http://localhost:3000';
+
+  const qs  = randomQueryString();
+  const url = `${apiUrl}/api/remittances?${qs}`;
+
+  const params = {
+    tags: { scenario: 'remittance_list' },
+  };
+
+  const res = http.get(url, params);
+
+  remittanceListDuration.add(res.timings.duration);
+  remittanceListCount.add(1);
+
+  const ok = check(res, {
+    'status is 200 or 400': (r) => r.status === 200 || r.status === 400,
+    'response has body':    (r) => r.body && r.body.length > 0,
+    'p99 < 500 ms':         (r) => r.timings.duration < 500,
+  });
+
+  if (!ok) {
+    remittanceListErrors.add(1);
+  }
+
+  sleep(0.001);
+}

--- a/tests/load/scenarios/websocket.js
+++ b/tests/load/scenarios/websocket.js
@@ -1,0 +1,109 @@
+/**
+ * k6 scenario: WebSocket connections
+ *
+ * Exercises the Socket.IO WebSocket endpoint on the API service.
+ * Each VU opens a connection, subscribes to events for 30 seconds,
+ * then disconnects.  The scenario simulates concurrent real-time clients.
+ *
+ * k6 uses the native ws:// WebSocket protocol. Socket.IO uses a custom
+ * handshake over HTTP long-polling before upgrading to WebSocket, so this
+ * script targets the raw WebSocket upgrade path that Socket.IO supports
+ * via `?EIO=4&transport=websocket`.
+ *
+ * Acceptance: 95 % of connections established in < 200 ms; 0 % error rate.
+ */
+
+import ws   from 'k6/ws';
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+
+export const wsConnectDuration  = new Trend('ws_connect_duration', true);
+export const wsMessageCount     = new Counter('ws_messages_received');
+export const wsErrors           = new Rate('ws_errors');
+export const wsConnectionsTotal = new Counter('ws_connections_total');
+
+const SESSION_SECONDS = 30; // how long each VU holds its connection open
+
+export default function webSocketLoad() {
+  const apiUrl    = __ENV.API_URL || 'http://localhost:3000';
+  const wsBaseUrl = apiUrl.replace(/^http/, 'ws');
+
+  // Step 1: Socket.IO HTTP handshake to obtain the session ID (sid)
+  const pollRes = http.get(
+    `${apiUrl}/socket.io/?EIO=4&transport=polling`,
+    { tags: { scenario: 'ws_handshake' } }
+  );
+
+  const handshakeOk = check(pollRes, {
+    'Socket.IO handshake 200': (r) => r.status === 200,
+  });
+
+  if (!handshakeOk) {
+    wsErrors.add(1);
+    return;
+  }
+
+  // Parse the session id from the Socket.IO handshake payload
+  // Payload looks like: 0{"sid":"...","upgrades":["websocket"],...}
+  let sid = '';
+  try {
+    const body  = pollRes.body.toString();
+    const match = body.match(/"sid":"([^"]+)"/);
+    sid = match ? match[1] : '';
+  } catch {
+    wsErrors.add(1);
+    return;
+  }
+
+  if (!sid) {
+    wsErrors.add(1);
+    return;
+  }
+
+  // Step 2: Upgrade to WebSocket
+  const wsUrl = `${wsBaseUrl}/socket.io/?EIO=4&transport=websocket&sid=${sid}`;
+
+  const startTs = Date.now();
+  let connected = false;
+
+  const response = ws.connect(wsUrl, {}, function (socket) {
+    connected = true;
+    wsConnectDuration.add(Date.now() - startTs);
+    wsConnectionsTotal.add(1);
+
+    socket.on('open', () => {
+      // Send Socket.IO upgrade probe packet ("2probe")
+      socket.send('2probe');
+    });
+
+    socket.on('message', (data) => {
+      wsMessageCount.add(1);
+
+      // Respond to Socket.IO ping (opcode "2") with pong ("3")
+      if (data === '2') {
+        socket.send('3');
+      }
+    });
+
+    socket.on('error', () => {
+      wsErrors.add(1);
+    });
+
+    // Hold the connection open for the session duration
+    socket.setTimeout(() => {
+      socket.close();
+    }, SESSION_SECONDS * 1000);
+  });
+
+  check(response, {
+    'WebSocket status 101': (r) => r && r.status === 101,
+    'connection established': () => connected,
+  });
+
+  if (!connected) {
+    wsErrors.add(1);
+  }
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary

Closes #924

### What's added

**`tests/load/` directory** with three k6 scenarios:

| File | Endpoint | Target |
|------|----------|--------|
| `scenarios/remittance-create.js` | `POST /api/remittance` (backend :3001) | p99 < 500 ms, errors < 1 % |
| `scenarios/remittance-list.js` | `GET /api/remittances` (api :3000) | p99 < 500 ms, errors < 1 % |
| `scenarios/websocket.js` | Socket.IO ws (api :3000) | p95 connect < 200 ms, errors < 5 % |

**`tests/load/main.js`** — combined entry point running all three scenarios in parallel with `ramping-vus` executor:
- 1 min ramp-up → **5 min sustained** at full VU count → 1 min cool-down
- Default VUs: 150 create + 300 list + 50 ws = 500 concurrent VUs → ≥500 RPS combined
- Hard k6 thresholds: `http_req_duration p(99)<500`, `http_reqs rate>450`, per-scenario error rates
- Generates HTML report + plain-text summary in `tests/load/results/`

**`.github/workflows/load-test.yml`** — manual `workflow_dispatch` workflow:
- Target environment selector (staging only, production blocked)
- Configurable VU counts per scenario
- Uploads HTML report and `metrics.json` as 30-day artifacts
- Posts a markdown step summary with the plain-text k6 output

**`tests/load/README.md`** — installation guide (Homebrew / apt), full suite and individual scenario invocations, local quick-smoke mode with low VUs

## Test plan

- [ ] Local: `k6 run tests/load/scenarios/remittance-list.js -e API_URL=http://localhost:3000 --vus 5 --duration 30s` — verify output and custom metrics
- [ ] Local: `k6 run tests/load/main.js -e API_URL=http://localhost:3000 -e BACKEND_URL=http://localhost:3001 -e CREATE_VUS=2 -e LIST_VUS=3 -e WS_VUS=1` — verify all three scenarios run and HTML report is generated
- [ ] CI: trigger **Load Tests → Run workflow** against staging; confirm VU counts respected, results artifact uploaded, step summary populated
- [ ] Confirm thresholds pass against staging at default VU counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)