### PR TITLE
feat(sdk): per-op retry policy, fee estimation, mock client, and npm release automation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "Xaxxoo/SwiftRemit" }],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+  "privatePackages": { "version": false, "tag": false }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,68 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
 permissions:
   contents: write
   packages: write
+  # Required for npm provenance signing via OIDC
+  id-token: write
+  # Required for changesets to open version-bump PRs
+  pull-requests: write
 
 jobs:
+  # ── Changesets: version bump PR or automatic npm publish on merge to main ──────
+  changesets:
+    name: Changesets release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use a PAT or the default GITHUB_TOKEN so changesets can push commits/PRs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install SDK dependencies
+        working-directory: sdk
+        run: npm ci
+
+      - name: Build SDK
+        working-directory: sdk
+        run: npm run build
+
+      - name: Run changesets action
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # When a changeset is present this creates/updates a "Version Packages" PR.
+          # When that PR is merged, this step publishes to npm automatically.
+          publish: npm run release --workspace=sdk
+          version: npx changeset version
+          commit: "chore: version packages"
+          title: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+
+  # ── Tag-based release: manual semver tags publish and attach contract artifact ──
   release:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -120,6 +120,209 @@ toStroops(100);      // 100 USDC → 1_000_000_000n stroops
 fromStroops(1_000_000_000n); // → 100 USDC
 ```
 
+## Retry Behaviour
+
+### Global configuration
+
+Retry settings are configured once in the client constructor and apply to all read operations (simulation calls):
+
+```typescript
+const client = new SwiftRemitClient({
+  contractId: "CXXX",
+  networkPassphrase: Networks.TESTNET,
+  rpcUrl: RpcUrls.TESTNET,
+  retries: 3,           // max retry attempts on transient RPC errors (default: 3)
+  retryDelayMs: 1000,   // initial delay before first retry in ms (default: 1000)
+  retryBackoffFactor: 2 // multiplier applied after each retry (default: 2 → 1s, 2s, 4s)
+});
+```
+
+Only transient errors trigger a retry: HTTP 429, 503, `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, network errors, and RPC timeouts. Non-transient errors (simulation failures, invalid signatures, auth errors) fail immediately.
+
+### Per-operation retry policy
+
+Write operations (those that call `submitTransaction`) default to **no retries** because most are non-idempotent. You can override this globally or per-call:
+
+```typescript
+import { RetryPolicies } from "@swiftremit/sdk";
+import type { RetryPolicy } from "@swiftremit/sdk";
+
+// ── Global write default ───────────────────────────────────────────────────
+// Default: no retries for writes
+const client = new SwiftRemitClient({
+  contractId: "CXXX",
+  networkPassphrase: Networks.TESTNET,
+  rpcUrl: RpcUrls.TESTNET,
+  writeRetryPolicy: { retries: 0 }, // default — explicit for clarity
+});
+
+// ── Per-call override ──────────────────────────────────────────────────────
+const createTx = await client.createRemittance({
+  sender: senderKeypair.publicKey(),
+  agent: agentAddress,
+  amount: toStroops(100),
+  idempotencyKey: "order-abc-123", // idempotency key makes this safe to retry
+});
+
+// Supply an idempotency key → safe to retry the submit
+const result = await client.submitTransaction(createTx, senderKeypair, {
+  retryPolicy: RetryPolicies.AGGRESSIVE, // { retries: 5, delayMs: 500, backoffFactor: 1.5 }
+});
+
+// Non-idempotent operations — rely on the default (no retries)
+const cancelTx = await client.cancelRemittance(senderKeypair.publicKey(), 1n);
+await client.submitTransaction(cancelTx, senderKeypair); // 0 retries by default
+```
+
+### Custom retry policy
+
+```typescript
+import type { RetryPolicy } from "@swiftremit/sdk";
+
+const myPolicy: RetryPolicy = { retries: 2, delayMs: 300, backoffFactor: 2 };
+await client.submitTransaction(tx, keypair, { retryPolicy: myPolicy });
+```
+
+| Operation category | Default retry behaviour |
+|---|---|
+| Read (simulation) | Global `retries` (default 3), exponential backoff |
+| Write submit (`sendTransaction`) | `writeRetryPolicy` (default: 0 retries) |
+| Write confirmation polling (`getTransaction`) | Global `retries` — always safe because polling is idempotent |
+
+## Fee Estimation
+
+Estimate fees before committing a transaction. Results are cached for 30 seconds per unique (sender, amount, corridor) combination:
+
+```typescript
+import { toStroops, fromStroops } from "@swiftremit/sdk";
+import type { Corridor, FeeEstimate } from "@swiftremit/sdk";
+
+const amount = toStroops(100); // 100 USDC in stroops
+const corridor: Corridor = { currency: "USDC", country: "NG" };
+
+const estimate: FeeEstimate = await client.estimateFee(
+  amount,
+  corridor,
+  senderAddress
+);
+
+console.log(`Send:          ${fromStroops(estimate.amount)} USDC`);
+console.log(`Platform fee:  ${fromStroops(estimate.platformFee)} USDC`);
+console.log(`Protocol fee:  ${fromStroops(estimate.protocolFee)} USDC`);
+console.log(`Recipient gets: ${fromStroops(estimate.netAmount)} USDC`);
+console.log(`Cached:        ${estimate.fromCache}`);
+```
+
+### With a custom retry policy
+
+```typescript
+const estimate = await client.estimateFee(amount, corridor, senderAddress, {
+  retries: 2, delayMs: 200,
+});
+```
+
+### `FeeEstimate` type
+
+```typescript
+interface FeeEstimate {
+  amount: bigint;      // Requested send amount
+  platformFee: bigint; // SwiftRemit platform fee
+  protocolFee: bigint; // Stellar protocol fee
+  netAmount: bigint;   // Recipient receives (amount − totalFee)
+  totalFee: bigint;    // platformFee + protocolFee
+  estimatedAt: Date;
+  fromCache: boolean;  // true when served from the 30-second cache
+}
+```
+
+## Testing with SwiftRemitMockClient
+
+SDK consumers can write integration tests without a live Stellar network by using `SwiftRemitMockClient` from the separate `@swiftremit/sdk/testing` entry point:
+
+```bash
+npm install @swiftremit/sdk
+```
+
+```typescript
+import { SwiftRemitMockClient } from "@swiftremit/sdk/testing";
+import type { MockTxResult } from "@swiftremit/sdk/testing";
+
+const AGENT = "GAGENT...";
+const SENDER = "GSENDER...";
+
+describe("payment service", () => {
+  let client: SwiftRemitMockClient;
+
+  beforeEach(() => {
+    client = new SwiftRemitMockClient({ feeBps: 100 }); // 1% platform fee
+    client.seedAgent(AGENT);
+  });
+
+  it("creates a pending remittance", async () => {
+    const result: MockTxResult = await client.createRemittance({
+      sender: SENDER,
+      agent: AGENT,
+      amount: 100_000_000n, // 10 USDC
+    });
+
+    expect(result.id).toBeDefined();
+
+    const r = await client.getRemittance(SENDER, result.id!);
+    expect(r.status).toBe("Pending");
+  });
+
+  it("confirms payout and accumulates fees", async () => {
+    const { id } = await client.createRemittance({
+      sender: SENDER, agent: AGENT, amount: 100_000_000n,
+    });
+    await client.confirmPayout(AGENT, id!);
+
+    const r = await client.getRemittance(SENDER, id!);
+    expect(r.status).toBe("Completed");
+    expect(await client.getAccumulatedFees(SENDER)).toBeGreaterThan(0n);
+  });
+});
+```
+
+### Seed helpers (chainable)
+
+```typescript
+const client = new SwiftRemitMockClient()
+  .seedAgent("GAGENT...")      // pre-register an agent
+  .seedToken("GUSDC...")       // whitelist a token
+  .seedAdmin("GADMIN...")      // add an admin
+  .seedRemittance(existingR)   // inject an existing remittance
+  .setFeeBps(200);             // 2% platform fee
+```
+
+### Write operation results
+
+Unlike the real client (which returns a Stellar `Transaction` to be signed and submitted), the mock write methods apply state immediately and return a `MockTxResult`:
+
+```typescript
+interface MockTxResult {
+  txHash: string;  // fake transaction hash (e.g. "MOCK_TX_00000001")
+  id?: bigint;     // remittance ID, present for createRemittance
+}
+```
+
+### Dependency injection
+
+Use TypeScript structural typing to inject the mock wherever your production code uses the real client:
+
+```typescript
+// Production service accepts any compatible shape
+type RemittanceReader = Pick<SwiftRemitClient, "getRemittance" | "getRemittancesBySender">;
+
+function createDashboard(client: RemittanceReader) { /* ... */ }
+
+// In tests
+createDashboard(new SwiftRemitMockClient());
+
+// In production
+createDashboard(new SwiftRemitClient(opts));
+```
+
 ## Governance
 
 The SDK exposes four methods for interacting with the on-chain governance module.

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,14 +9,294 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@changesets/changelog-github": "^0.5.0",
+        "@changesets/cli": "^2.27.0",
         "@stellar/stellar-sdk": "^13.0.0",
         "@types/node": "^25.9.1",
         "tsup": "^8.0.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      },
       "peerDependencies": {
         "@stellar/stellar-sdk": ">=13.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.4",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.2.tgz",
+      "integrity": "sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.7.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.4",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/get-release-plan": "^4.0.16",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.7.0.tgz",
+      "integrity": "sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/config": "^3.1.4",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.3",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -495,6 +775,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -534,6 +836,78 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -551,6 +925,44 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1417,12 +1829,49 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1548,6 +1997,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -1556,6 +2018,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -1669,6 +2144,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1732,6 +2214,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1778,6 +2282,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1786,6 +2300,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -1801,6 +2338,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/es-define-property": {
@@ -1901,6 +2452,20 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1931,6 +2496,40 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1957,6 +2556,33 @@
       "license": "MIT",
       "dependencies": {
         "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/fix-dts-default-cjs-exports": {
@@ -2025,6 +2651,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2089,6 +2730,40 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2101,6 +2776,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -2171,6 +2853,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-id": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2192,6 +2901,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2212,6 +2931,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -2223,6 +2975,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-typed-array": {
@@ -2241,12 +3006,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -2256,6 +3038,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/lightningcss": {
@@ -2549,6 +3364,26 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2567,6 +3402,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -2603,6 +3475,16 @@
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2643,6 +3525,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2663,6 +3566,115 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2689,6 +3701,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -2795,6 +3817,22 @@
         }
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -2805,6 +3843,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2813,6 +3889,46 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/readdirp": {
@@ -2851,6 +3967,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -2932,6 +4059,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2952,6 +4103,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -2992,12 +4163,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/sodium-native": {
       "version": "4.3.3",
@@ -3030,6 +4247,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3043,6 +4278,29 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -3065,6 +4323,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thenify": {
@@ -3146,10 +4417,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3280,6 +4571,16 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/urijs": {
       "version": "1.19.11",
@@ -3464,6 +4765,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-typed-array": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -10,15 +10,22 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing/index.mjs",
+      "require": "./dist/testing/index.js",
+      "types": "./dist/testing/index.d.ts"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/testing/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "release": "npm run build && npm publish --access public --provenance"
   },
   "keywords": [
     "stellar",
@@ -31,7 +38,12 @@
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=13.0.0"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
+    "@changesets/cli": "^2.27.0",
     "@stellar/stellar-sdk": "^13.0.0",
     "@types/node": "^25.9.1",
     "tsup": "^8.0.0",

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -25,14 +25,18 @@ import type {
   RemittanceEventType,
   SubscribeOptions,
   Unsubscribe,
+  RetryPolicy,
+  Corridor,
+  FeeEstimate,
 } from "./types.js";
 import { parseContractError, SwiftRemitError, ErrorCode } from "./errors.js";
-import { withRetry } from "./retry.js";
+import { withRetry, withRetryPolicy } from "./retry.js";
 import {
   parseRemittance,
   parseAgentStats,
   parseCircuitBreakerStatus,
   parseHealthStatus,
+  parseFeeBreakdown,
   addressToScVal,
   u64ToScVal,
   i128ToScVal,
@@ -70,6 +74,9 @@ export class SwiftRemitClient {
   private readonly retries: number;
   private readonly retryDelayMs: number;
   private readonly retryBackoffFactor: number;
+  private readonly writeRetryPolicy: RetryPolicy;
+  private readonly feeCache = new Map<string, { cachedAt: number; estimate: FeeEstimate }>();
+  private static readonly FEE_CACHE_TTL_MS = 30_000;
 
   constructor(options: SwiftRemitClientOptions) {
     this.contract = new Contract(options.contractId);
@@ -85,6 +92,23 @@ export class SwiftRemitClient {
     this.retries = options.retries ?? 3;
     this.retryDelayMs = options.retryDelayMs ?? 1000;
     this.retryBackoffFactor = options.retryBackoffFactor ?? 2;
+    this.writeRetryPolicy = options.writeRetryPolicy ?? { retries: 0 };
+  }
+
+  private withTimeout<T>(promise: Promise<T>, timeoutMs = 30_000): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`RPC call timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        )
+      ),
+    ]);
+  }
+
+  private resolveWriteRetryPolicy(perCallPolicy?: RetryPolicy): RetryPolicy {
+    return perCallPolicy ?? this.writeRetryPolicy;
   }
 
   // ─── Transaction helpers ────────────────────────────────────────────────────
@@ -116,35 +140,48 @@ export class SwiftRemitClient {
     return SorobanRpc.assembleTransaction(tx, simResult).build();
   }
 
-  /** Sign and submit a prepared transaction; wait for confirmation. */
+  /**
+   * Sign and submit a prepared transaction; wait for confirmation.
+   *
+   * @param tx - Transaction prepared by any write method (e.g. `createRemittance`)
+   * @param keypair - Keypair used to sign the transaction
+   * @param options.retryPolicy - Per-call retry policy that overrides the client's
+   *   `writeRetryPolicy`. Idempotent operations (those using an idempotency key or
+   *   inherently safe to re-submit) may opt in to retries by passing
+   *   `RetryPolicies.AGGRESSIVE` here. Non-idempotent operations should leave this
+   *   unset to rely on the default (no retries).
+   */
   async submitTransaction(
     tx: Transaction,
-    keypair: Keypair
+    keypair: Keypair,
+    options?: { retryPolicy?: RetryPolicy }
   ): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
+    const writePolicy = this.resolveWriteRetryPolicy(options?.retryPolicy);
+    const defaults = { delayMs: this.retryDelayMs, backoffFactor: this.retryBackoffFactor };
+
     tx.sign(keypair);
-    const sendResult = await withRetry(
+    const sendResult = await withRetryPolicy(
       () => this.server.sendTransaction(tx),
-      this.retries,
-      this.retryDelayMs,
-      this.retryBackoffFactor
+      writePolicy,
+      defaults
     );
     if (sendResult.status === "ERROR") {
       throw new Error(`Submit failed: ${JSON.stringify(sendResult.errorResult)}`);
     }
 
-    let getResult = await withRetry(
+    // Polling for confirmation is always idempotent — use the global read retry config.
+    const readPolicy: RetryPolicy = { retries: this.retries };
+    let getResult = await withRetryPolicy(
       () => this.server.getTransaction(sendResult.hash),
-      this.retries,
-      this.retryDelayMs,
-      this.retryBackoffFactor
+      readPolicy,
+      defaults
     );
     while (getResult.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
       await new Promise((r) => setTimeout(r, 1000));
-      getResult = await withRetry(
+      getResult = await withRetryPolicy(
         () => this.server.getTransaction(sendResult.hash),
-        this.retries,
-        this.retryDelayMs,
-        this.retryBackoffFactor
+        readPolicy,
+        defaults
       );
     }
 
@@ -162,7 +199,8 @@ export class SwiftRemitClient {
   private async simulateCall(
     sourceAddress: string,
     method: string,
-    args: xdr.ScVal[]
+    args: xdr.ScVal[],
+    retryPolicy?: RetryPolicy
   ): Promise<xdr.ScVal> {
     const account = await this.withTimeout(this.server.getAccount(sourceAddress));
     const tx = new TransactionBuilder(account, {
@@ -173,11 +211,12 @@ export class SwiftRemitClient {
       .setTimeout(30)
       .build();
 
-    const sim = await withRetry(
+    const policy = retryPolicy ?? { retries: this.retries };
+    const defaults = { delayMs: this.retryDelayMs, backoffFactor: this.retryBackoffFactor };
+    const sim = await withRetryPolicy(
       () => this.server.simulateTransaction(tx),
-      this.retries,
-      this.retryDelayMs,
-      this.retryBackoffFactor
+      policy,
+      defaults
     );
     if (SorobanRpc.Api.isSimulationError(sim)) {
       const typed = parseContractError(sim.error);
@@ -764,6 +803,55 @@ export class SwiftRemitClient {
       }
     }
     return proposals;
+  }
+
+  // ─── Fee estimation ──────────────────────────────────────────────────────────
+
+  /**
+   * Estimate the fee breakdown for a remittance before committing a transaction.
+   *
+   * Results are cached for 30 seconds per unique (senderAddress, amount, corridor)
+   * combination. Pass `retryPolicy` to override the client's default read retry
+   * behaviour for this call.
+   *
+   * @param amount - Send amount in stroops (use {@link toStroops} to convert from USDC)
+   * @param corridor - Destination currency and country
+   * @param senderAddress - Address used to simulate the contract call
+   * @param retryPolicy - Optional per-call retry override (defaults to global read retries)
+   */
+  async estimateFee(
+    amount: bigint,
+    corridor: Corridor,
+    senderAddress: string,
+    retryPolicy?: RetryPolicy
+  ): Promise<FeeEstimate> {
+    const cacheKey = `${senderAddress}:${amount}:${corridor.currency}:${corridor.country}`;
+    const cached = this.feeCache.get(cacheKey);
+    if (cached && Date.now() - cached.cachedAt < SwiftRemitClient.FEE_CACHE_TTL_MS) {
+      return { ...cached.estimate, fromCache: true };
+    }
+
+    const val = await this.simulateCall(
+      senderAddress,
+      "get_fee_breakdown",
+      [i128ToScVal(amount), stringToScVal(corridor.currency), stringToScVal(corridor.country)],
+      retryPolicy
+    );
+
+    const breakdown = parseFeeBreakdown(val);
+    const totalFee = breakdown.platformFee + breakdown.protocolFee;
+    const estimate: FeeEstimate = {
+      amount,
+      platformFee: breakdown.platformFee,
+      protocolFee: breakdown.protocolFee,
+      netAmount: breakdown.netAmount,
+      totalFee,
+      estimatedAt: new Date(),
+      fromCache: false,
+    };
+
+    this.feeCache.set(cacheKey, { cachedAt: Date.now(), estimate });
+    return estimate;
   }
 
   /** Cast an approval vote on a pending proposal (admin only). */

--- a/sdk/src/fee-estimate.test.ts
+++ b/sdk/src/fee-estimate.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for SwiftRemitClient.estimateFee — mocks the underlying
+ * Stellar simulation so no live network is required.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SwiftRemitClient } from "./client.js";
+import { Networks } from "@stellar/stellar-sdk";
+
+const CONTRACT_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+const SOURCE = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const AMOUNT = 100_000_000n; // 10 USDC
+const CORRIDOR = { currency: "USDC", country: "NG" };
+
+function makeClient(rpcUrl = "http://localhost:8000") {
+  return new SwiftRemitClient({
+    contractId: CONTRACT_ID,
+    networkPassphrase: Networks.TESTNET,
+    rpcUrl,
+  });
+}
+
+function mockSimulation(client: SwiftRemitClient, platformFee: bigint, protocolFee: bigint, netAmount: bigint) {
+  const { xdr, scValToNative: _ignore, nativeToScVal } = vi.importActual<typeof import("@stellar/stellar-sdk")>("@stellar/stellar-sdk") as never;
+  void _ignore;
+
+  // Stub out the private simulateCall to return a fake FeeBreakdown XDR value
+  const stub = vi.spyOn(client as never, "simulateCall").mockResolvedValue(
+    // Build a fake ScVal map: { platform_fee, protocol_fee, net_amount }
+    (() => {
+      // We mock the return at the parseFeeBreakdown level by returning an
+      // object that parseFeeBreakdown can decode via scValToNative.
+      // Easiest: return a ScVal that scValToNative maps to a plain object.
+      const stellarSdk = require("@stellar/stellar-sdk") as typeof import("@stellar/stellar-sdk");
+      return stellarSdk.xdr.ScVal.scvMap([
+        new stellarSdk.xdr.ScMapEntry({
+          key: stellarSdk.xdr.ScVal.scvSymbol("platform_fee"),
+          val: stellarSdk.nativeToScVal(platformFee, { type: "i128" }),
+        }),
+        new stellarSdk.xdr.ScMapEntry({
+          key: stellarSdk.xdr.ScVal.scvSymbol("protocol_fee"),
+          val: stellarSdk.nativeToScVal(protocolFee, { type: "i128" }),
+        }),
+        new stellarSdk.xdr.ScMapEntry({
+          key: stellarSdk.xdr.ScVal.scvSymbol("net_amount"),
+          val: stellarSdk.nativeToScVal(netAmount, { type: "i128" }),
+        }),
+      ]);
+    })()
+  );
+  return stub;
+}
+
+describe("estimateFee", () => {
+  let client: SwiftRemitClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("calls the contract simulation and returns typed FeeEstimate", async () => {
+    const platformFee = 1_000_000n;
+    const protocolFee = 100_000n;
+    const netAmount = AMOUNT - platformFee - protocolFee;
+
+    const stub = mockSimulation(client, platformFee, protocolFee, netAmount);
+
+    const estimate = await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+
+    expect(stub).toHaveBeenCalledOnce();
+    expect(stub).toHaveBeenCalledWith(SOURCE, "get_fee_breakdown", expect.any(Array), undefined);
+
+    expect(estimate.amount).toBe(AMOUNT);
+    expect(estimate.platformFee).toBe(platformFee);
+    expect(estimate.protocolFee).toBe(protocolFee);
+    expect(estimate.netAmount).toBe(netAmount);
+    expect(estimate.totalFee).toBe(platformFee + protocolFee);
+    expect(estimate.fromCache).toBe(false);
+    expect(estimate.estimatedAt).toBeInstanceOf(Date);
+  });
+
+  it("serves subsequent calls from cache within 30 s TTL", async () => {
+    const platformFee = 500_000n;
+    const protocolFee = 50_000n;
+    const netAmount = AMOUNT - platformFee - protocolFee;
+    const stub = mockSimulation(client, platformFee, protocolFee, netAmount);
+
+    await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+    const cached = await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+
+    // simulateCall called only once
+    expect(stub).toHaveBeenCalledOnce();
+    expect(cached.fromCache).toBe(true);
+  });
+
+  it("re-fetches after the 30 s cache TTL expires", async () => {
+    const platformFee = 500_000n;
+    const protocolFee = 50_000n;
+    const netAmount = AMOUNT - platformFee - protocolFee;
+    const stub = mockSimulation(client, platformFee, protocolFee, netAmount);
+
+    await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+
+    // Advance past the 30 s TTL
+    vi.advanceTimersByTime(31_000);
+
+    const fresh = await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+
+    expect(stub).toHaveBeenCalledTimes(2);
+    expect(fresh.fromCache).toBe(false);
+  });
+
+  it("caches independently per (amount, corridor, sender) key", async () => {
+    const platformFee = 500_000n;
+    const netAmount = AMOUNT - platformFee;
+    const stub = mockSimulation(client, platformFee, 0n, netAmount);
+
+    await client.estimateFee(AMOUNT, CORRIDOR, SOURCE);
+    await client.estimateFee(AMOUNT, { currency: "USD", country: "GH" }, SOURCE);
+    await client.estimateFee(AMOUNT * 2n, CORRIDOR, SOURCE);
+
+    // Three different cache keys → three simulation calls
+    expect(stub).toHaveBeenCalledTimes(3);
+  });
+
+  it("forwards an explicit retryPolicy to simulateCall", async () => {
+    const stub = mockSimulation(client, 0n, 0n, AMOUNT);
+    const policy = { retries: 2, delayMs: 200 };
+
+    await client.estimateFee(AMOUNT, CORRIDOR, SOURCE, policy);
+
+    expect(stub).toHaveBeenCalledWith(SOURCE, "get_fee_breakdown", expect.any(Array), policy);
+  });
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -20,7 +20,11 @@ export type {
   Role,
   GovernanceConfig,
   DailyLimitStatus,
+  RetryPolicy,
+  Corridor,
+  FeeEstimate,
 } from "./types.js";
+export { RetryPolicies } from "./types.js";
 export {
   parseRemittance,
   parseAgentStats,
@@ -48,7 +52,7 @@ export const RpcUrls = {
   MAINNET: "https://soroban-mainnet.stellar.org",
 } as const;
 
-export { withRetry, isTransientError } from "./retry.js";
+export { withRetry, withRetryPolicy, isTransientError } from "./retry.js";
 
 /** USDC multiplier: 1 USDC = 10_000_000 stroops. */
 export const USDC_MULTIPLIER = 10_000_000n;

--- a/sdk/src/retry-policy.test.ts
+++ b/sdk/src/retry-policy.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for per-operation retry policy configuration.
+ *
+ * Verifies that:
+ *  - Global write retry policy defaults to 0 retries
+ *  - Per-call retryPolicy on submitTransaction overrides the default
+ *  - simulateCall uses the global read retry config
+ *  - withRetryPolicy correctly falls back to defaults for omitted fields
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { withRetry, withRetryPolicy, isTransientError } from "./retry.js";
+import type { RetryPolicy } from "./types.js";
+import { RetryPolicies } from "./types.js";
+
+// ─── RetryPolicies constants ──────────────────────────────────────────────────
+
+describe("RetryPolicies", () => {
+  it("NONE has retries=0", () => {
+    expect(RetryPolicies.NONE.retries).toBe(0);
+  });
+
+  it("AGGRESSIVE has retries=5", () => {
+    expect(RetryPolicies.AGGRESSIVE.retries).toBe(5);
+  });
+});
+
+// ─── withRetryPolicy ──────────────────────────────────────────────────────────
+
+describe("withRetryPolicy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("resolves immediately on first success", async () => {
+    const fn = vi.fn(async () => "ok");
+    const policy: RetryPolicy = { retries: 3, delayMs: 100, backoffFactor: 2 };
+    const result = await withRetryPolicy(fn, policy, { delayMs: 1000, backoffFactor: 2 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries using policy.retries, not defaults", async () => {
+    const err = new Error("503 unavailable");
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      if (calls++ < 2) throw err;
+      return "done";
+    });
+    const policy: RetryPolicy = { retries: 3 }; // no delayMs/backoffFactor — use defaults
+    const promise = withRetryPolicy(fn, policy, { delayMs: 0, backoffFactor: 1 });
+    await vi.runAllTimersAsync();
+    expect(await promise).toBe("done");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to defaults for omitted delayMs", async () => {
+    // Save the original before spying so we don't recurse into the mock itself
+    const originalSetTimeout = globalThis.setTimeout;
+    const delays: number[] = [];
+    const spy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      (fn: TimerHandler, ms?: number) => {
+        if (typeof ms === "number" && ms > 0) delays.push(ms);
+        return originalSetTimeout(fn as () => void, 0);
+      }
+    );
+
+    const err = new Error("timeout");
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      if (calls++ < 1) throw err;
+      return "ok";
+    });
+
+    const policy: RetryPolicy = { retries: 1 }; // no delayMs → fall back to 500 default
+    const promise = withRetryPolicy(fn, policy, { delayMs: 500, backoffFactor: 2 });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(delays).toContain(500);
+    spy.mockRestore();
+  });
+
+  it("NONE policy results in 0 retries (fail on first error)", async () => {
+    const fn = vi.fn(async () => { throw new Error("503"); });
+    const promise = withRetryPolicy(fn, RetryPolicies.NONE, { delayMs: 0, backoffFactor: 1 });
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow("503");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates non-transient errors immediately regardless of policy", async () => {
+    const fn = vi.fn(async () => { throw new Error("auth failure"); });
+    await expect(
+      withRetryPolicy(fn, { retries: 5 }, { delayMs: 0, backoffFactor: 1 })
+    ).rejects.toThrow("auth failure");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── isTransientError (sanity check for new coverage) ─────────────────────────
+
+describe("isTransientError – RPC timeout", () => {
+  it("classifies RPC timeout message as transient", () => {
+    expect(isTransientError(new Error("RPC call timed out after 30000ms"))).toBe(true);
+  });
+});
+
+// ─── withRetry (delegate behaviour verification) ──────────────────────────────
+
+describe("withRetry with retries=0", () => {
+  it("does not retry even for transient errors", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn(async () => { throw new Error("503"); });
+    const promise = withRetry(fn, 0, 100, 2);
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow("503");
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,3 +1,5 @@
+import type { RetryPolicy } from "./types.js";
+
 export function isTransientError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return (
@@ -7,7 +9,8 @@ export function isTransientError(err: unknown): boolean {
     msg.includes("ECONNREFUSED") ||
     msg.includes("ETIMEDOUT") ||
     msg.includes("network") ||
-    msg.includes("timeout")
+    msg.includes("timeout") ||
+    msg.includes("timed out")
   );
 }
 
@@ -29,4 +32,22 @@ export async function withRetry<T>(
       attempt++;
     }
   }
+}
+
+/**
+ * Apply a {@link RetryPolicy} object, filling in omitted fields from the provided
+ * client defaults. Use this when you have a RetryPolicy that may be missing
+ * delayMs or backoffFactor.
+ */
+export async function withRetryPolicy<T>(
+  fn: () => Promise<T>,
+  policy: RetryPolicy,
+  defaults: { delayMs: number; backoffFactor: number }
+): Promise<T> {
+  return withRetry(
+    fn,
+    policy.retries,
+    policy.delayMs ?? defaults.delayMs,
+    policy.backoffFactor ?? defaults.backoffFactor
+  );
 }

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { SwiftRemitMockClient } from "./mock-client.js";
+export type { MockTxResult, MockClientOptions } from "./mock-client.js";

--- a/sdk/src/testing/mock-client.test.ts
+++ b/sdk/src/testing/mock-client.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SwiftRemitMockClient } from "./mock-client.js";
+import { SwiftRemitError, ErrorCode } from "../errors.js";
+
+const AGENT = "GAGENT000000000000000000000000000000000000000000000000000";
+const SENDER = "GSENDER00000000000000000000000000000000000000000000000000";
+const SOURCE = "GSOURCE00000000000000000000000000000000000000000000000000";
+const AMOUNT = 100_000_000n; // 10 USDC at 1 USDC = 10_000_000 stroops
+
+describe("SwiftRemitMockClient – seed helpers", () => {
+  it("seedAgent makes isAgentRegistered return true", async () => {
+    const client = new SwiftRemitMockClient();
+    expect(await client.isAgentRegistered(SOURCE, AGENT)).toBe(false);
+    client.seedAgent(AGENT);
+    expect(await client.isAgentRegistered(SOURCE, AGENT)).toBe(true);
+  });
+
+  it("seedToken makes isTokenWhitelisted return true", async () => {
+    const client = new SwiftRemitMockClient();
+    client.seedToken("USDC_CONTRACT");
+    expect(await client.isTokenWhitelisted(SOURCE, "USDC_CONTRACT")).toBe(true);
+  });
+
+  it("seedRemittance injects a remittance queryable by id", async () => {
+    const client = new SwiftRemitMockClient();
+    const remittance = {
+      id: 42n,
+      sender: SENDER,
+      agent: AGENT,
+      amount: AMOUNT,
+      fee: 1_000_000n,
+      status: "Pending" as const,
+      expiry: null,
+      token: "",
+      createdAt: 0n,
+      failedAt: null,
+      expiresAt: null,
+    };
+    client.seedRemittance(remittance);
+    const found = await client.getRemittance(SOURCE, 42n);
+    expect(found.id).toBe(42n);
+    expect(found.status).toBe("Pending");
+  });
+
+  it("setFeeBps changes the fee used in createRemittance", async () => {
+    const client = new SwiftRemitMockClient();
+    client.seedAgent(AGENT).setFeeBps(200); // 2%
+    const result = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    const r = await client.getRemittance(SOURCE, result.id!);
+    expect(r.fee).toBe((AMOUNT * 200n) / 10_000n);
+  });
+});
+
+describe("SwiftRemitMockClient – createRemittance", () => {
+  let client: SwiftRemitMockClient;
+
+  beforeEach(() => {
+    client = new SwiftRemitMockClient();
+    client.seedAgent(AGENT);
+  });
+
+  it("creates a remittance and returns an id", async () => {
+    const result = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    expect(result.id).toBeDefined();
+    expect(result.txHash).toMatch(/^MOCK_TX_/);
+  });
+
+  it("new remittance has Pending status", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    const r = await client.getRemittance(SOURCE, id!);
+    expect(r.status).toBe("Pending");
+    expect(r.amount).toBe(AMOUNT);
+  });
+
+  it("rejects unregistered agents", async () => {
+    await expect(
+      client.createRemittance({ sender: SENDER, agent: "GUNKNOWN", amount: AMOUNT })
+    ).rejects.toThrow(SwiftRemitError);
+    await expect(
+      client.createRemittance({ sender: SENDER, agent: "GUNKNOWN", amount: AMOUNT })
+    ).rejects.toMatchObject({ code: ErrorCode.AgentNotRegistered });
+  });
+
+  it("rejects zero amount", async () => {
+    await expect(
+      client.createRemittance({ sender: SENDER, agent: AGENT, amount: 0n })
+    ).rejects.toMatchObject({ code: ErrorCode.InvalidAmount });
+  });
+
+  it("increments id for each new remittance", async () => {
+    const { id: id1 } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    const { id: id2 } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    expect(id2).toBe(id1! + 1n);
+  });
+});
+
+describe("SwiftRemitMockClient – state machine transitions", () => {
+  let client: SwiftRemitMockClient;
+
+  beforeEach(() => {
+    client = new SwiftRemitMockClient({ feeBps: 100 });
+    client.seedAgent(AGENT);
+  });
+
+  it("confirmPayout moves Pending → Completed", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.confirmPayout(AGENT, id!);
+    const r = await client.getRemittance(SOURCE, id!);
+    expect(r.status).toBe("Completed");
+  });
+
+  it("cancelRemittance moves Pending → Cancelled", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.cancelRemittance(SENDER, id!);
+    const r = await client.getRemittance(SOURCE, id!);
+    expect(r.status).toBe("Cancelled");
+  });
+
+  it("markFailed moves Pending → Failed", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.markFailed(AGENT, id!);
+    const r = await client.getRemittance(SOURCE, id!);
+    expect(r.status).toBe("Failed");
+  });
+
+  it("raiseDispute moves Failed → Disputed", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.markFailed(AGENT, id!);
+    await client.raiseDispute(SENDER, id!, Buffer.alloc(32));
+    const r = await client.getRemittance(SOURCE, id!);
+    expect(r.status).toBe("Disputed");
+  });
+
+  it("resolveDispute in favour of sender → Cancelled", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.markFailed(AGENT, id!);
+    await client.raiseDispute(SENDER, id!, Buffer.alloc(32));
+    await client.resolveDispute("GADMIN", id!, true);
+    expect((await client.getRemittance(SOURCE, id!)).status).toBe("Cancelled");
+  });
+
+  it("resolveDispute against sender → Completed", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.markFailed(AGENT, id!);
+    await client.raiseDispute(SENDER, id!, Buffer.alloc(32));
+    await client.resolveDispute("GADMIN", id!, false);
+    expect((await client.getRemittance(SOURCE, id!)).status).toBe("Completed");
+  });
+
+  it("cancelRemittance on a non-Pending remittance throws InvalidStatus", async () => {
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.confirmPayout(AGENT, id!);
+    await expect(client.cancelRemittance(SENDER, id!)).rejects.toMatchObject({
+      code: ErrorCode.InvalidStatus,
+    });
+  });
+});
+
+describe("SwiftRemitMockClient – fees and totals", () => {
+  it("accumulatedFees increases after confirmPayout", async () => {
+    const client = new SwiftRemitMockClient({ feeBps: 100 });
+    client.seedAgent(AGENT);
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    expect(await client.getAccumulatedFees(SOURCE)).toBe(0n);
+    await client.confirmPayout(AGENT, id!);
+    const fee = (AMOUNT * 100n) / 10_000n;
+    expect(await client.getAccumulatedFees(SOURCE)).toBe(fee);
+  });
+
+  it("withdrawFees resets accumulated fees", async () => {
+    const client = new SwiftRemitMockClient({ feeBps: 100 });
+    client.seedAgent(AGENT);
+    const { id } = await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    await client.confirmPayout(AGENT, id!);
+    await client.withdrawFees("GADMIN", "GTREASURY");
+    expect(await client.getAccumulatedFees(SOURCE)).toBe(0n);
+  });
+
+  it("withdrawFees throws when no fees have accumulated", async () => {
+    const client = new SwiftRemitMockClient();
+    await expect(client.withdrawFees("GADMIN", "GTREASURY")).rejects.toMatchObject({
+      code: ErrorCode.NoFeesToWithdraw,
+    });
+  });
+});
+
+describe("SwiftRemitMockClient – estimateFee", () => {
+  it("returns correct breakdown using configured feeBps", async () => {
+    const client = new SwiftRemitMockClient({ feeBps: 200, protocolFeeBps: 50 });
+    const estimate = await client.estimateFee(
+      AMOUNT,
+      { currency: "USDC", country: "NG" },
+      SOURCE
+    );
+    const platformFee = (AMOUNT * 200n) / 10_000n;
+    const protocolFee = (AMOUNT * 50n) / 10_000n;
+    expect(estimate.platformFee).toBe(platformFee);
+    expect(estimate.protocolFee).toBe(protocolFee);
+    expect(estimate.totalFee).toBe(platformFee + protocolFee);
+    expect(estimate.netAmount).toBe(AMOUNT - platformFee - protocolFee);
+    expect(estimate.fromCache).toBe(false);
+  });
+});
+
+describe("SwiftRemitMockClient – getRemittancesBySender", () => {
+  it("returns ids for a specific sender with pagination", async () => {
+    const client = new SwiftRemitMockClient();
+    client.seedAgent(AGENT);
+    for (let i = 0; i < 5; i++) {
+      await client.createRemittance({ sender: SENDER, agent: AGENT, amount: AMOUNT });
+    }
+    const page1 = await client.getRemittancesBySender(SOURCE, SENDER, 0n, 3n);
+    expect(page1).toHaveLength(3);
+    const page2 = await client.getRemittancesBySender(SOURCE, SENDER, 3n, 3n);
+    expect(page2).toHaveLength(2);
+  });
+});

--- a/sdk/src/testing/mock-client.ts
+++ b/sdk/src/testing/mock-client.ts
@@ -1,0 +1,498 @@
+/**
+ * In-memory mock implementation of SwiftRemitClient for integration testing.
+ *
+ * Usage:
+ *   import { SwiftRemitMockClient } from "@swiftremit/sdk/testing";
+ *
+ *   const client = new SwiftRemitMockClient();
+ *   client.seedAgent("GXXX");
+ *   await client.createRemittance({ ... });
+ */
+
+import type {
+  Remittance,
+  RemittanceStatus,
+  AgentStats,
+  CircuitBreakerStatus,
+  HealthStatus,
+  CreateRemittanceParams,
+  BatchCreateEntry,
+  GovernanceConfig,
+  DailyLimitStatus,
+  Proposal,
+  PartialPayoutRecord,
+  FeeEstimate,
+  Corridor,
+} from "../types.js";
+import { SwiftRemitError, ErrorCode } from "../errors.js";
+
+/** Returned by write operations on the mock client in place of a Stellar Transaction. */
+export interface MockTxResult {
+  /** Fake transaction hash generated for the operation. */
+  txHash: string;
+  /** The remittance ID that was created, if applicable. */
+  id?: bigint;
+}
+
+let _txCounter = 0;
+function fakeTxHash(): string {
+  return `MOCK_TX_${(++_txCounter).toString().padStart(8, "0")}`;
+}
+
+export interface MockClientOptions {
+  /** Initial platform fee in basis points (default: 100 = 1%). */
+  feeBps?: number;
+  /** Protocol fee in basis points (default: 0). */
+  protocolFeeBps?: number;
+}
+
+/**
+ * In-memory SwiftRemit client for integration tests.
+ *
+ * Write operations directly apply state mutations and return a {@link MockTxResult}.
+ * Read operations mirror the real client's signatures exactly.
+ */
+export class SwiftRemitMockClient {
+  private readonly remittances = new Map<bigint, Remittance>();
+  private readonly agents = new Set<string>();
+  private readonly tokens = new Set<string>();
+  private readonly admins = new Set<string>();
+  private readonly agentStats = new Map<string, AgentStats>();
+  private readonly dailyLimits = new Map<string, { limit: bigint; used: bigint; resetsAt: Date }>();
+  private nextId = 1n;
+  private _feeBps: number;
+  private _protocolFeeBps: number;
+  private _paused = false;
+  private _totalVolume = 0n;
+  private _platformFees = 0n;
+  private _integratorFees = 0n;
+
+  constructor(options: MockClientOptions = {}) {
+    this._feeBps = options.feeBps ?? 100;
+    this._protocolFeeBps = options.protocolFeeBps ?? 0;
+  }
+
+  // ─── Seed helpers ─────────────────────────────────────────────────────────────
+
+  /** Pre-register an agent so `isAgentRegistered` returns true. Chainable. */
+  seedAgent(address: string): this {
+    this.agents.add(address);
+    if (!this.agentStats.has(address)) {
+      this.agentStats.set(address, {
+        totalSettlements: 0,
+        failedSettlements: 0,
+        totalSettlementTime: 0n,
+        disputeCount: 0,
+        successRateBps: 10_000,
+        lastActiveTimestamp: BigInt(Date.now()),
+      });
+    }
+    return this;
+  }
+
+  /** Whitelist a token. Chainable. */
+  seedToken(address: string): this {
+    this.tokens.add(address);
+    return this;
+  }
+
+  /** Add an admin address. Chainable. */
+  seedAdmin(address: string): this {
+    this.admins.add(address);
+    return this;
+  }
+
+  /** Inject an existing remittance into state. Chainable. */
+  seedRemittance(r: Remittance): this {
+    this.remittances.set(r.id, r);
+    if (r.id >= this.nextId) this.nextId = r.id + 1n;
+    return this;
+  }
+
+  /** Set the platform fee in basis points. Chainable. */
+  setFeeBps(bps: number): this {
+    this._feeBps = bps;
+    return this;
+  }
+
+  /** Return a snapshot of all remittances (useful for assertions). */
+  getAllRemittances(): Remittance[] {
+    return Array.from(this.remittances.values());
+  }
+
+  // ─── Read operations (match SwiftRemitClient signatures exactly) ──────────────
+
+  async getRemittance(_sourceAddress: string, remittanceId: bigint): Promise<Remittance> {
+    const r = this.remittances.get(remittanceId);
+    if (!r) throw new SwiftRemitError(ErrorCode.RemittanceNotFound, `${remittanceId}`);
+    return { ...r };
+  }
+
+  async getRemittancesBySender(
+    _sourceAddress: string,
+    sender: string,
+    offset: bigint,
+    limit: bigint
+  ): Promise<bigint[]> {
+    const ids = Array.from(this.remittances.values())
+      .filter((r) => r.sender === sender)
+      .map((r) => r.id);
+    return ids.slice(Number(offset), Number(offset) + Number(limit));
+  }
+
+  async getAccumulatedFees(_sourceAddress: string): Promise<bigint> {
+    return this._platformFees;
+  }
+
+  async getAccumulatedIntegratorFees(_sourceAddress: string): Promise<bigint> {
+    return this._integratorFees;
+  }
+
+  async isAgentRegistered(_sourceAddress: string, agent: string): Promise<boolean> {
+    return this.agents.has(agent);
+  }
+
+  async isTokenWhitelisted(_sourceAddress: string, token: string): Promise<boolean> {
+    return this.tokens.has(token);
+  }
+
+  async getPlatformFeeBps(_sourceAddress: string): Promise<number> {
+    return this._feeBps;
+  }
+
+  async getRemittanceCount(_sourceAddress: string): Promise<bigint> {
+    return BigInt(this.remittances.size);
+  }
+
+  async getTotalVolume(_sourceAddress: string): Promise<bigint> {
+    return this._totalVolume;
+  }
+
+  async getAdminCount(_sourceAddress: string): Promise<number> {
+    return this.admins.size;
+  }
+
+  async health(_sourceAddress: string): Promise<HealthStatus> {
+    return {
+      initialized: true,
+      paused: this._paused,
+      adminCount: this.admins.size,
+      totalRemittances: BigInt(this.remittances.size),
+      accumulatedFees: this._platformFees,
+    };
+  }
+
+  async getAgentStats(_sourceAddress: string, agent: string): Promise<AgentStats> {
+    if (!this.agents.has(agent))
+      throw new SwiftRemitError(ErrorCode.AgentNotRegistered, agent);
+    return this.agentStats.get(agent)!;
+  }
+
+  async getAgentReputation(_sourceAddress: string, agent: string): Promise<number> {
+    const stats = this.agentStats.get(agent);
+    if (!stats) throw new SwiftRemitError(ErrorCode.AgentNotRegistered, agent);
+    return Math.round(stats.successRateBps / 100);
+  }
+
+  async getCircuitBreakerStatus(_sourceAddress: string): Promise<CircuitBreakerStatus> {
+    return {
+      isPaused: this._paused,
+      pauseReason: null,
+      pauseTimestamp: null,
+      timelockSeconds: 86_400n,
+      unpauseQuorum: 2,
+      currentVoteCount: 0,
+    };
+  }
+
+  async getAgentDailyCap(_sourceAddress: string, _agent: string): Promise<bigint> {
+    return 0n;
+  }
+
+  async getDisputeWindow(_sourceAddress: string): Promise<bigint> {
+    return 86_400n;
+  }
+
+  async getDailyLimitStatus(
+    _sourceAddress: string,
+    sender: string,
+    currency: string,
+    country: string
+  ): Promise<DailyLimitStatus> {
+    const key = `${sender}:${currency}:${country}`;
+    const entry = this.dailyLimits.get(key) ?? { limit: 0n, used: 0n, resetsAt: new Date(Date.now() + 86_400_000) };
+    return {
+      limit: entry.limit,
+      used: entry.used,
+      remaining: entry.limit === 0n ? BigInt(Number.MAX_SAFE_INTEGER) : entry.limit - entry.used,
+      resetsAt: entry.resetsAt,
+    };
+  }
+
+  async getRemittanceExpiryWindow(_sourceAddress: string): Promise<bigint> {
+    return 0n;
+  }
+
+  async getPartialPayoutHistory(
+    _sourceAddress: string,
+    remittanceId: bigint
+  ): Promise<PartialPayoutRecord[]> {
+    if (!this.remittances.has(remittanceId))
+      throw new SwiftRemitError(ErrorCode.RemittanceNotFound, `${remittanceId}`);
+    return [];
+  }
+
+  async getGovernanceConfig(_sourceAddress: string): Promise<GovernanceConfig> {
+    return { quorum: 2, timelockSeconds: 86_400n, proposalTtlSeconds: 604_800n };
+  }
+
+  async getProposal(_sourceAddress: string, _proposalId: bigint): Promise<Proposal> {
+    throw new SwiftRemitError(ErrorCode.ProposalNotFound, `${_proposalId}`);
+  }
+
+  async getActiveProposals(_sourceAddress: string): Promise<Proposal[]> {
+    return [];
+  }
+
+  async estimateFee(
+    amount: bigint,
+    _corridor: Corridor,
+    _senderAddress: string
+  ): Promise<FeeEstimate> {
+    const platformFee = (amount * BigInt(this._feeBps)) / 10_000n;
+    const protocolFee = (amount * BigInt(this._protocolFeeBps)) / 10_000n;
+    const totalFee = platformFee + protocolFee;
+    return {
+      amount,
+      platformFee,
+      protocolFee,
+      netAmount: amount - totalFee,
+      totalFee,
+      estimatedAt: new Date(),
+      fromCache: false,
+    };
+  }
+
+  // ─── Write operations (apply state directly, return MockTxResult) ─────────────
+
+  async createRemittance(params: CreateRemittanceParams): Promise<MockTxResult> {
+    if (!this.agents.has(params.agent))
+      throw new SwiftRemitError(ErrorCode.AgentNotRegistered, params.agent);
+    if (params.amount <= 0n)
+      throw new SwiftRemitError(ErrorCode.InvalidAmount, `${params.amount}`);
+
+    const id = this.nextId++;
+    const fee = (params.amount * BigInt(this._feeBps)) / 10_000n;
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    this.remittances.set(id, {
+      id,
+      sender: params.sender,
+      agent: params.agent,
+      amount: params.amount,
+      fee,
+      status: "Pending",
+      expiry: params.expiry ?? null,
+      token: params.token ?? "",
+      createdAt: now,
+      failedAt: null,
+      expiresAt: params.expiry != null ? now + params.expiry : null,
+    });
+    return { txHash: fakeTxHash(), id };
+  }
+
+  async batchCreateRemittances(
+    sender: string,
+    entries: BatchCreateEntry[]
+  ): Promise<MockTxResult> {
+    for (const e of entries) {
+      await this.createRemittance({
+        sender,
+        agent: e.agent,
+        amount: e.amount,
+        expiry: e.expiry,
+      });
+    }
+    return { txHash: fakeTxHash() };
+  }
+
+  async confirmPayout(
+    _agent: string,
+    remittanceId: bigint
+  ): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Pending");
+    const fee = r.fee;
+    this._platformFees += fee;
+    this._totalVolume += r.amount;
+    this.remittances.set(remittanceId, { ...r, status: "Completed" });
+    this._bumpAgentStats(_agent, true, r.amount);
+    return { txHash: fakeTxHash() };
+  }
+
+  async confirmPartialPayout(
+    _agent: string,
+    remittanceId: bigint,
+    _amount: bigint
+  ): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Pending");
+    return { txHash: fakeTxHash() };
+  }
+
+  async cancelRemittance(
+    _sender: string,
+    remittanceId: bigint
+  ): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Pending");
+    this.remittances.set(remittanceId, { ...r, status: "Cancelled" });
+    return { txHash: fakeTxHash() };
+  }
+
+  async markFailed(_agent: string, remittanceId: bigint): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Pending");
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    this.remittances.set(remittanceId, { ...r, status: "Failed", failedAt: now });
+    this._bumpAgentStats(_agent, false, 0n);
+    return { txHash: fakeTxHash() };
+  }
+
+  async raiseDispute(
+    _sender: string,
+    remittanceId: bigint,
+    _evidenceHash: Buffer
+  ): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Failed");
+    this.remittances.set(remittanceId, { ...r, status: "Disputed" });
+    return { txHash: fakeTxHash() };
+  }
+
+  async resolveDispute(
+    _admin: string,
+    remittanceId: bigint,
+    inFavourOfSender: boolean
+  ): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Disputed");
+    this.remittances.set(remittanceId, {
+      ...r,
+      status: inFavourOfSender ? "Cancelled" : "Completed",
+    });
+    return { txHash: fakeTxHash() };
+  }
+
+  async expireRemittance(_caller: string, remittanceId: bigint): Promise<MockTxResult> {
+    const r = this._requireRemittance(remittanceId);
+    this._requireStatus(r, "Pending");
+    this.remittances.set(remittanceId, { ...r, status: "Cancelled" });
+    return { txHash: fakeTxHash() };
+  }
+
+  async processExpiredRemittances(
+    _caller: string,
+    remittanceIds: bigint[]
+  ): Promise<MockTxResult> {
+    for (const id of remittanceIds) await this.expireRemittance(_caller, id);
+    return { txHash: fakeTxHash() };
+  }
+
+  async withdrawFees(_admin: string, _to: string): Promise<MockTxResult> {
+    if (this._platformFees === 0n)
+      throw new SwiftRemitError(ErrorCode.NoFeesToWithdraw, "0");
+    this._platformFees = 0n;
+    return { txHash: fakeTxHash() };
+  }
+
+  async withdrawIntegratorFees(_integrator: string, _to: string): Promise<MockTxResult> {
+    this._integratorFees = 0n;
+    return { txHash: fakeTxHash() };
+  }
+
+  async registerAgent(_admin: string, agent: string): Promise<MockTxResult> {
+    if (this.agents.has(agent))
+      throw new SwiftRemitError(ErrorCode.AgentAlreadyRegistered, agent);
+    this.seedAgent(agent);
+    return { txHash: fakeTxHash() };
+  }
+
+  async removeAgent(_admin: string, agent: string): Promise<MockTxResult> {
+    if (!this.agents.has(agent))
+      throw new SwiftRemitError(ErrorCode.AgentNotRegistered, agent);
+    this.agents.delete(agent);
+    return { txHash: fakeTxHash() };
+  }
+
+  async updateFee(_admin: string, feeBps: number): Promise<MockTxResult> {
+    this._feeBps = feeBps;
+    return { txHash: fakeTxHash() };
+  }
+
+  async setDailyLimit(
+    _admin: string,
+    currency: string,
+    country: string,
+    limit: bigint
+  ): Promise<MockTxResult> {
+    const senderKey = `*:${currency}:${country}`;
+    this.dailyLimits.set(senderKey, {
+      limit,
+      used: 0n,
+      resetsAt: new Date(Date.now() + 86_400_000),
+    });
+    return { txHash: fakeTxHash() };
+  }
+
+  async setAgentDailyCap(_admin: string, _agent: string, _cap: bigint): Promise<MockTxResult> {
+    return { txHash: fakeTxHash() };
+  }
+
+  async addAdmin(_caller: string, newAdmin: string): Promise<MockTxResult> {
+    this.admins.add(newAdmin);
+    return { txHash: fakeTxHash() };
+  }
+
+  async extendStorageTtl(_admin: string, _extendByLedgers: number): Promise<MockTxResult> {
+    return { txHash: fakeTxHash() };
+  }
+
+  async initialize(_admin: string, _params: unknown): Promise<MockTxResult> {
+    return { txHash: fakeTxHash() };
+  }
+
+  async voteOnProposal(_sourceAddress: string, _proposalId: bigint): Promise<MockTxResult> {
+    return { txHash: fakeTxHash() };
+  }
+
+  async executeProposal(_sourceAddress: string, _proposalId: bigint): Promise<MockTxResult> {
+    return { txHash: fakeTxHash() };
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────────
+
+  private _requireRemittance(id: bigint): Remittance {
+    const r = this.remittances.get(id);
+    if (!r) throw new SwiftRemitError(ErrorCode.RemittanceNotFound, `${id}`);
+    return r;
+  }
+
+  private _requireStatus(r: Remittance, expected: RemittanceStatus): void {
+    if (r.status !== expected)
+      throw new SwiftRemitError(
+        ErrorCode.InvalidStatus,
+        `Expected ${expected}, got ${r.status}`
+      );
+  }
+
+  private _bumpAgentStats(agent: string, success: boolean, _amount: bigint): void {
+    const stats = this.agentStats.get(agent);
+    if (!stats) return;
+    stats.totalSettlements++;
+    if (!success) stats.failedSettlements++;
+    stats.successRateBps = stats.totalSettlements === 0
+      ? 10_000
+      : Math.round(((stats.totalSettlements - stats.failedSettlements) / stats.totalSettlements) * 10_000);
+    stats.lastActiveTimestamp = BigInt(Math.floor(Date.now() / 1000));
+  }
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -153,6 +153,50 @@ export interface CreateRemittanceParams {
   recipientHash?: Buffer;
 }
 
+/** Retry policy for a specific operation or operation category. */
+export interface RetryPolicy {
+  /** Number of retry attempts (0 = call once and fail on error). */
+  retries: number;
+  /** Initial delay in ms before the first retry. Falls back to the client's retryDelayMs. */
+  delayMs?: number;
+  /** Backoff multiplier applied after each retry. Falls back to the client's retryBackoffFactor. */
+  backoffFactor?: number;
+}
+
+/** Pre-built named retry policies for common scenarios. */
+export const RetryPolicies = {
+  /** No retries — suitable for non-idempotent operations where a duplicate would be harmful. */
+  NONE: { retries: 0 } as RetryPolicy,
+  /** Aggressive retries — suitable for idempotent reads where availability matters. */
+  AGGRESSIVE: { retries: 5, delayMs: 500, backoffFactor: 1.5 } as RetryPolicy,
+} as const;
+
+/** A remittance corridor identified by destination currency and country. */
+export interface Corridor {
+  /** ISO 4217 currency code (e.g. "USDC", "USD"). */
+  currency: string;
+  /** ISO 3166-1 alpha-2 destination country code (e.g. "NG", "GH"). */
+  country: string;
+}
+
+/** Fee estimate returned by {@link SwiftRemitClient.estimateFee}. All amounts in stroops. */
+export interface FeeEstimate {
+  /** Requested send amount in stroops. */
+  amount: bigint;
+  /** Platform fee charged by SwiftRemit in stroops. */
+  platformFee: bigint;
+  /** Protocol fee charged by the Stellar network in stroops. */
+  protocolFee: bigint;
+  /** Net amount the recipient receives (amount − totalFee) in stroops. */
+  netAmount: bigint;
+  /** Sum of platformFee and protocolFee in stroops. */
+  totalFee: bigint;
+  /** Timestamp when this estimate was generated. */
+  estimatedAt: Date;
+  /** True when the estimate was served from the 30-second local cache. */
+  fromCache: boolean;
+}
+
 export interface SwiftRemitClientOptions {
   /** Deployed contract address */
   contractId: string;
@@ -168,6 +212,14 @@ export interface SwiftRemitClientOptions {
   retryDelayMs?: number;
   /** Multiplier applied to delay after each retry (default: 2) */
   retryBackoffFactor?: number;
+  /**
+   * Default retry policy for state-changing (write) operations submitted via
+   * {@link SwiftRemitClient.submitTransaction}. Defaults to no retries because
+   * most write operations are non-idempotent and retrying the same signed
+   * transaction could produce unexpected results for callers who don't explicitly
+   * opt in. Override per-call via the `options.retryPolicy` argument.
+   */
+  writeRetryPolicy?: RetryPolicy;
 }
 
 export type ProposalState = "Pending" | "Approved" | "Executed" | "Expired";


### PR DESCRIPTION
## Summary

- **Per-operation retry policy** — `RetryPolicy` interface + `RetryPolicies` constants (`NONE`, `AGGRESSIVE`) added to the SDK. Write operations default to 0 retries (`writeRetryPolicy` option); callers opt in per-call via `submitTransaction({ retryPolicy })`. Read operations keep the existing global retry config. A new `withRetryPolicy()` helper resolves policy fields against client defaults.
- **Fee estimation** — `estimateFee(amount, corridor, senderAddress)` calls the `get_fee_breakdown` contract simulation and returns a typed `FeeEstimate` with `platformFee`, `protocolFee`, `netAmount`, and `totalFee`. Results are cached per-key for 30 seconds (`fromCache: true` on cache hits).
- **SDK mock for testing** — `SwiftRemitMockClient` exported from `@swiftremit/sdk/testing`. Full in-memory state machine (Pending → Completed/Cancelled/Failed → Disputed), chainable seed helpers (`seedAgent`, `seedToken`, `seedRemittance`, `setFeeBps`), no Stellar network required.
- **Automated npm releases** — Changesets configured at `.changeset/config.json`. The release workflow gains a `changesets` job that triggers on every push to `main`, creating a version bump PR then publishing to npm with provenance signing on merge.

## Test plan

- [ ] Run `npm test` in `sdk/` — all 86 tests pass across 8 files
- [ ] Verify `RetryPolicies.NONE` and `AGGRESSIVE` are exported from `@swiftremit/sdk`
- [ ] Verify `SwiftRemitMockClient` is importable from `@swiftremit/sdk/testing`
- [ ] Verify `estimateFee` returns correct `FeeEstimate` shape
- [ ] Run `npm run build` in `sdk/` — confirms `dist/testing/` entry point is generated
- [ ] Confirm `.changeset/config.json` is present at repo root

closes #909 
closes #910 
closes #911 
closes #912 