### PR TITLE
Branch2

### DIFF
--- a/sdk/.changeset/README.md
+++ b/sdk/.changeset/README.md
@@ -1,0 +1,32 @@
+# Changesets
+
+This directory contains [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation.
+
+## Workflow
+
+1. **Create a changeset** when starting work on a change that should be noted in the changelog:
+   ```bash
+   npm run changeset
+   ```
+   Select the semver bump type (`major`, `minor`, or `patch`) and describe the change.
+
+2. **Version packages** before a release:
+   ```bash
+   npm run version-packages
+   ```
+   This reads pending changesets, bumps the version in `package.json`, updates `CHANGELOG.md`, and removes consumed changeset files.
+
+3. **Publish** after merging to `main`:
+   ```bash
+   npm run release
+   ```
+
+## Rules
+
+- Every PR that changes the SDK API or behavior must include a changeset.
+- Breaking changes must be marked `major` and include a migration note in the changeset description.
+- Patch bumps are for bug fixes; minor bumps are for new features; major bumps are for breaking changes.
+
+## Migration Guides
+
+For breaking changes, add a migration guide in `MIGRATION_GUIDE.md` (or a version-specific sub-guide) and link it from the changelog entry.

--- a/sdk/.changeset/config.json
+++ b/sdk/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "changesets": [
+    "major",
+    "minor",
+    "patch"
+  ],
+  "ignore": []
+}

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-28
+
+### Added
+
+- Initial public release of `@swiftremit/sdk`
+- `SwiftRemitClient` with typed read/write wrappers for all contract methods
+- Governance helpers: `getProposal`, `getActiveProposals`, `voteOnProposal`, `executeProposal`
+- New high-level governance utilities:
+  - Typed proposal builder functions (`buildUpdateFeeProposal`, `buildAddAdminProposal`, etc.)
+  - `getVoteStatus(proposalId, voterAddress)` — query individual vote state
+  - `propose(action)` — submit a typed proposal transaction
+- `parseProposal` and other ScVal → native parsers
+- Memory-backed `proposalActionToScVal` encoder for compute-cost governance transactions
+- Utilities: `toStroops`, `fromStroops`, `USDC_MULTIPLIER`
+- Event subscription via Horizon SSE (`subscribeToRemittanceEvents`)
+- React Native wrapper (`@swiftremit/react-native-sdk`) with signer abstraction and hooks
+- Full TypeScript declaration files (`.d.ts`)
+
+### Changed
+
+- `ProposalAction` type expanded to include all contract variants (`UpdateCooldownPeriod`, `WhitelistAsset`, `AdjustReputationThreshold`)
+
+### Fixed
+
+- Correct bigint/number conversions for parser-returned contract values
+
+### Security
+
+- HTTP transport allowed only for localhost/127.0.0.1; warns on insecure RPC URLs
+
+[1.0.0]: https://github.com/GFOX/SwiftRemit/releases/tag/sdk-v1.0.0

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -321,6 +321,10 @@ console.log("Batch submitted:", result.hash);
 
 MIT
 
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for version history and migration guides.
+
 ## React Native
 
 A React Native wrapper is available in `sdk/react-native/`. It wraps the core TypeScript SDK with:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -18,7 +18,10 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "changeset publish"
   },
   "keywords": [
     "stellar",
@@ -32,6 +35,7 @@
     "@stellar/stellar-sdk": ">=13.0.0"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.10",
     "@stellar/stellar-sdk": "^13.0.0",
     "@types/node": "^25.9.1",
     "tsup": "^8.0.0",


### PR DESCRIPTION
Closes #914 

The implementation is done. Changes made:

sdk/CHANGELOG.md — Added Keep a Changelog formatted changelog with the 1.0.0 initial release entry covering all current SDK features, governance helpers, and known changes.
sdk/.changeset/config.json — Configured changesets for the single @swiftremit/sdk package (access: public, baseBranch: main).
sdk/.changeset/README.md — Documented the changeset → version-packages → release workflow and rules for breaking changes.
sdk/package.json — Added changeset, version-packages, and release scripts plus @changesets/cli as a devDependency.
sdk/README.md — Added a Changelog section pointing to CHANGELOG.md.
Since this is a v1.0.0 initial release, there is no prior v0 to migrate from; the .changeset/README.md establishes the process for future breaking-change migration guides.