### PR TITLE
feat: PDF receipts, Stellar fee estimation, and i18n notifications

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -41,6 +41,7 @@
     "socket.io": "^4.8.3",
     "swagger-ui-express": "^5.0.0",
     "uuid": "^9.0.0",
+    "pdfkit": "^0.15.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -52,6 +53,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.10.0",
+    "@types/pdfkit": "^0.13.9",
     "@types/pg": "^8.10.9",
     "@types/supertest": "^7.2.0",
     "@types/swagger-ui-express": "^4.1.6",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -17,6 +17,7 @@ import { createAdminRouter } from './routes/admin';
 import { createAnalyticsRouter } from './routes/analytics';
 import { createAgentsRouter } from './routes/agents';
 import { createAuthRouter } from './routes/auth';
+import { createAccountsRouter } from './routes/accounts';
 import { ErrorResponse } from './types';
 import { AnchorStore } from './db/anchorStore';
 import { Server as SocketIOServer } from 'socket.io';
@@ -185,6 +186,9 @@ export function createApp(options: AppOptions = {}): Application {
 
   // Agents — registration and management (Issue #880)
   app.use('/api/agents', createAgentsRouter());
+
+  // Accounts — Stellar fee estimation and XLM balance (Issue #949)
+  app.use('/api/accounts', createAccountsRouter());
 
   // WebSocket health endpoint (development only — guarded inside the router)
   if (options.io) {

--- a/api/src/routes/accounts.ts
+++ b/api/src/routes/accounts.ts
@@ -1,0 +1,157 @@
+/**
+ * GET /api/accounts/:address/stellar-fees
+ *
+ * Returns the current Stellar base fee, the account's native XLM balance,
+ * and the estimated XLM required for the next N operations (Issue #949).
+ *
+ * Query parameters:
+ *   operations  {number}  - Number of operations to estimate fees for (default: 1, max: 100)
+ */
+
+import { Router, Request, Response } from 'express';
+import { ErrorResponse } from '../types';
+
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{54}$/;
+const XLM_STROOPS_PER_XLM = 10_000_000;
+const DEFAULT_BASE_FEE_STROOPS = 100;
+const LOW_XLM_THRESHOLD = 2;
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function sendError(res: Response, status: number, message: string, code: string): Response<ErrorResponse> {
+  return res.status(status).json({ success: false, error: { message, code }, timestamp: timestamp() });
+}
+
+function getHorizonUrl(): string {
+  if (process.env.HORIZON_URL) return process.env.HORIZON_URL;
+  const network = (process.env.STELLAR_NETWORK ?? 'testnet').toLowerCase();
+  return network === 'mainnet' || network === 'public'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+}
+
+function getTopUpLink(): string {
+  const network = (process.env.STELLAR_NETWORK ?? 'testnet').toLowerCase();
+  if (network === 'mainnet' || network === 'public') {
+    return 'https://www.stellarterm.com/exchange/XLM-native/USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+  }
+  return 'https://laboratory.stellar.org/#account-creator?network=testnet';
+}
+
+export function createAccountsRouter(): Router {
+  const router = Router();
+
+  /**
+   * @openapi
+   * /api/accounts/{address}/stellar-fees:
+   *   get:
+   *     summary: Get Stellar network fee info and XLM balance for an account
+   *     tags:
+   *       - Accounts
+   *     parameters:
+   *       - name: address
+   *         in: path
+   *         required: true
+   *         description: Stellar account address (G...)
+   *         schema:
+   *           type: string
+   *       - name: operations
+   *         in: query
+   *         required: false
+   *         description: Number of operations to estimate fees for (default 1, max 100)
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 100
+   *           default: 1
+   *     responses:
+   *       200:
+   *         description: Stellar fee and balance information
+   *       400:
+   *         description: Invalid address or parameters
+   *       404:
+   *         description: Account not found on the network
+   */
+  router.get('/:address/stellar-fees', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    const operationsStr = (req.query.operations as string | undefined) ?? '1';
+
+    if (!STELLAR_ADDRESS_RE.test(address)) {
+      return sendError(res, 400, 'Invalid Stellar address format', 'INVALID_ADDRESS');
+    }
+
+    const operationCount = parseInt(operationsStr, 10);
+    if (isNaN(operationCount) || operationCount < 1 || operationCount > 100) {
+      return sendError(res, 400, '`operations` must be between 1 and 100', 'INVALID_OPERATIONS');
+    }
+
+    const horizonUrl = getHorizonUrl();
+
+    // Fetch fee stats and account in parallel
+    const [feeStatsRes, accountRes] = await Promise.allSettled([
+      fetch(`${horizonUrl}/fee_stats`),
+      fetch(`${horizonUrl}/accounts/${address}`),
+    ]);
+
+    // Parse base fee
+    let baseFeeStroops = DEFAULT_BASE_FEE_STROOPS;
+    if (feeStatsRes.status === 'fulfilled' && feeStatsRes.value.ok) {
+      try {
+        const feeData = await feeStatsRes.value.json() as { fee_charged?: { mode?: string } };
+        const mode = feeData?.fee_charged?.mode;
+        if (mode) baseFeeStroops = parseInt(mode, 10) || DEFAULT_BASE_FEE_STROOPS;
+      } catch {
+        // fall back to default
+      }
+    }
+
+    // Parse XLM balance
+    let xlmBalance: number | null = null;
+    let accountFound = true;
+
+    if (accountRes.status === 'fulfilled') {
+      if (accountRes.value.status === 404) {
+        accountFound = false;
+      } else if (accountRes.value.ok) {
+        try {
+          const accountData = await accountRes.value.json() as {
+            balances?: Array<{ asset_type: string; balance: string }>;
+          };
+          const nativeBalance = accountData?.balances?.find(b => b.asset_type === 'native');
+          if (nativeBalance) xlmBalance = parseFloat(nativeBalance.balance);
+        } catch {
+          // account data unavailable
+        }
+      }
+    }
+
+    if (!accountFound) {
+      return sendError(res, 404, 'Account not found on the Stellar network', 'ACCOUNT_NOT_FOUND');
+    }
+
+    const estimatedFeeStroops = baseFeeStroops * operationCount;
+    const estimatedFeeXlm = estimatedFeeStroops / XLM_STROOPS_PER_XLM;
+    const lowBalance = xlmBalance !== null && xlmBalance < LOW_XLM_THRESHOLD;
+
+    return res.json({
+      success: true,
+      data: {
+        address,
+        base_fee_stroops: baseFeeStroops,
+        base_fee_xlm: baseFeeStroops / XLM_STROOPS_PER_XLM,
+        xlm_balance: xlmBalance,
+        estimated_fee_stroops: estimatedFeeStroops,
+        estimated_fee_xlm: estimatedFeeXlm,
+        operation_count: operationCount,
+        low_balance: lowBalance,
+        ...(lowBalance && { top_up_link: getTopUpLink() }),
+        horizon_url: horizonUrl,
+      },
+      timestamp: timestamp(),
+    });
+  });
+
+  return router;
+}

--- a/api/src/routes/remittances.ts
+++ b/api/src/routes/remittances.ts
@@ -19,6 +19,7 @@ import { Router, Request, Response } from 'express';
 import { ErrorResponse } from '../types';
 import { RemittanceStore } from '../db/remittanceStore';
 import { createRemittanceSchema, validateRequest } from '../schemas/requestValidation';
+import { generateReceiptPdf } from '../services/receiptGenerator';
 
 export type RemittanceStatus = 'Pending' | 'Processing' | 'Completed' | 'Cancelled' | 'Failed' | 'Disputed';
 
@@ -225,6 +226,85 @@ export function createRemittancesRouter(options: RemittancesRouterOptions = {}):
       }
       throw error;
     }
+  });
+
+  /**
+   * @openapi
+   * /api/remittances/{id}/receipt:
+   *   get:
+   *     summary: Download a PDF receipt for a completed remittance
+   *     description: >
+   *       Generates and returns a PDF receipt for the specified remittance.
+   *       Requires authentication via X-API-Key (admin) or X-Sender-Address
+   *       matching the remittance sender.
+   *     tags:
+   *       - Remittances
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         description: Remittance ID
+   *         schema:
+   *           type: string
+   *     security:
+   *       - ApiKeyAuth: []
+   *       - SenderAddressAuth: []
+   *     responses:
+   *       200:
+   *         description: PDF receipt file
+   *         content:
+   *           application/pdf:
+   *             schema:
+   *               type: string
+   *               format: binary
+   *       401:
+   *         description: Missing or invalid authentication
+   *       403:
+   *         description: Sender address does not match remittance owner
+   *       404:
+   *         description: Remittance not found
+   *       503:
+   *         description: Remittance store not configured
+   */
+  router.get('/:id/receipt', async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    if (!remittanceStore) {
+      return sendError(res, 503, 'Remittance store not configured', 'SERVICE_UNAVAILABLE');
+    }
+
+    // Authentication: admin API key or sender address
+    const adminKey = process.env.ADMIN_API_KEY;
+    const providedApiKey = req.headers['x-api-key'] as string | undefined;
+    const senderAddress = req.headers['x-sender-address'] as string | undefined;
+    const isAdmin = adminKey && providedApiKey === adminKey;
+
+    if (!isAdmin && !senderAddress) {
+      return sendError(
+        res,
+        401,
+        'Authentication required. Provide X-API-Key (admin) or X-Sender-Address header.',
+        'UNAUTHORIZED',
+      );
+    }
+
+    const remittance = await remittanceStore.getById(id);
+    if (!remittance) {
+      return sendError(res, 404, `Remittance ${id} not found`, 'NOT_FOUND');
+    }
+
+    // Non-admin callers can only download their own receipts
+    if (!isAdmin && senderAddress !== remittance.sender_id) {
+      return sendError(res, 403, 'Sender address does not match remittance owner', 'FORBIDDEN');
+    }
+
+    const pdfBuffer = await generateReceiptPdf(remittance);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="receipt-${id}.pdf"`,
+      'Content-Length': String(pdfBuffer.length),
+    });
+    return res.send(pdfBuffer);
   });
 
   return router;

--- a/api/src/services/receiptGenerator.ts
+++ b/api/src/services/receiptGenerator.ts
@@ -1,0 +1,117 @@
+/**
+ * Generates a PDF receipt for a completed remittance transaction (Issue #948).
+ * Uses PDFKit for document generation.
+ */
+
+import PDFDocument from 'pdfkit';
+import { Remittance } from '../db/remittanceStore';
+
+const BRAND_COLOR = '#1a56db';
+const LABEL_COLOR = '#6b7280';
+const EXPLORER_BASE_URL =
+  process.env.STELLAR_EXPLORER_URL ?? 'https://stellarchain.io/transactions';
+
+function formatAmount(stroops: number): string {
+  return (stroops / 10_000_000).toFixed(7);
+}
+
+/**
+ * Generates a PDF receipt for the given remittance and resolves to a Buffer.
+ */
+export function generateReceiptPdf(remittance: Remittance): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+  const chunks: Buffer[] = [];
+  const doc = new PDFDocument({ margin: 50, size: 'A4' });
+
+  doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+  doc.on('end', () => resolve(Buffer.concat(chunks)));
+  doc.on('error', reject);
+
+  // ── Header ──────────────────────────────────────────────────────────────────
+  doc
+    .fontSize(22)
+    .fillColor(BRAND_COLOR)
+    .text('SwiftRemit', { align: 'left' })
+    .fontSize(10)
+    .fillColor(LABEL_COLOR)
+    .text('Blockchain-Powered Remittances', { align: 'left' })
+    .moveDown(0.5);
+
+  doc
+    .moveTo(50, doc.y)
+    .lineTo(545, doc.y)
+    .strokeColor(BRAND_COLOR)
+    .lineWidth(1.5)
+    .stroke()
+    .moveDown(0.8);
+
+  doc
+    .fontSize(16)
+    .fillColor('#111827')
+    .text('Transfer Receipt', { align: 'center' })
+    .moveDown(1);
+
+  // ── Transaction details table ────────────────────────────────────────────────
+  const rows: [string, string][] = [
+    ['Transaction ID', remittance.id],
+    ['Status', remittance.status],
+    ['Sender', remittance.sender_id],
+    ['Agent / Recipient', remittance.agent_id],
+    ['Amount (USDC)', formatAmount(remittance.amount)],
+    ['Fee (USDC)', formatAmount(remittance.fee)],
+    ['Net Amount (USDC)', formatAmount(remittance.amount - remittance.fee)],
+    ['Created', new Date(remittance.created_at).toUTCString()],
+    ['Last Updated', new Date(remittance.updated_at).toUTCString()],
+  ];
+
+  const labelX = 50;
+  const valueX = 220;
+  const rowHeight = 22;
+
+  rows.forEach(([label, value], idx) => {
+    const y = doc.y;
+    if (idx % 2 === 0) {
+      doc.save().fillColor('#f9fafb').rect(labelX, y - 3, 495, rowHeight).fill().restore();
+    }
+    doc.fontSize(10).fillColor(LABEL_COLOR).text(label, labelX, y, { width: 160 });
+    doc.fontSize(10).fillColor('#111827').text(value, valueX, y, { width: 325 });
+    doc.moveDown(0.6);
+  });
+
+  doc.moveDown(1);
+
+  // ── Explorer link ────────────────────────────────────────────────────────────
+  doc
+    .fontSize(9)
+    .fillColor(LABEL_COLOR)
+    .text('Verify on-chain:', labelX)
+    .fillColor(BRAND_COLOR)
+    .text(`${EXPLORER_BASE_URL}/${remittance.id}`, labelX, doc.y - 12, {
+      link: `${EXPLORER_BASE_URL}/${remittance.id}`,
+      underline: true,
+      width: 495,
+    });
+
+  doc.moveDown(2);
+
+  // ── Footer ───────────────────────────────────────────────────────────────────
+  doc
+    .moveTo(50, doc.y)
+    .lineTo(545, doc.y)
+    .strokeColor('#e5e7eb')
+    .lineWidth(1)
+    .stroke()
+    .moveDown(0.5);
+
+  doc
+    .fontSize(8)
+    .fillColor(LABEL_COLOR)
+    .text(
+      `This receipt was generated on ${new Date().toUTCString()}. ` +
+        'SwiftRemit is not responsible for exchange rate fluctuations after settlement.',
+      { align: 'center', width: 495 },
+    );
+
+  doc.end();
+  }); // end Promise
+}

--- a/backend/migrations/add_preferred_language_to_notification_preferences.down.sql
+++ b/backend/migrations/add_preferred_language_to_notification_preferences.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_preferences
+  DROP COLUMN IF EXISTS preferred_language;

--- a/backend/migrations/add_preferred_language_to_notification_preferences.sql
+++ b/backend/migrations/add_preferred_language_to_notification_preferences.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_preferences
+  ADD COLUMN IF NOT EXISTS preferred_language VARCHAR(8) NOT NULL DEFAULT 'en';

--- a/backend/scripts/check-notification-templates.ts
+++ b/backend/scripts/check-notification-templates.ts
@@ -1,0 +1,30 @@
+/**
+ * CI check: every supported locale must define every template key.
+ * Exit 1 if any key is missing.
+ */
+
+import { SUPPORTED_LOCALES, TEMPLATE_KEYS } from '../src/notification-templates';
+import en from '../src/notification-templates/en';
+import es from '../src/notification-templates/es';
+import fr from '../src/notification-templates/fr';
+import pt from '../src/notification-templates/pt';
+import { LocaleTemplates, SupportedLocale } from '../src/notification-templates/types';
+
+const localeMap: Record<SupportedLocale, LocaleTemplates> = { en, es, fr, pt };
+
+let failed = false;
+
+for (const locale of SUPPORTED_LOCALES) {
+  for (const key of TEMPLATE_KEYS) {
+    if (!localeMap[locale][key]) {
+      console.error(`[check-notification-templates] MISSING: locale="${locale}" key="${key}"`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) {
+  process.exit(1);
+} else {
+  console.log('[check-notification-templates] All locales have all template keys.');
+}

--- a/backend/src/notification-service.ts
+++ b/backend/src/notification-service.ts
@@ -1,15 +1,18 @@
 /**
- * Notification Service — Issue #852
+ * Notification Service — Issue #852, #950
  *
  * Sends email (SendGrid) and SMS (Twilio) notifications when remittance
- * status changes to completed or failed. Respects per-user opt-out preferences.
+ * status changes to completed or failed. Respects per-user opt-out preferences
+ * and preferred_language for localised message templates.
  */
 
 import axios from 'axios';
 import { Pool } from 'pg';
+import { buildLocalizedMessage, TemplateKey } from './notification-templates';
 
 export type NotificationChannel = 'email' | 'sms';
 export type RemittanceNotificationStatus = 'completed' | 'failed' | 'created';
+export type KycNotificationEvent = 'kyc_approved' | 'kyc_expired';
 
 export interface NotificationPreferences {
   user_id: string;
@@ -17,6 +20,7 @@ export interface NotificationPreferences {
   phone?: string;
   email_opt_in: boolean;
   sms_opt_in: boolean;
+  preferred_language?: string;
 }
 
 export interface RemittanceNotificationPayload {
@@ -25,6 +29,11 @@ export interface RemittanceNotificationPayload {
   amount: number;
   currency: string;
   senderUserId: string;
+}
+
+export interface KycNotificationPayload {
+  event: KycNotificationEvent;
+  userId: string;
 }
 
 // ─── Provider abstractions ────────────────────────────────────────────────────
@@ -59,26 +68,41 @@ async function sendSms(to: string, body: string): Promise<void> {
   );
 }
 
-// ─── Message builders ─────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function buildMessage(status: RemittanceNotificationStatus, id: string, amount: number, currency: string): { subject: string; text: string } {
+function remittanceStatusToTemplateKey(status: RemittanceNotificationStatus): TemplateKey {
   switch (status) {
-    case 'completed':
-      return {
-        subject: 'Your remittance has been completed',
-        text: `Your remittance ${id} of ${amount} ${currency} has been successfully completed.`,
-      };
-    case 'failed':
-      return {
-        subject: 'Your remittance has failed',
-        text: `Your remittance ${id} of ${amount} ${currency} could not be completed. Funds will be refunded.`,
-      };
-    case 'created':
-      return {
-        subject: 'Your remittance has been created',
-        text: `Your remittance ${id} of ${amount} ${currency} has been created and is pending processing.`,
-      };
+    case 'completed': return 'remittance_completed';
+    case 'failed':    return 'remittance_failed';
+    case 'created':   return 'remittance_created';
   }
+}
+
+async function dispatch(
+  prefs: NotificationPreferences,
+  subject: string,
+  text: string,
+  userId: string,
+): Promise<void> {
+  const tasks: Promise<void>[] = [];
+
+  if (prefs.email_opt_in && prefs.email) {
+    tasks.push(
+      sendEmail(prefs.email, subject, text).catch(err =>
+        console.error(`[notification] email failed for ${userId}:`, err),
+      ),
+    );
+  }
+
+  if (prefs.sms_opt_in && prefs.phone) {
+    tasks.push(
+      sendSms(prefs.phone, text).catch(err =>
+        console.error(`[notification] sms failed for ${userId}:`, err),
+      ),
+    );
+  }
+
+  await Promise.all(tasks);
 }
 
 // ─── Main service ─────────────────────────────────────────────────────────────
@@ -92,7 +116,7 @@ export class NotificationService {
    */
   async getPreferences(userId: string): Promise<NotificationPreferences | null> {
     const result = await this.pool.query<NotificationPreferences>(
-      `SELECT user_id, email, phone, email_opt_in, sms_opt_in
+      `SELECT user_id, email, phone, email_opt_in, sms_opt_in, preferred_language
        FROM notification_preferences WHERE user_id = $1`,
       [userId],
     );
@@ -104,48 +128,56 @@ export class NotificationService {
    */
   async setPreferences(prefs: NotificationPreferences): Promise<void> {
     await this.pool.query(
-      `INSERT INTO notification_preferences (user_id, email, phone, email_opt_in, sms_opt_in)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO notification_preferences (user_id, email, phone, email_opt_in, sms_opt_in, preferred_language)
+       VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT (user_id) DO UPDATE SET
          email = EXCLUDED.email,
          phone = EXCLUDED.phone,
          email_opt_in = EXCLUDED.email_opt_in,
          sms_opt_in = EXCLUDED.sms_opt_in,
+         preferred_language = EXCLUDED.preferred_language,
          updated_at = NOW()`,
-      [prefs.user_id, prefs.email ?? null, prefs.phone ?? null, prefs.email_opt_in, prefs.sms_opt_in],
+      [
+        prefs.user_id,
+        prefs.email ?? null,
+        prefs.phone ?? null,
+        prefs.email_opt_in,
+        prefs.sms_opt_in,
+        prefs.preferred_language ?? 'en',
+      ],
     );
   }
 
   /**
    * Send notifications for a remittance status change.
-   * Only notifies for completed/failed/created statuses; silently skips others.
-   * Respects opt-out preferences.
+   * Messages are localised to the user's preferred_language; falls back to English.
    */
   async notifyRemittanceStatus(payload: RemittanceNotificationPayload): Promise<void> {
     const { remittanceId, status, amount, currency, senderUserId } = payload;
     const prefs = await this.getPreferences(senderUserId);
-    if (!prefs) return; // no contact info registered
+    if (!prefs) return;
 
-    const { subject, text } = buildMessage(status, remittanceId, amount, currency);
+    const key = remittanceStatusToTemplateKey(status);
+    const { subject, text } = buildLocalizedMessage(prefs.preferred_language, key, {
+      remittanceId,
+      amount,
+      currency,
+    });
 
-    const tasks: Promise<void>[] = [];
+    await dispatch(prefs, subject, text, senderUserId);
+  }
 
-    if (prefs.email_opt_in && prefs.email) {
-      tasks.push(
-        sendEmail(prefs.email, subject, text).catch(err =>
-          console.error(`[notification] email failed for ${senderUserId}:`, err),
-        ),
-      );
-    }
+  /**
+   * Send a KYC event notification (approved / expired).
+   * Messages are localised to the user's preferred_language; falls back to English.
+   */
+  async notifyKycEvent(payload: KycNotificationPayload): Promise<void> {
+    const { event, userId } = payload;
+    const prefs = await this.getPreferences(userId);
+    if (!prefs) return;
 
-    if (prefs.sms_opt_in && prefs.phone) {
-      tasks.push(
-        sendSms(prefs.phone, text).catch(err =>
-          console.error(`[notification] sms failed for ${senderUserId}:`, err),
-        ),
-      );
-    }
+    const { subject, text } = buildLocalizedMessage(prefs.preferred_language, event, {});
 
-    await Promise.all(tasks);
+    await dispatch(prefs, subject, text, userId);
   }
 }

--- a/backend/src/notification-templates/en.ts
+++ b/backend/src/notification-templates/en.ts
@@ -1,0 +1,30 @@
+import { LocaleTemplates } from './types';
+
+const en: LocaleTemplates = {
+  remittance_created: {
+    subject: 'Your remittance has been created',
+    text: ({ remittanceId, amount, currency }) =>
+      `Your remittance ${remittanceId} of ${amount} ${currency} has been created and is pending processing.`,
+  },
+  remittance_completed: {
+    subject: 'Your remittance has been completed',
+    text: ({ remittanceId, amount, currency }) =>
+      `Your remittance ${remittanceId} of ${amount} ${currency} has been successfully completed.`,
+  },
+  remittance_failed: {
+    subject: 'Your remittance has failed',
+    text: ({ remittanceId, amount, currency }) =>
+      `Your remittance ${remittanceId} of ${amount} ${currency} could not be completed. Funds will be refunded.`,
+  },
+  kyc_approved: {
+    subject: 'Your identity verification has been approved',
+    text: () => 'Your KYC verification has been approved. You can now send and receive remittances.',
+  },
+  kyc_expired: {
+    subject: 'Your identity verification has expired',
+    text: () =>
+      'Your KYC verification has expired. Please re-verify your identity to continue using SwiftRemit.',
+  },
+};
+
+export default en;

--- a/backend/src/notification-templates/es.ts
+++ b/backend/src/notification-templates/es.ts
@@ -1,0 +1,31 @@
+import { LocaleTemplates } from './types';
+
+const es: LocaleTemplates = {
+  remittance_created: {
+    subject: 'Tu remesa ha sido creada',
+    text: ({ remittanceId, amount, currency }) =>
+      `Tu remesa ${remittanceId} de ${amount} ${currency} ha sido creada y está pendiente de procesamiento.`,
+  },
+  remittance_completed: {
+    subject: 'Tu remesa ha sido completada',
+    text: ({ remittanceId, amount, currency }) =>
+      `Tu remesa ${remittanceId} de ${amount} ${currency} se ha completado exitosamente.`,
+  },
+  remittance_failed: {
+    subject: 'Tu remesa ha fallado',
+    text: ({ remittanceId, amount, currency }) =>
+      `Tu remesa ${remittanceId} de ${amount} ${currency} no pudo completarse. Los fondos serán reembolsados.`,
+  },
+  kyc_approved: {
+    subject: 'Tu verificación de identidad ha sido aprobada',
+    text: () =>
+      'Tu verificación KYC ha sido aprobada. Ya puedes enviar y recibir remesas.',
+  },
+  kyc_expired: {
+    subject: 'Tu verificación de identidad ha expirado',
+    text: () =>
+      'Tu verificación KYC ha expirado. Por favor, verifica tu identidad nuevamente para continuar usando SwiftRemit.',
+  },
+};
+
+export default es;

--- a/backend/src/notification-templates/fr.ts
+++ b/backend/src/notification-templates/fr.ts
@@ -1,0 +1,31 @@
+import { LocaleTemplates } from './types';
+
+const fr: LocaleTemplates = {
+  remittance_created: {
+    subject: 'Votre virement a été créé',
+    text: ({ remittanceId, amount, currency }) =>
+      `Votre virement ${remittanceId} de ${amount} ${currency} a été créé et est en attente de traitement.`,
+  },
+  remittance_completed: {
+    subject: 'Votre virement a été effectué',
+    text: ({ remittanceId, amount, currency }) =>
+      `Votre virement ${remittanceId} de ${amount} ${currency} a été effectué avec succès.`,
+  },
+  remittance_failed: {
+    subject: 'Votre virement a échoué',
+    text: ({ remittanceId, amount, currency }) =>
+      `Votre virement ${remittanceId} de ${amount} ${currency} n'a pas pu être effectué. Les fonds seront remboursés.`,
+  },
+  kyc_approved: {
+    subject: 'Votre vérification d\'identité a été approuvée',
+    text: () =>
+      'Votre vérification KYC a été approuvée. Vous pouvez maintenant envoyer et recevoir des virements.',
+  },
+  kyc_expired: {
+    subject: 'Votre vérification d\'identité a expiré',
+    text: () =>
+      'Votre vérification KYC a expiré. Veuillez vérifier votre identité à nouveau pour continuer à utiliser SwiftRemit.',
+  },
+};
+
+export default fr;

--- a/backend/src/notification-templates/index.ts
+++ b/backend/src/notification-templates/index.ts
@@ -1,0 +1,42 @@
+import en from './en';
+import es from './es';
+import fr from './fr';
+import pt from './pt';
+import { LocaleTemplates, SupportedLocale, TemplateKey, TemplateParams } from './types';
+
+export { SupportedLocale, TemplateKey, TemplateParams };
+
+const TEMPLATES: Record<SupportedLocale, LocaleTemplates> = { en, es, fr, pt };
+
+export const SUPPORTED_LOCALES: SupportedLocale[] = ['en', 'es', 'fr', 'pt'];
+export const TEMPLATE_KEYS: TemplateKey[] = [
+  'remittance_created',
+  'remittance_completed',
+  'remittance_failed',
+  'kyc_approved',
+  'kyc_expired',
+];
+
+/**
+ * Returns the message template for the given locale and key.
+ * Falls back to English if the locale or key is missing.
+ */
+export function getTemplate(
+  locale: string | undefined | null,
+  key: TemplateKey,
+): LocaleTemplates[TemplateKey] {
+  const resolved = (locale && TEMPLATES[locale as SupportedLocale]) ? locale as SupportedLocale : 'en';
+  return TEMPLATES[resolved][key] ?? TEMPLATES['en'][key];
+}
+
+/**
+ * Build a localised notification message.
+ */
+export function buildLocalizedMessage(
+  locale: string | undefined | null,
+  key: TemplateKey,
+  params: TemplateParams,
+): { subject: string; text: string } {
+  const template = getTemplate(locale, key);
+  return { subject: template.subject, text: template.text(params) };
+}

--- a/backend/src/notification-templates/pt.ts
+++ b/backend/src/notification-templates/pt.ts
@@ -1,0 +1,31 @@
+import { LocaleTemplates } from './types';
+
+const pt: LocaleTemplates = {
+  remittance_created: {
+    subject: 'A sua remessa foi criada',
+    text: ({ remittanceId, amount, currency }) =>
+      `A sua remessa ${remittanceId} de ${amount} ${currency} foi criada e está pendente de processamento.`,
+  },
+  remittance_completed: {
+    subject: 'A sua remessa foi concluída',
+    text: ({ remittanceId, amount, currency }) =>
+      `A sua remessa ${remittanceId} de ${amount} ${currency} foi concluída com sucesso.`,
+  },
+  remittance_failed: {
+    subject: 'A sua remessa falhou',
+    text: ({ remittanceId, amount, currency }) =>
+      `A sua remessa ${remittanceId} de ${amount} ${currency} não pôde ser concluída. Os fundos serão reembolsados.`,
+  },
+  kyc_approved: {
+    subject: 'A sua verificação de identidade foi aprovada',
+    text: () =>
+      'A sua verificação KYC foi aprovada. Já pode enviar e receber remessas.',
+  },
+  kyc_expired: {
+    subject: 'A sua verificação de identidade expirou',
+    text: () =>
+      'A sua verificação KYC expirou. Por favor, verifique novamente a sua identidade para continuar a usar o SwiftRemit.',
+  },
+};
+
+export default pt;

--- a/backend/src/notification-templates/types.ts
+++ b/backend/src/notification-templates/types.ts
@@ -1,0 +1,20 @@
+export type SupportedLocale = 'en' | 'es' | 'fr' | 'pt';
+export type TemplateKey =
+  | 'remittance_created'
+  | 'remittance_completed'
+  | 'remittance_failed'
+  | 'kyc_approved'
+  | 'kyc_expired';
+
+export interface TemplateParams {
+  remittanceId?: string;
+  amount?: number;
+  currency?: string;
+}
+
+export interface MessageTemplate {
+  subject: string;
+  text: (params: TemplateParams) => string;
+}
+
+export type LocaleTemplates = Record<TemplateKey, MessageTemplate>;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -43,3 +43,39 @@ setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
 if (!isFreighterAvailable()) {
   showFreighterBanner()
 }
+
+// ─── Low-XLM balance warning (Issue #949) ────────────────────────────────────
+
+const LOW_XLM_THRESHOLD = 2
+
+function showLowXlmBanner(xlmBalance: number, topUpLink: string): void {
+  if (document.getElementById('low-xlm-banner')) return
+  const banner = document.createElement('div')
+  banner.id = 'low-xlm-banner'
+  banner.setAttribute('role', 'alert')
+  banner.style.cssText =
+    'position:fixed;top:0;left:0;right:0;padding:12px;background:#ef4444;color:#fff;text-align:center;z-index:10000;font-family:sans-serif;'
+  banner.innerHTML =
+    `Your XLM balance (${xlmBalance.toFixed(4)} XLM) is below ${LOW_XLM_THRESHOLD} XLM. ` +
+    `Transactions may fail. ` +
+    `<a href="${topUpLink}" target="_blank" rel="noopener noreferrer" style="color:#fff;font-weight:bold;text-decoration:underline;">Top up XLM</a>`
+  document.body.prepend(banner)
+}
+
+export async function checkXlmBalance(stellarAddress: string): Promise<void> {
+  const apiBase = (import.meta as { env?: Record<string, string> }).env?.VITE_API_BASE_URL ?? '/api'
+  try {
+    const res = await fetch(`${apiBase}/accounts/${encodeURIComponent(stellarAddress)}/stellar-fees`)
+    if (!res.ok) return
+    const json = await res.json() as {
+      success: boolean
+      data: { low_balance: boolean; xlm_balance: number; top_up_link?: string }
+    }
+    if (json.success && json.data.low_balance) {
+      const link = json.data.top_up_link ?? 'https://laboratory.stellar.org/#account-creator?network=testnet'
+      showLowXlmBanner(json.data.xlm_balance, link)
+    }
+  } catch {
+    // Non-critical — ignore network failures
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -76,6 +76,26 @@ export { withRetry, withRetryPolicy, isTransientError } from "./retry.js";
 /** USDC multiplier: 1 USDC = 10_000_000 stroops. */
 export const USDC_MULTIPLIER = 10_000_000n;
 
+/** Stroops per XLM. */
+export const XLM_STROOPS = 10_000_000;
+
+/** Default Stellar base fee per operation in stroops. */
+export const STELLAR_BASE_FEE_STROOPS = 100;
+
+/**
+ * Estimate the XLM network fee for a given number of Stellar operations.
+ *
+ * @param operationCount - Number of operations in the transaction (default: 1)
+ * @param baseFeeStroops - Per-operation base fee in stroops (default: 100).
+ *   Pass the value from `GET /api/accounts/:address/stellar-fees` for
+ *   network-accurate estimates under congestion.
+ * @returns Estimated fee in XLM
+ */
+export function estimateStellarFee(operationCount = 1, baseFeeStroops = STELLAR_BASE_FEE_STROOPS): number {
+  if (operationCount < 1) throw new RangeError("operationCount must be at least 1");
+  return (baseFeeStroops * operationCount) / XLM_STROOPS;
+}
+
 /** Convert a human-readable USDC amount to stroops. */
 export function toStroops(usdc: number): bigint {
   return BigInt(Math.round(usdc * Number(USDC_MULTIPLIER)));


### PR DESCRIPTION
## Summary

Implements three related enhancements from the Stellar Wave milestone:

- **#948** — `GET /api/remittances/:id/receipt` returns a branded PDF receipt for any remittance. Authentication is required via `X-API-Key` (admin) or `X-Sender-Address` (must match the remittance owner).
- **#949** — `GET /api/accounts/:address/stellar-fees` returns the current Horizon base fee, the account's native XLM balance, and the estimated XLM cost for N operations. Includes a `low_balance` flag and `top_up_link` when balance is below 2 XLM. An `estimateStellarFee(operationCount)` helper is added to the SDK. The frontend gains a `checkXlmBalance()` utility that calls the endpoint and renders a red warning banner when XLM is low.
- **#950** — Notification templates are extracted into per-locale files (`en`, `es`, `fr`, `pt`) covering all five event types: `remittance_created`, `remittance_completed`, `remittance_failed`, `kyc_approved`, `kyc_expired`. A `preferred_language` column is added to `notification_preferences` (with migration). The notification service loads the correct locale template and falls back to English when a translation is missing. A CI-friendly script (`check-notification-templates.ts`) exits 1 if any locale is missing any key.

## Changes

| Area | File(s) | Change |
|------|---------|--------|
| API | `api/src/routes/remittances.ts` | Added `GET /:id/receipt` endpoint |
| API | `api/src/services/receiptGenerator.ts` | New — PDFKit-based receipt generator |
| API | `api/src/routes/accounts.ts` | New — Stellar fee + XLM balance endpoint |
| API | `api/src/app.ts` | Registered `/api/accounts` router |
| API | `api/package.json` | Added `pdfkit` + `@types/pdfkit` dependencies |
| Backend | `backend/src/notification-service.ts` | i18n template lookup, `preferred_language` in preferences, `notifyKycEvent()` |
| Backend | `backend/src/notification-templates/` | New — `types.ts`, `index.ts`, `en.ts`, `es.ts`, `fr.ts`, `pt.ts` |
| Backend | `backend/migrations/` | Migration to add `preferred_language` column |
| Backend | `backend/scripts/check-notification-templates.ts` | New — CI completeness check |
| SDK | `sdk/src/index.ts` | Added `estimateStellarFee()` helper |
| Frontend | `frontend/src/main.ts` | Added `checkXlmBalance()` and low-XLM banner |

## Notes

- Run `npm install` in `api/` after merging to pick up `pdfkit`.
- Run `npm run migrate` in `backend/` to apply the `preferred_language` column migration.
- Add `tsx backend/scripts/check-notification-templates.ts` to CI to enforce template completeness.
- The PDF receipt endpoint requires `ADMIN_API_KEY` to be set in the environment for admin access. Sender-based auth uses the `X-Sender-Address` header matched against `remittance.sender_id`.
- `STELLAR_EXPLORER_URL` can be set to override the default on-chain explorer base URL in receipts.

## Test plan

- [ ] `GET /api/remittances/:id/receipt` with a valid `X-API-Key` returns a PDF (`Content-Type: application/pdf`)
- [ ] Same endpoint with a mismatched `X-Sender-Address` returns 403
- [ ] Same endpoint with no auth headers returns 401
- [ ] `GET /api/accounts/G.../stellar-fees` returns `base_fee_stroops`, `xlm_balance`, `estimated_fee_xlm`
- [ ] Response includes `low_balance: true` and `top_up_link` when XLM balance < 2
- [ ] `estimateStellarFee(2)` returns `0.00002` (2 × 100 stroops / 10 000 000)
- [ ] Sending a notification to a user with `preferred_language = 'pt'` delivers Portuguese text
- [ ] Missing translation falls back to English without throwing
- [ ] `check-notification-templates.ts` exits 0 with all templates present; exits 1 if a key is removed

closes #948
closes #949 
closes #950 