### PR TITLE
feat: add sdk governance proposal heloer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "SwiftRemit",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -20,6 +20,7 @@ import type {
   GovernanceConfig,
   DailyLimitStatus,
   Proposal,
+  ProposalAction,
   PartialPayoutRecord,
   RemittanceEvent,
   RemittanceEventType,
@@ -60,6 +61,125 @@ function shouldAllowHttp(rpcUrl: string): boolean {
 
   const hostname = parsedUrl.hostname.toLowerCase();
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+// ─── Proposal action helpers ──────────────────────────────────────────────────
+
+function proposalActionToScVal(action: ProposalAction): xdr.ScVal {
+  let entry: xdr.ScMapEntry;
+  if ("UpdateFee" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("UpdateFee"),
+      val: xdr.ScVal.scvU32(action.UpdateFee),
+    });
+  } else if ("RegisterAgent" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("RegisterAgent"),
+      val: addressToScVal(action.RegisterAgent),
+    });
+  } else if ("RemoveAgent" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("RemoveAgent"),
+      val: addressToScVal(action.RemoveAgent),
+    });
+  } else if ("AddAdmin" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("AddAdmin"),
+      val: addressToScVal(action.AddAdmin),
+    });
+  } else if ("RemoveAdmin" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("RemoveAdmin"),
+      val: addressToScVal(action.RemoveAdmin),
+    });
+  } else if ("UpdateQuorum" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("UpdateQuorum"),
+      val: xdr.ScVal.scvU32(action.UpdateQuorum),
+    });
+  } else if ("UpdateTimelock" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("UpdateTimelock"),
+      val: u64ToScVal(action.UpdateTimelock),
+    });
+  } else if ("UpdateCooldownPeriod" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("UpdateCooldownPeriod"),
+      val: u64ToScVal(action.UpdateCooldownPeriod),
+    });
+  } else if ("WhitelistAsset" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("WhitelistAsset"),
+      val: addressToScVal(action.WhitelistAsset),
+    });
+  } else if ("AdjustReputationThreshold" in action) {
+    entry = new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("AdjustReputationThreshold"),
+      val: xdr.ScVal.scvU32(action.AdjustReputationThreshold),
+    });
+  } else {
+    throw new SwiftRemitError(
+      ErrorCode.DataCorruption,
+      "Unknown proposal action type"
+    );
+  }
+  return xdr.ScVal.scvMap([entry]);
+}
+
+/** Build a typed UpdateFee proposal action. */
+export function buildUpdateFeeProposal(feeBps: number): ProposalAction {
+  return { UpdateFee: feeBps };
+}
+
+/** Build a typed RegisterAgent proposal action. */
+export function buildRegisterAgentProposal(agent: string): ProposalAction {
+  return { RegisterAgent: agent };
+}
+
+/** Build a typed RemoveAgent proposal action. */
+export function buildRemoveAgentProposal(agent: string): ProposalAction {
+  return { RemoveAgent: agent };
+}
+
+/** Build a typed AddAdmin proposal action. */
+export function buildAddAdminProposal(admin: string): ProposalAction {
+  return { AddAdmin: admin };
+}
+
+/** Build a typed RemoveAdmin proposal action. */
+export function buildRemoveAdminProposal(admin: string): ProposalAction {
+  return { RemoveAdmin: admin };
+}
+
+/** Build a typed UpdateQuorum proposal action. */
+export function buildUpdateQuorumProposal(quorum: number): ProposalAction {
+  return { UpdateQuorum: quorum };
+}
+
+/** Build a typed UpdateTimelock proposal action. */
+export function buildUpdateTimelockProposal(
+  timelockSeconds: bigint
+): ProposalAction {
+  return { UpdateTimelock: timelockSeconds };
+}
+
+/** Build a typed UpdateCooldownPeriod proposal action. */
+export function buildUpdateCooldownPeriodProposal(
+  cooldownSeconds: bigint
+): ProposalAction {
+  return { UpdateCooldownPeriod: cooldownSeconds };
+}
+
+/** Build a typed WhitelistAsset proposal action. */
+export function buildWhitelistAssetProposal(assetAddress: string): ProposalAction {
+  return { WhitelistAsset: assetAddress };
+}
+
+/** Build a typed AdjustReputationThreshold proposal action. */
+export function buildAdjustReputationThresholdProposal(
+  threshold: number
+): ProposalAction {
+  return { AdjustReputationThreshold: threshold };
 }
 
 export class SwiftRemitClient {
@@ -743,13 +863,19 @@ export class SwiftRemitClient {
   }
 
   /**
-   * Fetch all proposals with state Pending or Approved.
-   * Iterates proposal IDs starting from 0 until the contract returns NotFound.
+   * Fetch proposals with state Pending or Approved, starting from `offset`.
+   *
+   * @param offset - Proposal ID to start iterating from
+   * @param limit - Maximum number of active proposals to return
    */
-  async getActiveProposals(sourceAddress: string): Promise<Proposal[]> {
+  async getActiveProposals(
+    sourceAddress: string,
+    offset: bigint = 0n,
+    limit: bigint = 50n
+  ): Promise<Proposal[]> {
     const proposals: Proposal[] = [];
-    let id = 0n;
-    while (true) {
+    let id = offset;
+    while (BigInt(proposals.length) < limit) {
       try {
         const val = await this.simulateCall(sourceAddress, "get_proposal", [
           u64ToScVal(id),
@@ -760,10 +886,34 @@ export class SwiftRemitClient {
         }
         id++;
       } catch {
-        break; // ProposalNotFound — no more proposals
+        break;
       }
     }
     return proposals;
+  }
+
+  /** Check whether `voterAddress` has already voted on `proposalId`. */
+  async getVoteStatus(
+    sourceAddress: string,
+    proposalId: bigint,
+    voterAddress: string
+  ): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "get_vote_status", [
+      u64ToScVal(proposalId),
+      addressToScVal(voterAddress),
+    ]);
+    return Boolean(scValToNative(val));
+  }
+
+  /** Create a new governance proposal (admin only). */
+  async propose(
+    sourceAddress: string,
+    action: ProposalAction
+  ): Promise<Transaction> {
+    return this.prepareTransaction(sourceAddress, "propose", [
+      addressToScVal(sourceAddress),
+      proposalActionToScVal(action),
+    ]);
   }
 
   /** Cast an approval vote on a pending proposal (admin only). */

--- a/sdk/src/convert.ts
+++ b/sdk/src/convert.ts
@@ -162,6 +162,10 @@ export function parseProposal(val: xdr.ScVal): Proposal {
     action = { UpdateQuorum: Number(actionVal) };
   } else if (actionKey === "UpdateTimelock") {
     action = { UpdateTimelock: BigInt(actionVal as number) };
+  } else if (actionKey === "UpdateCooldownPeriod") {
+    action = { UpdateCooldownPeriod: BigInt(actionVal as number) };
+  } else if (actionKey === "AdjustReputationThreshold") {
+    action = { AdjustReputationThreshold: Number(actionVal) };
   } else {
     action = { [actionKey]: String(actionVal) } as ProposalAction;
   }

--- a/sdk/src/governance.test.ts
+++ b/sdk/src/governance.test.ts
@@ -1,7 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parseProposal } from "../src/convert.js";
-import type { Proposal } from "../src/types.js";
+import {
+  SwiftRemitClient,
+  buildUpdateFeeProposal,
+  buildRegisterAgentProposal,
+  buildRemoveAgentProposal,
+  buildAddAdminProposal,
+  buildRemoveAdminProposal,
+  buildUpdateQuorumProposal,
+  buildUpdateTimelockProposal,
+  buildUpdateCooldownPeriodProposal,
+  buildWhitelistAssetProposal,
+  buildAdjustReputationThresholdProposal,
+} from "../src/client.js";
+import type { Proposal, ProposalAction } from "../src/types.js";
 import { makeProposalScVal } from "../src/test-utils.js";
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+
+const mockSimulateTransaction = vi.fn();
+const mockGetAccount = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    rpc: {
+      ...((actual as unknown as Record<string, unknown>)["rpc"] as object),
+      Server: class {
+        constructor(..._args: unknown[]) {}
+        getEvents = vi.fn();
+        getAccount = mockGetAccount;
+        simulateTransaction = mockSimulateTransaction;
+        sendTransaction = vi.fn();
+        getTransaction = vi.fn();
+      },
+    },
+  };
+});
 
 // ─── parseProposal ────────────────────────────────────────────────────────────
 
@@ -52,28 +87,229 @@ describe("parseProposal", () => {
     const p = parseProposal(makeProposalScVal({ action: { RemoveAgent: "GXYZ" } }));
     expect(p.action).toEqual({ RemoveAgent: "GXYZ" });
   });
-});
 
-// ─── getActiveProposals (client-side filtering) ───────────────────────────────
-
-describe("getActiveProposals filtering logic", () => {
-  it("keeps only Pending and Approved proposals", () => {
-    const all: Proposal[] = [
-      { id: 0n, proposer: "G1", action: { UpdateFee: 100 }, state: "Pending",   createdAt: 0n, expiry: 9999n, approvalCount: 0, approvalTimestamp: null },
-      { id: 1n, proposer: "G1", action: { UpdateFee: 200 }, state: "Approved",  createdAt: 0n, expiry: 9999n, approvalCount: 2, approvalTimestamp: 500n },
-      { id: 2n, proposer: "G1", action: { UpdateFee: 300 }, state: "Executed",  createdAt: 0n, expiry: 9999n, approvalCount: 2, approvalTimestamp: 500n },
-      { id: 3n, proposer: "G1", action: { UpdateFee: 400 }, state: "Expired",   createdAt: 0n, expiry: 1000n, approvalCount: 0, approvalTimestamp: null },
-    ];
-    const active = all.filter((p) => p.state === "Pending" || p.state === "Approved");
-    expect(active).toHaveLength(2);
-    expect(active.map((p) => p.state)).toEqual(["Pending", "Approved"]);
+  it("parses UpdateCooldownPeriod action", () => {
+    const p = parseProposal(
+      makeProposalScVal({ action: { UpdateCooldownPeriod: 3600 } })
+    );
+    expect(p.action).toEqual({ UpdateCooldownPeriod: 3600n });
   });
 
-  it("returns empty array when no active proposals exist", () => {
-    const all: Proposal[] = [
-      { id: 0n, proposer: "G1", action: { UpdateFee: 100 }, state: "Executed", createdAt: 0n, expiry: 9999n, approvalCount: 2, approvalTimestamp: 500n },
+  it("parses WhitelistAsset action", () => {
+    const p = parseProposal(
+      makeProposalScVal({ action: { WhitelistAsset: "GASSET" } })
+    );
+    expect(p.action).toEqual({ WhitelistAsset: "GASSET" });
+  });
+
+  it("parses AdjustReputationThreshold action", () => {
+    const p = parseProposal(
+      makeProposalScVal({ action: { AdjustReputationThreshold: 75 } })
+    );
+    expect(p.action).toEqual({ AdjustReputationThreshold: 75 });
+  });
+});
+
+// ─── Proposal builder functions ───────────────────────────────────────────────
+
+describe("proposal builder functions", () => {
+  it("buildUpdateFeeProposal", () => {
+    expect(buildUpdateFeeProposal(300)).toEqual({ UpdateFee: 300 });
+  });
+
+  it("buildRegisterAgentProposal", () => {
+    expect(buildRegisterAgentProposal("GAGENT")).toEqual({
+      RegisterAgent: "GAGENT",
+    });
+  });
+
+  it("buildRemoveAgentProposal", () => {
+    expect(buildRemoveAgentProposal("GAGENT")).toEqual({
+      RemoveAgent: "GAGENT",
+    });
+  });
+
+  it("buildAddAdminProposal", () => {
+    expect(buildAddAdminProposal("GADMIN")).toEqual({ AddAdmin: "GADMIN" });
+  });
+
+  it("buildRemoveAdminProposal", () => {
+    expect(buildRemoveAdminProposal("GADMIN")).toEqual({
+      RemoveAdmin: "GADMIN",
+    });
+  });
+
+  it("buildUpdateQuorumProposal", () => {
+    expect(buildUpdateQuorumProposal(3)).toEqual({ UpdateQuorum: 3 });
+  });
+
+  it("buildUpdateTimelockProposal", () => {
+    expect(buildUpdateTimelockProposal(86400n)).toEqual({
+      UpdateTimelock: 86400n,
+    });
+  });
+
+  it("buildUpdateCooldownPeriodProposal", () => {
+    expect(buildUpdateCooldownPeriodProposal(3600n)).toEqual({
+      UpdateCooldownPeriod: 3600n,
+    });
+  });
+
+  it("buildWhitelistAssetProposal", () => {
+    expect(buildWhitelistAssetProposal("GASSET")).toEqual({
+      WhitelistAsset: "GASSET",
+    });
+  });
+
+  it("buildAdjustReputationThresholdProposal", () => {
+    expect(buildAdjustReputationThresholdProposal(80)).toEqual({
+      AdjustReputationThreshold: 80,
+    });
+  });
+});
+
+// ─── getActiveProposals pagination ────────────────────────────────────────────
+
+describe("getActiveProposals pagination", () => {
+  let client: SwiftRemitClient;
+
+  const makeScVal = (id: bigint, state: Proposal["state"]): xdr.ScVal => {
+    const base: Record<string, unknown> = {
+      id: Number(id),
+      proposer: "GADMIN",
+      action: { UpdateFee: 100 },
+      state: { [state]: {} },
+      created_at: Number(id),
+      expiry: Number(id) + 1000,
+      approval_count: state === "Approved" ? 2 : 0,
+      approval_timestamp: state === "Approved" ? Number(id) + 500 : null,
+      execute_after: state === "Approved" ? Number(id) + 600 : null,
+    };
+    return nativeToScVal(base);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccount.mockResolvedValue({});
+    client = new SwiftRemitClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+    });
+  });
+
+  it("returns only Pending and Approved proposals up to limit", async () => {
+    const proposals: Proposal[] = [
+      { id: 0n, proposer: "GADMIN", action: { UpdateFee: 100 }, state: "Pending", createdAt: 0n, expiry: 1000n, approvalCount: 0, approvalTimestamp: null, executeAfter: null },
+      { id: 1n, proposer: "GADMIN", action: { UpdateFee: 200 }, state: "Approved", createdAt: 1n, expiry: 1001n, approvalCount: 2, approvalTimestamp: 500n, executeAfter: 600n },
+      { id: 2n, proposer: "GADMIN", action: { UpdateFee: 300 }, state: "Executed", createdAt: 2n, expiry: 1002n, approvalCount: 2, approvalTimestamp: 500n, executeAfter: 600n },
+      { id: 3n, proposer: "GADMIN", action: { UpdateFee: 400 }, state: "Expired", createdAt: 3n, expiry: 1003n, approvalCount: 0, approvalTimestamp: null, executeAfter: null },
     ];
-    const active = all.filter((p) => p.state === "Pending" || p.state === "Approved");
-    expect(active).toHaveLength(0);
+
+    let callIndex = 0;
+    mockSimulateTransaction.mockImplementation(async () => {
+      const p = proposals[callIndex];
+      callIndex++;
+      if (!p) {
+        throw new Error("Simulation failed: ResourceNotFound");
+      }
+      return {
+        result: {
+          retval: makeScVal(p.id, p.state),
+        },
+      };
+    });
+
+    const result = await client.getActiveProposals("GSOURCE", 0n, 50n);
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.state)).toEqual(["Pending", "Approved"]);
+  });
+
+  it("respects limit", async () => {
+    const proposals: Proposal[] = [
+      { id: 0n, proposer: "GADMIN", action: { UpdateFee: 100 }, state: "Pending", createdAt: 0n, expiry: 1000n, approvalCount: 0, approvalTimestamp: null, executeAfter: null },
+      { id: 1n, proposer: "GADMIN", action: { UpdateFee: 200 }, state: "Pending", createdAt: 1n, expiry: 1001n, approvalCount: 0, approvalTimestamp: null, executeAfter: null },
+      { id: 2n, proposer: "GADMIN", action: { UpdateFee: 300 }, state: "Pending", createdAt: 2n, expiry: 1002n, approvalCount: 0, approvalTimestamp: null, executeAfter: null },
+    ];
+
+    let callIndex = 0;
+    mockSimulateTransaction.mockImplementation(async () => {
+      const p = proposals[callIndex];
+      callIndex++;
+      if (!p) {
+        throw new Error("Simulation failed: ResourceNotFound");
+      }
+      return {
+        result: {
+          retval: makeScVal(p.id, p.state),
+        },
+      };
+    });
+
+    const result = await client.getActiveProposals("GSOURCE", 0n, 2n);
+    expect(result).toHaveLength(2);
+    expect(callIndex).toBe(2);
+  });
+
+  it("returns empty array when no active proposals exist", async () => {
+    const proposals: Proposal[] = [
+      { id: 0n, proposer: "GADMIN", action: { UpdateFee: 100 }, state: "Executed", createdAt: 0n, expiry: 1000n, approvalCount: 2, approvalTimestamp: 500n, executeAfter: 600n },
+    ];
+
+    let callIndex = 0;
+    mockSimulateTransaction.mockImplementation(async () => {
+      const p = proposals[callIndex];
+      callIndex++;
+      if (!p) {
+        throw new Error("Simulation failed: ResourceNotFound");
+      }
+      return {
+        result: {
+          retval: makeScVal(p.id, p.state),
+        },
+      };
+    });
+
+    const result = await client.getActiveProposals("GSOURCE", 0n, 50n);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── getVoteStatus ────────────────────────────────────────────────────────────
+
+describe("getVoteStatus", () => {
+  let client: SwiftRemitClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccount.mockResolvedValue({});
+    client = new SwiftRemitClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+    });
+  });
+
+  it("returns true when voter has voted", async () => {
+    mockSimulateTransaction.mockResolvedValue({
+      result: {
+        retval: xdr.ScVal.scvBool(true),
+      },
+    });
+
+    const result = await client.getVoteStatus("GSOURCE", 1n, "GVOTER");
+    expect(result).toBe(true);
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when voter has not voted", async () => {
+    mockSimulateTransaction.mockResolvedValue({
+      result: {
+        retval: xdr.ScVal.scvBool(false),
+      },
+    });
+
+    const result = await client.getVoteStatus("GSOURCE", 1n, "GVOTER");
+    expect(result).toBe(false);
   });
 });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,17 @@
-export { SwiftRemitClient, MAX_BATCH_SIZE } from "./client.js";
+export {
+  SwiftRemitClient,
+  MAX_BATCH_SIZE,
+  buildUpdateFeeProposal,
+  buildRegisterAgentProposal,
+  buildRemoveAgentProposal,
+  buildAddAdminProposal,
+  buildRemoveAdminProposal,
+  buildUpdateQuorumProposal,
+  buildUpdateTimelockProposal,
+  buildUpdateCooldownPeriodProposal,
+  buildWhitelistAssetProposal,
+  buildAdjustReputationThresholdProposal,
+} from "./client.js";
 export { SwiftRemitError, ErrorCode, parseContractError } from "./errors.js";
 export type {
   SwiftRemitClientOptions,
@@ -20,6 +33,9 @@ export type {
   Role,
   GovernanceConfig,
   DailyLimitStatus,
+  Proposal,
+  ProposalAction,
+  ProposalState,
 } from "./types.js";
 export {
   parseRemittance,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -179,7 +179,10 @@ export type ProposalAction =
   | { AddAdmin: string }
   | { RemoveAdmin: string }
   | { UpdateQuorum: number }
-  | { UpdateTimelock: bigint };
+  | { UpdateTimelock: bigint }
+  | { UpdateCooldownPeriod: bigint }
+  | { WhitelistAsset: string }
+  | { AdjustReputationThreshold: number };
 
 export interface Proposal {
   id: bigint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3345,6 +3345,11 @@ impl SwiftRemitContract {
         storage::get_proposal(&env, proposal_id)
     }
 
+    /// Returns whether the given `voter` has already cast a vote on `proposal_id`.
+    pub fn get_vote_status(env: Env, proposal_id: u64, voter: Address) -> bool {
+        storage::has_governance_voted(&env, proposal_id, &voter)
+    }
+
     /// Returns the current list of admin addresses.
     pub fn get_admins(env: Env) -> soroban_sdk::Vec<Address> {
         storage::get_admin_list(&env)


### PR DESCRIPTION
Implemented all governance SDK helpers. Here's what changed:

Rust contract (src/lib.rs):

Added get_vote_status(env, proposal_id, voter) → bool public query method
TypeScript SDK:

sdk/src/types.ts — Added missing ProposalAction variants: UpdateCooldownPeriod, WhitelistAsset, AdjustReputationThreshold
sdk/src/convert.ts — Updated parseProposal to correctly parse the 3 new action types
sdk/src/client.ts — Added:
10 typed builder functions (buildUpdateFeeProposal, buildAddAdminProposal, etc.)
proposalActionToScVal encoder for the propose contract call
propose(sourceAddress, action) → Transaction
getActiveProposals(sourceAddress, offset, limit) with pagination
getVoteStatus(sourceAddress, proposalId, voterAddress) → boolean
sdk/src/index.ts — Exported new types and all builder functions
sdk/src/governance.test.ts — Wrote unit tests covering:
parseProposal for all 10 proposal action types
All 10 builder functions
getActiveProposals pagination (limit, offset, empty results)
getVoteStatus true/false responses

Closes #913