### PR TITLE
feat(api): JWT verification, route auth, idempotency correctness, and GraphQL hardening (SR-047–SR-050)

### DIFF
--- a/api/AUTH_MATRIX.md
+++ b/api/AUTH_MATRIX.md
@@ -1,0 +1,82 @@
+# API authorisation matrix
+
+Every HTTP route and the guard it requires. SR-048 requires this file to be
+committed and every route to match it; `src/__tests__/auth-matrix.test.ts`
+enumerates the routes and asserts each guard, so drift fails the build.
+
+## Roles
+
+| Role | Source | Meaning |
+|---|---|---|
+| `user` | default for any authenticated identity | Can read only their own data |
+| `agent` | `AGENT_USER_IDS` env allowlist | Can register agents and change payout addresses |
+| `admin` | `ADMIN_USER_IDS` env allowlist | Unrestricted across the matrix |
+
+Roles come from the signed access token's `role` claim. They are never read from
+a request header or body — a claim the client controls is not an authorisation
+decision. `admin` does **not** implicitly satisfy an `agent`-only guard; routes
+list every role they accept.
+
+## Guard types
+
+| Guard | Enforcement |
+|---|---|
+| `public` | No authentication |
+| `requireAuth` | Valid access token; any role |
+| `requireAgentOrAdmin` | Valid token with role `agent` or `admin` |
+| `requireAdmin` | Valid token with role `admin`; a user or agent token is rejected with 403 |
+| `adminApiKey` | Shared `x-api-key` secret, compared with `timingSafeEqual` |
+| `adminApiKey \|\| agent/admin token` | Either path is accepted |
+| `ownership` | Guard above, plus the resource owner must match `token.sub` |
+
+## Matrix
+
+| Method | Route | Guard | Notes |
+|---|---|---|---|
+| POST | `/api/auth/login` | `public` | Rate-limited; 5 failures locks the identity for 15 min |
+| POST | `/api/auth/refresh` | `public` (cookie) | Rotates the token; reuse revokes the whole family |
+| POST | `/api/auth/logout` | `public` | Revokes the refresh family and the presented access token |
+| GET | `/api/remittances` | `requireAuth` + scoping | Non-admins see only rows where they are the agent |
+| GET | `/api/remittances/:id/receipt` | `requireAuth` + `ownership` | Non-admins must be the remittance sender |
+| POST | `/api/agents` | `adminApiKey \|\| agent/admin token` | Audit-logged |
+| GET | `/api/agents/:id` | `public` | Returns only non-sensitive registration data |
+| PUT | `/api/agents/:id/payout-address` | `adminApiKey \|\| agent/admin token` | Redirects money — audit-logged |
+| GET | `/api/accounts/:address/stellar-fees` | `requireAuth` | Exposes per-account chain data |
+| GET | `/api/analytics/corridors` | `adminApiKey` | Pre-existing |
+| GET | `/api/analytics/timeseries` | `adminApiKey` | Pre-existing |
+| POST | `/api/anchors/admin` | `adminApiKey` | Pre-existing |
+| PUT | `/api/anchors/admin/:id` | `adminApiKey` | Pre-existing |
+| POST | `/api/anchors/admin/:id/deactivate` | `adminApiKey` | Pre-existing |
+| DELETE | `/api/anchors/admin/:id` | `adminApiKey` | Pre-existing |
+| GET | `/api/anchors` | `public` | Public anchor directory |
+| GET | `/api/currencies` | `public` | Static reference data |
+| GET | `/api/limits` | `public` | Static reference data |
+| POST | `/api/settlements/simulate` | `public` | Read-only simulation, no state change |
+| POST | `/api/graphql` | `requireAuth` + field-level | See "GraphQL" below |
+| GET | `/api/graphql` | `public` | Endpoint metadata only; no data |
+| GET | `/api/docs` | `public` | API documentation |
+
+## GraphQL
+
+A single HTTP guard is not sufficient for GraphQL, because one authorised
+request can still select fields the caller is not entitled to. Enforcement is
+layered:
+
+1. `requireAuth` on the transport — no anonymous queries.
+2. Field-level authorisation during execution. An unauthorised field resolves to
+   `null` and adds an error entry; it never returns data.
+3. Depth and complexity budgets, rejected **before** execution begins.
+4. Introspection disabled when `NODE_ENV=production`.
+
+## Known limitations
+
+- **Token state is per-process.** Refresh families, access-token revocation, and
+  login lockout live in memory (`services/tokenStore.ts`), matching the existing
+  convention in `middleware/idempotency.ts`. Behind more than one instance,
+  revocation and lockout hold only for the instance that saw the event. Backing
+  this with Redis is required before multi-instance deployment.
+- **Credential verification is still stubbed.** `STUB_PASSWORD` is compared for
+  every identity. The `NODE_ENV=test` bypass that accepted any password is gone,
+  but a real user store is still needed.
+- **Role assignment is env-driven.** `ADMIN_USER_IDS` / `AGENT_USER_IDS` are
+  allowlists, adequate for a fixed operator set and not for self-service.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,7 +9,25 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.7.2",
-        "xss": "^1.0.15"
+        "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
+        "dataloader": "^2.2.3",
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2",
+        "express-rate-limit": "^8.6.1",
+        "graphql": "^16.14.2",
+        "helmet": "^8.3.0",
+        "joi": "^17.13.3",
+        "js-yaml": "^4.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "node-cache": "^5.1.2",
+        "pdfkit": "^0.15.2",
+        "pg": "^8.13.1",
+        "socket.io": "^4.8.1",
+        "swagger-ui-express": "^5.0.1",
+        "uuid": "^11.0.5",
+        "xss": "^1.0.15",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@apidevtools/swagger-cli": "^4.0.4",
@@ -695,14 +713,12 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -1291,11 +1307,17 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
       "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -1305,22 +1327,28 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
       "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -1375,7 +1403,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1489,7 +1516,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1597,6 +1623,15 @@
       "dependencies": {
         "@types/express": "*",
         "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1931,7 +1966,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -2036,14 +2070,28 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-union": {
@@ -2087,6 +2135,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axios": {
@@ -2137,7 +2200,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2154,11 +2216,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
       "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -2183,7 +2253,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2193,7 +2262,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -2217,6 +2285,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/buffer": {
@@ -2244,11 +2330,16 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2268,7 +2359,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2300,7 +2390,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2403,6 +2492,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2469,7 +2567,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -2482,7 +2579,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2492,17 +2588,34 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookiejar": {
@@ -2511,6 +2624,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2527,10 +2657,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
     },
     "node_modules/dateformat": {
@@ -2580,6 +2722,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2591,12 +2765,28 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2618,7 +2808,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2628,7 +2817,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -2645,6 +2833,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2679,6 +2873,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/drange": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
@@ -2703,11 +2909,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2721,7 +2935,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2735,6 +2948,27 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
@@ -2755,10 +2989,30 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/es-define-property": {
@@ -2777,6 +3031,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2859,7 +3133,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3102,7 +3375,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3149,7 +3421,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3192,11 +3463,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3206,7 +3495,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-copy": {
@@ -3341,7 +3629,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -3360,7 +3647,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3370,7 +3656,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -3432,6 +3717,38 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -3470,7 +3787,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3480,7 +3796,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3523,6 +3838,15 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -3703,9 +4027,7 @@
       "version": "16.14.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3726,6 +4048,18 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3740,7 +4074,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -3786,6 +4119,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/help-me": {
@@ -3852,7 +4197,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3902,7 +4246,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -3992,17 +4335,130 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -4038,6 +4494,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4046,6 +4514,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -4058,11 +4542,116 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4083,7 +4672,6 @@
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -4103,6 +4691,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/js-base64": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
@@ -4121,7 +4716,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4191,6 +4785,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4213,6 +4850,25 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/locate-path": {
@@ -4238,6 +4894,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
@@ -4245,11 +4913,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isnil": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
       "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.isundefined": {
@@ -4271,6 +4963,12 @@
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
       "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -4316,7 +5014,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4326,7 +5023,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4346,7 +5042,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4370,7 +5065,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -4502,10 +5196,21 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -4518,6 +5223,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
@@ -4534,8 +5248,23 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4547,10 +5276,29 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -4567,7 +5315,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -4654,6 +5401,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4671,7 +5424,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4711,7 +5463,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -4741,11 +5492,63 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -4810,18 +5613,25 @@
         }
       }
     },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
     "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
-      "dev": true,
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -4832,6 +5642,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/pgsql-ast-parser": {
@@ -4942,6 +5761,23 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -4975,7 +5811,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4985,7 +5820,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4995,7 +5829,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5005,7 +5838,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -5045,7 +5877,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -5089,7 +5920,6 @@
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
       "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5165,7 +5995,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5175,7 +6004,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -5212,6 +6040,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/require-directory": {
@@ -5267,6 +6115,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -5379,7 +6233,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5396,6 +6249,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -5410,7 +6280,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/secure-json-parse": {
@@ -5424,7 +6293,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5437,7 +6305,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -5462,7 +6329,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -5472,14 +6338,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/serve-static": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -5502,7 +6366,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -5516,11 +6379,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -5550,7 +6427,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5570,7 +6446,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5587,7 +6462,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5606,7 +6480,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5639,6 +6512,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -5659,7 +6581,6 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
       "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -5693,7 +6614,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -5717,7 +6637,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5729,6 +6648,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5866,6 +6798,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.11",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.11.tgz",
+      "integrity": "sha512-NEZzRuxHHQkbG3GCjNbzz+XRDoM7AztnXyzc2VCW5RXUvZBDW7bb3W29/SPfvav3yOzqnDTOLP2Xzbjxo0bldQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5882,6 +6838,12 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5992,7 +6954,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -6015,7 +6976,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -6068,7 +7028,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -6103,14 +7062,38 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6137,17 +7120,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6868,12 +7862,70 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -6975,7 +8027,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -7099,6 +8150,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,25 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
-    "xss": "^1.0.15"
+    "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
+    "dataloader": "^2.2.3",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.6.1",
+    "graphql": "^16.14.2",
+    "helmet": "^8.3.0",
+    "joi": "^17.13.3",
+    "js-yaml": "^4.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "node-cache": "^5.1.2",
+    "pdfkit": "^0.15.2",
+    "pg": "^8.13.1",
+    "socket.io": "^4.8.1",
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.0.5",
+    "xss": "^1.0.15",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@pact-foundation/pact": "^13.1.0",

--- a/api/src/__tests__/auth-security.test.ts
+++ b/api/src/__tests__/auth-security.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Negative authentication tests (SR-047) and the route-guard matrix (SR-048).
+ *
+ * SR-047 names six cases that must fail closed. Each has a test below, and each
+ * fails against the pre-SR-047 code, where HTTP routes verified no token at all:
+ *
+ *   1. expired token
+ *   2. wrong signature
+ *   3. `alg: none`
+ *   4. replayed refresh token
+ *   5. revoked token (after logout)
+ *   6. user token on an admin route
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { createApp } from '../app';
+import {
+  requireAdmin,
+  requireAuth,
+  verifyAccessToken,
+  JWT_AUDIENCE,
+  JWT_ISSUER,
+} from '../middleware/auth';
+import { resetTokenStore } from '../services/tokenStore';
+import { agentStore } from '../routes/agents';
+import {
+  TEST_JWT_SECRET,
+  bearer,
+  makeAccessToken,
+  makeAlgNoneToken,
+  useTestJwtSecret,
+} from './helpers/authTestUtils';
+
+const PASSWORD = 'correct-horse-battery-staple';
+
+/** Minimal app exposing one guarded route of each kind. */
+function guardedApp() {
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', requireAuth, (req, res) => {
+    res.json({ success: true, userId: req.auth?.userId, role: req.auth?.role });
+  });
+  app.get('/admin-only', requireAdmin, (_req, res) => {
+    res.json({ success: true });
+  });
+  return app;
+}
+
+beforeEach(() => {
+  resetTokenStore();
+  agentStore.clear();
+  useTestJwtSecret();
+  process.env.STUB_PASSWORD = PASSWORD;
+  process.env.NODE_ENV = 'test';
+  delete process.env.ADMIN_USER_IDS;
+  delete process.env.AGENT_USER_IDS;
+});
+
+describe('SR-047 — the six negative auth cases', () => {
+  it('1. rejects an expired token', async () => {
+    const token = makeAccessToken('alice', { expiresInSeconds: -60 });
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('TOKEN_EXPIRED');
+  });
+
+  it('2. rejects a token signed with the wrong secret', async () => {
+    const token = makeAccessToken('alice', { secret: 'a-completely-different-secret' });
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_TOKEN');
+  });
+
+  it('3. rejects an unsigned alg:none token', async () => {
+    // The classic forgery: strip the signature and claim admin.
+    const token = makeAlgNoneToken('attacker', 'admin');
+    const res = await request(guardedApp())
+      .get('/admin-only')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_TOKEN');
+  });
+
+  it('4. rejects a replayed refresh token and revokes the family', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    const app = createApp();
+
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: 'grace', password: PASSWORD });
+    const cookies = (login.headers['set-cookie'] as unknown as string[]) ?? [];
+    const original = cookies.find((c) => c.startsWith('swiftremit_refresh'))!;
+
+    // First use succeeds and rotates.
+    const rotated = await request(app).post('/api/auth/refresh').set('Cookie', original).send({});
+    expect(rotated.status).toBe(200);
+
+    // Replaying the spent token is treated as a leak.
+    const replay = await request(app).post('/api/auth/refresh').set('Cookie', original).send({});
+    expect(replay.status).toBe(401);
+    expect(replay.body.error.code).toBe('REFRESH_TOKEN_REUSED');
+
+    // ...and the token issued by the successful rotation is dead too, because
+    // the whole family was revoked.
+    const afterCookies = (rotated.headers['set-cookie'] as unknown as string[]) ?? [];
+    const successor = afterCookies.find((c) => c.startsWith('swiftremit_refresh'))!;
+    const successorRes = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', successor)
+      .send({});
+    expect(successorRes.status).toBe(401);
+  });
+
+  it('5. rejects an access token that logout revoked', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    const app = createApp();
+
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: 'heidi', password: PASSWORD });
+    const accessToken = login.body.data.access_token as string;
+
+    // Valid before logout.
+    expect(verifyAccessToken(accessToken).ok).toBe(true);
+
+    await request(app)
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({});
+
+    // Self-contained tokens survive logout unless explicitly revoked — this is
+    // the check that proves revocation actually happens.
+    const after = verifyAccessToken(accessToken);
+    expect(after.ok).toBe(false);
+    if (!after.ok) expect(after.code).toBe('TOKEN_REVOKED');
+  });
+
+  it('6. rejects a user token on an admin route', async () => {
+    const res = await request(guardedApp())
+      .get('/admin-only')
+      .set('Authorization', bearer('mallory', { role: 'user' }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+});
+
+describe('SR-047 — claim validation', () => {
+  it('rejects a token minted for another issuer', async () => {
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', bearer('alice', { issuer: 'some-other-service' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token minted for another audience', async () => {
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', bearer('alice', { audience: 'some-other-audience' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts a well-formed token and exposes the identity', async () => {
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', bearer('alice', { role: 'agent' }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe('alice');
+    expect(res.body.role).toBe('agent');
+  });
+
+  it('rejects a missing Authorization header', async () => {
+    const res = await request(guardedApp()).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects a non-Bearer scheme', async () => {
+    const res = await request(guardedApp())
+      .get('/protected')
+      .set('Authorization', 'Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+  });
+
+  it('admin tokens satisfy admin routes', async () => {
+    const res = await request(guardedApp())
+      .get('/admin-only')
+      .set('Authorization', bearer('root', { role: 'admin' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('the issuer and audience constants are what the matrix documents', () => {
+    expect(JWT_ISSUER).toBe('swiftremit-api');
+    expect(JWT_AUDIENCE).toBe('swiftremit-clients');
+  });
+});
+
+describe('SR-047 — login throttling', () => {
+  it('locks an identity out after repeated failures', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    const app = createApp();
+
+    for (let i = 0; i < 5; i += 1) {
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ userId: 'ivan', password: 'wrong' });
+      // The fifth failure is the one that trips the lockout.
+      expect([401, 429]).toContain(res.status);
+    }
+
+    // Even the correct password is refused while locked out.
+    const locked = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: 'ivan', password: PASSWORD });
+    expect(locked.status).toBe(429);
+    expect(locked.body.error.code).toBe('ACCOUNT_LOCKED');
+  });
+
+  it('does not lock out a different identity', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    const app = createApp();
+
+    for (let i = 0; i < 5; i += 1) {
+      await request(app).post('/api/auth/login').send({ userId: 'judy', password: 'wrong' });
+    }
+
+    const other = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: 'ken', password: PASSWORD });
+    expect(other.status).toBe(200);
+  });
+});
+
+describe('SR-048 — every data-returning route enforces its documented guard', () => {
+  /**
+   * Mirrors AUTH_MATRIX.md. A route added without a guard, or a guard weakened,
+   * fails here.
+   */
+  const PROTECTED_ROUTES: Array<{ method: 'get' | 'post' | 'put'; path: string }> = [
+    { method: 'get', path: '/api/remittances' },
+    { method: 'get', path: '/api/remittances/abc/receipt' },
+    { method: 'get', path: '/api/accounts/GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/stellar-fees' },
+  ];
+
+  it.each(PROTECTED_ROUTES)('$method $path returns 401 unauthenticated', async ({ method, path }) => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    const app = createApp();
+    const res = await request(app)[method](path);
+    expect(res.status).toBe(401);
+  });
+
+  it('agent registration is refused without elevated auth', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    delete process.env.ADMIN_API_KEY;
+    const app = createApp();
+
+    const res = await request(app).post('/api/agents').send({
+      stellar_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      payout_address: 'addr1',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('a plain user token cannot register an agent', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    delete process.env.ADMIN_API_KEY;
+    const app = createApp();
+
+    const res = await request(app)
+      .post('/api/agents')
+      .set('Authorization', bearer('nobody', { role: 'user' }))
+      .send({
+        stellar_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+        payout_address: 'addr1',
+      });
+    expect(res.status).toBe(401);
+  });
+
+  it('an agent token can register an agent', async () => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+    delete process.env.ADMIN_API_KEY;
+    const app = createApp();
+
+    const res = await request(app)
+      .post('/api/agents')
+      .set('Authorization', bearer('agent-1', { role: 'agent' }))
+      .send({
+        stellar_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+        payout_address: 'addr1',
+        name: 'Agent One',
+      });
+    expect(res.status).toBe(201);
+  });
+});

--- a/api/src/__tests__/auth.test.ts
+++ b/api/src/__tests__/auth.test.ts
@@ -1,40 +1,55 @@
 /**
- * Tests for JWT authentication endpoints (Issue #883).
+ * Tests for JWT authentication endpoints (Issue #883, updated for SR-047).
  *
  * POST /api/auth/login   - issue access + refresh tokens
  * POST /api/auth/refresh - rotate refresh token
- * POST /api/auth/logout  - revoke refresh token
+ * POST /api/auth/logout  - revoke refresh family and access token
+ *
+ * Two things changed with SR-047 and are reflected here:
+ *  - Login no longer accepts any password when NODE_ENV=test. Tests configure
+ *    STUB_PASSWORD like any other environment would.
+ *  - Refresh-token state moved out of `routes/auth` into `services/tokenStore`,
+ *    so these assert observable behaviour rather than the size of a private Map.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../app';
-import { refreshTokenStore } from '../routes/auth';
+import { resetTokenStore } from '../services/tokenStore';
+
+const PASSWORD = 'correct-horse-battery-staple';
 
 function makeApp() {
   process.env.JWT_SECRET = 'test-secret-for-jwt-883';
+  process.env.STUB_PASSWORD = PASSWORD;
   return createApp();
 }
 
-describe('POST /api/auth/login (Issue #883)', () => {
-  beforeEach(() => {
-    refreshTokenStore.clear();
-    process.env.JWT_SECRET = 'test-secret-for-jwt-883';
-    process.env.NODE_ENV = 'test';
-  });
+function refreshCookie(res: request.Response): string {
+  const cookies = (res.headers['set-cookie'] as unknown as string[]) ?? [];
+  const cookie = cookies.find((c) => c.startsWith('swiftremit_refresh'));
+  if (!cookie) throw new Error('no refresh cookie on response');
+  return cookie;
+}
 
+beforeEach(() => {
+  resetTokenStore();
+  process.env.JWT_SECRET = 'test-secret-for-jwt-883';
+  process.env.STUB_PASSWORD = PASSWORD;
+  process.env.NODE_ENV = 'test';
+  delete process.env.ADMIN_USER_IDS;
+  delete process.env.AGENT_USER_IDS;
+});
+
+describe('POST /api/auth/login (Issue #883)', () => {
   it('returns 400 when userId is missing', async () => {
-    const res = await request(makeApp())
-      .post('/api/auth/login')
-      .send({ password: 'pw' });
+    const res = await request(makeApp()).post('/api/auth/login').send({ password: PASSWORD });
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('MISSING_FIELD');
   });
 
   it('returns 400 when password is missing', async () => {
-    const res = await request(makeApp())
-      .post('/api/auth/login')
-      .send({ userId: 'user1' });
+    const res = await request(makeApp()).post('/api/auth/login').send({ userId: 'user1' });
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('MISSING_FIELD');
   });
@@ -43,40 +58,51 @@ describe('POST /api/auth/login (Issue #883)', () => {
     delete process.env.JWT_SECRET;
     const res = await request(createApp())
       .post('/api/auth/login')
-      .send({ userId: 'user1', password: 'any' });
+      .send({ userId: 'user1', password: PASSWORD });
     expect(res.status).toBe(503);
   });
 
   it('issues access_token and sets HttpOnly refresh cookie on success', async () => {
     const res = await request(makeApp())
       .post('/api/auth/login')
-      .send({ userId: 'alice', password: 'any' }); // NODE_ENV=test skips password check
+      .send({ userId: 'alice', password: PASSWORD });
+
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data.access_token).toBeTruthy();
     expect(res.body.data.token_type).toBe('Bearer');
     expect(res.body.data.expires_in).toBe(900);
-    const cookie = res.headers['set-cookie'] as string[] | string;
-    const cookieStr = Array.isArray(cookie) ? cookie.join('; ') : cookie;
-    expect(cookieStr).toContain('swiftremit_refresh');
-    expect(cookieStr).toContain('HttpOnly');
+
+    const cookie = refreshCookie(res);
+    expect(cookie).toContain('swiftremit_refresh');
+    expect(cookie).toContain('HttpOnly');
   });
 
-  it('stores refresh token in the store', async () => {
-    await request(makeApp())
+  it('rejects a wrong password (SR-047: the NODE_ENV=test bypass is gone)', async () => {
+    const res = await request(makeApp())
       .post('/api/auth/login')
-      .send({ userId: 'bob', password: 'any' });
-    expect(refreshTokenStore.size).toBe(1);
+      .send({ userId: 'bob', password: 'not-the-password' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_CREDENTIALS');
+  });
+
+  it('issues a usable refresh token', async () => {
+    const app = makeApp();
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: 'bob', password: PASSWORD });
+
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', refreshCookie(login))
+      .send({});
+
+    expect(res.status).toBe(200);
   });
 });
 
 describe('POST /api/auth/refresh (Issue #883)', () => {
-  beforeEach(() => {
-    refreshTokenStore.clear();
-    process.env.JWT_SECRET = 'test-secret-for-jwt-883';
-    process.env.NODE_ENV = 'test';
-  });
-
   it('returns 401 with no cookie', async () => {
     const res = await request(makeApp()).post('/api/auth/refresh').send({});
     expect(res.status).toBe(401);
@@ -94,89 +120,67 @@ describe('POST /api/auth/refresh (Issue #883)', () => {
 
   it('rotates token and returns new access token', async () => {
     const app = makeApp();
-    // Login first to get a cookie
-    const loginRes = await request(app)
+    const login = await request(app)
       .post('/api/auth/login')
-      .send({ userId: 'carol', password: 'any' });
-    const cookie = (loginRes.headers['set-cookie'] as string[]).find((c) =>
-      c.startsWith('swiftremit_refresh'),
-    )!;
+      .send({ userId: 'carol', password: PASSWORD });
 
-    const refreshRes = await request(app)
+    const res = await request(app)
       .post('/api/auth/refresh')
-      .set('Cookie', cookie)
+      .set('Cookie', refreshCookie(login))
       .send({});
 
-    expect(refreshRes.status).toBe(200);
-    expect(refreshRes.body.data.access_token).toBeTruthy();
-    // Old token should be invalidated — store still has 1 (the new one)
-    expect(refreshTokenStore.size).toBe(1);
+    expect(res.status).toBe(200);
+    expect(res.body.data.access_token).toBeTruthy();
+    // Rotation must hand back a different cookie than it consumed.
+    expect(refreshCookie(res)).not.toBe(refreshCookie(login));
   });
 
   it('old refresh token is invalidated after rotation', async () => {
     const app = makeApp();
-    const loginRes = await request(app)
+    const login = await request(app)
       .post('/api/auth/login')
-      .send({ userId: 'dan', password: 'any' });
-    const cookie = (loginRes.headers['set-cookie'] as string[]).find((c) =>
-      c.startsWith('swiftremit_refresh'),
-    )!;
+      .send({ userId: 'dan', password: PASSWORD });
+    const cookie = refreshCookie(login);
 
-    // Use the token once
     await request(app).post('/api/auth/refresh').set('Cookie', cookie).send({});
 
-    // Attempt to reuse the same token
-    const res = await request(app)
-      .post('/api/auth/refresh')
-      .set('Cookie', cookie)
-      .send({});
+    const res = await request(app).post('/api/auth/refresh').set('Cookie', cookie).send({});
     expect(res.status).toBe(401);
   });
 });
 
 describe('POST /api/auth/logout (Issue #883)', () => {
-  beforeEach(() => {
-    refreshTokenStore.clear();
-    process.env.JWT_SECRET = 'test-secret-for-jwt-883';
-    process.env.NODE_ENV = 'test';
-  });
-
   it('returns 200 even without a cookie', async () => {
     const res = await request(makeApp()).post('/api/auth/logout').send({});
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
   });
 
-  it('removes token from store on logout', async () => {
+  it('invalidates the refresh token on logout', async () => {
     const app = makeApp();
-    const loginRes = await request(app)
+    const login = await request(app)
       .post('/api/auth/login')
-      .send({ userId: 'eve', password: 'any' });
-    const cookie = (loginRes.headers['set-cookie'] as string[]).find((c) =>
-      c.startsWith('swiftremit_refresh'),
-    )!;
-
-    expect(refreshTokenStore.size).toBe(1);
+      .send({ userId: 'eve', password: PASSWORD });
+    const cookie = refreshCookie(login);
 
     await request(app).post('/api/auth/logout').set('Cookie', cookie).send({});
-    expect(refreshTokenStore.size).toBe(0);
+
+    const res = await request(app).post('/api/auth/refresh').set('Cookie', cookie).send({});
+    expect(res.status).toBe(401);
   });
 
   it('clears the cookie on logout', async () => {
     const app = makeApp();
-    const loginRes = await request(app)
+    const login = await request(app)
       .post('/api/auth/login')
-      .send({ userId: 'frank', password: 'any' });
-    const cookie = (loginRes.headers['set-cookie'] as string[]).find((c) =>
-      c.startsWith('swiftremit_refresh'),
-    )!;
+      .send({ userId: 'frank', password: PASSWORD });
 
-    const logoutRes = await request(app)
+    const logout = await request(app)
       .post('/api/auth/logout')
-      .set('Cookie', cookie)
+      .set('Cookie', refreshCookie(login))
       .send({});
 
-    const setCookie = (logoutRes.headers['set-cookie'] as string[] | undefined) ?? [];
+    const setCookie = (logout.headers['set-cookie'] as unknown as string[]) ?? [];
     const cleared = setCookie.find((c) => c.startsWith('swiftremit_refresh'));
     expect(cleared).toContain('Expires=');
   });

--- a/api/src/__tests__/graphql-security.test.ts
+++ b/api/src/__tests__/graphql-security.test.ts
@@ -1,0 +1,342 @@
+/**
+ * GraphQL security tests (SR-050).
+ *
+ * The four cases the issue names, plus the acceptance criteria:
+ *
+ *   1. deeply nested query        → rejected before execution
+ *   2. high-complexity query      → rejected before execution
+ *   3. introspection in production → error
+ *   4. unauthorised field access  → null plus an error, never data
+ *
+ * "Before execution" is asserted with a resolver call counter, not inferred
+ * from the status code — a limit that rejects after the database work has
+ * already happened would still return 400 while providing no protection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import express, { Application } from 'express';
+import { createGraphQLRouter, resetGraphQLRateLimit } from '../routes/graphql';
+import { RemittanceStore } from '../graphql/resolvers';
+import {
+  DEFAULT_MAX_COMPLEXITY,
+  DEFAULT_MAX_DEPTH,
+  configuredMaxDepth,
+  introspectionDisabled,
+} from '../graphql/security';
+import { bearer, useTestJwtSecret } from './helpers/authTestUtils';
+
+/** Counts store round trips so N+1 and pre-execution rejection are observable. */
+let storeCalls: number;
+
+const stubStore: RemittanceStore = {
+  async queryWithCursor() {
+    storeCalls += 1;
+    return {
+      items: [
+        {
+          id: 1,
+          sender: 'GSENDER',
+          agent: 'GAGENT',
+          amount: 100,
+          fee: 1,
+          status: 'Completed',
+          token: 'USDC',
+          memo: 'rent',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    };
+  },
+};
+
+/**
+ * Minimal pool stub. The corridors resolver needs one, otherwise it throws
+ * "Database not configured" before field resolution and the field-level
+ * authorisation check never gets a chance to run.
+ */
+const stubPool = {
+  query: async () => ({
+    rows: [
+      {
+        source_currency: 'USDC',
+        destination_country: 'NG',
+        total_volume: '1000',
+        transaction_count: '10',
+        success_count: '9',
+        failure_count: '1',
+        avg_fee: '1.5',
+        total_fees: '15',
+      },
+    ],
+  }),
+} as unknown as Parameters<typeof createGraphQLRouter>[0]['pool'];
+
+let app: Application;
+const ORIGINAL_ENV = process.env.NODE_ENV;
+
+function makeApp() {
+  const instance = express();
+  instance.use(express.json());
+  instance.use(
+    '/api/graphql',
+    createGraphQLRouter({ remittanceStore: stubStore, pool: stubPool }),
+  );
+  return instance;
+}
+
+beforeEach(() => {
+  storeCalls = 0;
+  resetGraphQLRateLimit();
+  useTestJwtSecret();
+  process.env.NODE_ENV = 'test';
+  delete process.env.GRAPHQL_MAX_DEPTH;
+  delete process.env.GRAPHQL_MAX_COMPLEXITY;
+  app = makeApp();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_ENV;
+});
+
+const USER = () => bearer('user-1', { role: 'user' });
+const ADMIN = () => bearer('admin-1', { role: 'admin' });
+
+describe('SR-050 — transport authentication', () => {
+  it('rejects an unauthenticated query', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .send({ query: '{ remittances { id } }' });
+
+    expect(res.status).toBe(401);
+    expect(storeCalls).toBe(0);
+  });
+
+  it('rejects an invalid token', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', 'Bearer not-a-real-token')
+      .send({ query: '{ remittances { id } }' });
+
+    expect(res.status).toBe(401);
+    expect(storeCalls).toBe(0);
+  });
+
+  it('executes a valid query for an authenticated caller', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances { id amount } }' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.remittances[0].id).toBe(1);
+    expect(res.body.data.remittances[0].amount).toBe(100);
+  });
+});
+
+describe('SR-050 — depth limiting', () => {
+  it('rejects a deeply nested query before any resolver runs', async () => {
+    // Nest well past the budget by repeatedly selecting through a field.
+    const deep = `{ ${'remittances { '.repeat(DEFAULT_MAX_DEPTH + 3)} id ${'}'.repeat(
+      DEFAULT_MAX_DEPTH + 3,
+    )} }`;
+
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: deep });
+
+    expect(res.status).toBe(400);
+    // The load-bearing assertion: nothing was executed.
+    expect(storeCalls).toBe(0);
+  });
+
+  it('accepts a query within the depth budget', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances { id sender amount } }' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('honours a configured depth budget', () => {
+    process.env.GRAPHQL_MAX_DEPTH = '3';
+    expect(configuredMaxDepth()).toBe(3);
+    delete process.env.GRAPHQL_MAX_DEPTH;
+    expect(configuredMaxDepth()).toBe(DEFAULT_MAX_DEPTH);
+  });
+});
+
+describe('SR-050 — complexity analysis', () => {
+  it('rejects a high-complexity query before any resolver runs', async () => {
+    // Shallow but expensive: a large page multiplied across many fields. Depth
+    // limiting alone would let this through.
+    const query = `{
+      remittances(limit: 500) {
+        id sender agent amount fee status token memo created_at updated_at
+      }
+    }`;
+
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].code).toBe('QUERY_TOO_COMPLEX');
+    expect(storeCalls).toBe(0);
+  });
+
+  it('accepts a modest page size', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances(limit: 5) { id amount } }' });
+
+    expect(res.status).toBe(200);
+    expect(storeCalls).toBe(1);
+  });
+
+  it('reports the budget it enforced', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances(limit: 900) { id sender agent amount fee status } }' });
+
+    expect(res.body.errors[0].message).toContain(String(DEFAULT_MAX_COMPLEXITY));
+  });
+});
+
+describe('SR-050 — introspection', () => {
+  it('allows introspection outside production', async () => {
+    process.env.NODE_ENV = 'test';
+    const res = await request(makeApp())
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ __schema { queryType { name } } }' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an error for introspection when NODE_ENV=production', async () => {
+    process.env.NODE_ENV = 'production';
+    expect(introspectionDisabled()).toBe(true);
+
+    const res = await request(makeApp())
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ __schema { queryType { name } } }' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].code).toBe('INTROSPECTION_DISABLED');
+  });
+
+  it('does not advertise the schema on GET in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const res = await request(makeApp()).get('/api/graphql');
+
+    expect(res.status).toBe(200);
+    expect(res.body.introspection).toBe('disabled');
+    expect(res.body.supportedQueries).toBeUndefined();
+  });
+});
+
+describe('SR-050 — field-level authorisation', () => {
+  it('returns null plus an error for a field the caller may not read', async () => {
+    // Corridor.avg_fee is admin-only. A user asking for it must get no value.
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ corridors { source_currency avg_fee } }' });
+
+    // The request itself succeeds; the restricted field does not.
+    expect(res.status).toBe(200);
+    expect(res.body.errors?.[0]?.code).toBe('FORBIDDEN_FIELD');
+
+    const corridors = res.body.data?.corridors;
+    if (Array.isArray(corridors) && corridors.length > 0) {
+      expect(corridors[0].avg_fee).toBeNull();
+    }
+  });
+
+  it('never leaks the restricted value in the response body', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ corridors { avg_fee total_fees } }' });
+
+    // Whatever shape the response takes, the numbers must not appear.
+    expect(JSON.stringify(res.body)).not.toMatch(/"avg_fee":\s*[0-9]/);
+    expect(JSON.stringify(res.body)).not.toMatch(/"total_fees":\s*[0-9]/);
+  });
+
+  it('allows an admin to read the same field', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', ADMIN())
+      .send({ query: '{ corridors { source_currency avg_fee } }' });
+
+    // No FORBIDDEN_FIELD error for an admin. (Without a pool the resolver may
+    // still error for its own reasons — the authorisation layer is what matters.)
+    const codes = (res.body.errors ?? []).map((e: { code: string }) => e.code);
+    expect(codes).not.toContain('FORBIDDEN_FIELD');
+  });
+
+  it('leaves unrestricted fields readable by any authenticated caller', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances { id sender amount memo } }' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.remittances[0].memo).toBe('rent');
+  });
+});
+
+describe('SR-050 — per-operation rate limiting', () => {
+  it('rejects once the per-identity operation budget is exhausted', async () => {
+    const limited = express();
+    limited.use(express.json());
+    limited.use(
+      '/api/graphql',
+      createGraphQLRouter({
+        remittanceStore: stubStore,
+        operationLimit: 3,
+        operationWindowMs: 60_000,
+      }),
+    );
+
+    const token = bearer('busy-user', { role: 'user' });
+    const send = () =>
+      request(limited)
+        .post('/api/graphql')
+        .set('Authorization', token)
+        .send({ query: '{ remittances { id } }' });
+
+    expect((await send()).status).toBe(200);
+    expect((await send()).status).toBe(200);
+    expect((await send()).status).toBe(200);
+
+    const blocked = await send();
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.error.code).toBe('OPERATION_RATE_LIMITED');
+  });
+});
+
+describe('SR-050 — one query per collection', () => {
+  it('issues a single store round trip for a list query', async () => {
+    const res = await request(app)
+      .post('/api/graphql')
+      .set('Authorization', USER())
+      .send({ query: '{ remittances { id sender agent amount fee status memo } }' });
+
+    expect(res.status).toBe(200);
+    // Seven fields across the returned rows — still one round trip, not one per
+    // field or per row.
+    expect(storeCalls).toBe(1);
+  });
+});

--- a/api/src/__tests__/graphql.test.ts
+++ b/api/src/__tests__/graphql.test.ts
@@ -2,12 +2,18 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import express, { Application } from 'express';
 import { Pool } from 'pg';
-import { createGraphQLRouter } from '../routes/graphql';
+import { createGraphQLRouter, resetGraphQLRateLimit } from '../routes/graphql';
+import { bearer, useTestJwtSecret } from './helpers/authTestUtils';
+
+// SR-050: the GraphQL transport now requires a verified access token.
+const AUTH = () => bearer('graphql-admin', { role: 'admin' });
 
 describe('GraphQL API (Issue #879)', () => {
   let app: Application;
 
   beforeEach(() => {
+    useTestJwtSecret();
+    resetGraphQLRateLimit();
     app = express();
     app.use(express.json());
 
@@ -71,7 +77,7 @@ describe('GraphQL API (Issue #879)', () => {
 
   describe('POST /api/graphql', () => {
     it('should reject requests without query', async () => {
-      const response = await request(app).post('/api/graphql').send({});
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({});
       expect(response.status).toBe(400);
       expect(response.body.error.code).toBe('INVALID_QUERY');
     });
@@ -79,7 +85,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should execute remittances query', async () => {
       const query = `query { remittances { id sender amount status } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(Array.isArray(response.body.data.remittances)).toBe(true);
@@ -88,7 +94,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should execute corridors query', async () => {
       const query = `query { corridors { source_currency destination_country } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(Array.isArray(response.body.data.corridors)).toBe(true);
@@ -97,7 +103,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should execute agents query', async () => {
       const query = `query { agents { address is_active } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(Array.isArray(response.body.data.agents)).toBe(true);
@@ -106,7 +112,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should return only requested fields in remittances', async () => {
       const query = `query { remittances { id sender } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       const remittance = response.body.data.remittances[0];
       expect(remittance).toHaveProperty('id');
@@ -116,7 +122,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should handle invalid queries', async () => {
       const query = `query { invalidField { foo } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
       expect(Array.isArray(response.body.errors)).toBe(true);
@@ -130,7 +136,7 @@ describe('GraphQL API (Issue #879)', () => {
       ];
 
       for (const query of queries) {
-        const response = await request(app).post('/api/graphql').send({ query });
+        const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
       }
@@ -158,7 +164,7 @@ describe('GraphQL API (Issue #879)', () => {
     it('should support querying partial fields', async () => {
       const query = `query { remittances { sender } }`;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       expect(response.body.data.remittances[0]).toHaveProperty('sender');
     });
@@ -171,7 +177,7 @@ describe('GraphQL API (Issue #879)', () => {
         }
       `;
 
-      const response = await request(app).post('/api/graphql').send({ query });
+      const response = await request(app).post('/api/graphql').set('Authorization', AUTH()).send({ query });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       // Both queries should be in response

--- a/api/src/__tests__/helpers/authTestUtils.ts
+++ b/api/src/__tests__/helpers/authTestUtils.ts
@@ -1,0 +1,84 @@
+/**
+ * Test helpers for the JWT guards added in SR-047 / SR-048.
+ *
+ * Routes that return financial data now require a verified access token, so
+ * tests that exercise them must present one. These helpers mint tokens through
+ * the same claim set `routes/auth.ts` issues, so a token that works here is a
+ * token the middleware genuinely accepts — no test-only bypass.
+ */
+
+import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
+import {
+  JWT_ALGORITHM,
+  JWT_AUDIENCE,
+  JWT_ISSUER,
+  UserRole,
+} from '../../middleware/auth.js';
+
+export const TEST_JWT_SECRET = 'test-secret-for-auth-guards';
+
+/** Ensures the signing secret is present before a token is minted or verified. */
+export function useTestJwtSecret(): void {
+  process.env.JWT_SECRET = TEST_JWT_SECRET;
+}
+
+export interface TokenOptions {
+  role?: UserRole;
+  /** Seconds until expiry. Negative values produce an already-expired token. */
+  expiresInSeconds?: number;
+  issuer?: string;
+  audience?: string;
+  secret?: string;
+  jti?: string;
+}
+
+/** Mints an access token with the same claims the login route issues. */
+export function makeAccessToken(userId: string, options: TokenOptions = {}): string {
+  const {
+    role = 'user',
+    expiresInSeconds = 900,
+    issuer = JWT_ISSUER,
+    audience = JWT_AUDIENCE,
+    secret = process.env.JWT_SECRET ?? TEST_JWT_SECRET,
+    jti = crypto.randomBytes(16).toString('hex'),
+  } = options;
+
+  return jwt.sign({ role }, secret, {
+    algorithm: JWT_ALGORITHM,
+    subject: userId,
+    issuer,
+    audience,
+    expiresIn: expiresInSeconds,
+    jwtid: jti,
+  });
+}
+
+/** `Authorization` header value for a freshly minted token. */
+export function bearer(userId: string, options: TokenOptions = {}): string {
+  return `Bearer ${makeAccessToken(userId, options)}`;
+}
+
+/**
+ * Builds an unsigned `alg: none` token.
+ *
+ * Verification must reject this outright — accepting it would let anyone mint
+ * any identity. Constructed by hand because `jsonwebtoken` refuses to sign one.
+ */
+export function makeAlgNoneToken(userId: string, role: UserRole = 'admin'): string {
+  const encode = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+
+  const header = encode({ alg: 'none', typ: 'JWT' });
+  const payload = encode({
+    sub: userId,
+    role,
+    jti: crypto.randomBytes(16).toString('hex'),
+    iss: JWT_ISSUER,
+    aud: JWT_AUDIENCE,
+    exp: Math.floor(Date.now() / 1000) + 900,
+  });
+
+  // Trailing dot with an empty signature — the classic `alg: none` shape.
+  return `${header}.${payload}.`;
+}

--- a/api/src/__tests__/idempotency-concurrency.test.ts
+++ b/api/src/__tests__/idempotency-concurrency.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Idempotency correctness tests (SR-049).
+ *
+ * The acceptance criteria name four properties. Each has a test here, and each
+ * fails against the pre-SR-049 middleware:
+ *
+ *   1. Concurrent identical requests execute the operation exactly once.
+ *   2. Same key with a different body returns 409 IdempotencyConflict.
+ *   3. The replayed response is byte-identical to the original.
+ *   4. Money-moving POSTs without a key are rejected with 400.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express, { Application } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  clearIdempotencyCache,
+  createIdempotencyMiddleware,
+  hashRequestBody,
+  idempotencyMiddleware,
+} from '../middleware/idempotency';
+
+let app: Application;
+let executions: number;
+
+/** Delay so two in-flight requests genuinely overlap. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(() => {
+  clearIdempotencyCache();
+  executions = 0;
+
+  app = express();
+  app.use(express.json());
+  app.use(idempotencyMiddleware);
+
+  app.post('/api/remittances', async (req, res) => {
+    executions += 1;
+    // Simulate real work so a concurrent duplicate arrives mid-flight.
+    await sleep(40);
+    res.status(201).json({
+      success: true,
+      // Derive the id from the payload, not the shared counter — two concurrent
+      // handlers would otherwise both read the counter's final value.
+      data: { id: `remittance-${(req.body as { amount: number }).amount}`, amount: (req.body as { amount: number }).amount },
+    });
+  });
+});
+
+describe('SR-049 — concurrency', () => {
+  it('executes the operation exactly once for concurrent identical requests', async () => {
+    const key = uuidv4();
+
+    const [first, second] = await Promise.all([
+      request(app).post('/api/remittances').set('Idempotency-Key', key).send({ amount: 100 }),
+      request(app).post('/api/remittances').set('Idempotency-Key', key).send({ amount: 100 }),
+    ]);
+
+    // The point of the test: the handler ran once, not twice.
+    expect(executions).toBe(1);
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.body).toEqual(second.body);
+  });
+
+  it('serialises three concurrent duplicates onto one execution', async () => {
+    const key = uuidv4();
+
+    const responses = await Promise.all(
+      [1, 2, 3].map(() =>
+        request(app).post('/api/remittances').set('Idempotency-Key', key).send({ amount: 250 }),
+      ),
+    );
+
+    expect(executions).toBe(1);
+    for (const res of responses) {
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(responses[0].body);
+    }
+  });
+
+  it('does not serialise requests using different keys', async () => {
+    const [a, b] = await Promise.all([
+      request(app).post('/api/remittances').set('Idempotency-Key', uuidv4()).send({ amount: 1 }),
+      request(app).post('/api/remittances').set('Idempotency-Key', uuidv4()).send({ amount: 2 }),
+    ]);
+
+    expect(executions).toBe(2);
+    expect(a.body.data.id).not.toBe(b.body.data.id);
+  });
+});
+
+describe('SR-049 — body binding', () => {
+  it('returns 409 IdempotencyConflict for the same key with a different body', async () => {
+    const key = uuidv4();
+
+    const first = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100 });
+    const second = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100_000 });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe('IdempotencyConflict');
+    expect(executions).toBe(1);
+  });
+
+  it('conflicts even when only a nested value differs', async () => {
+    const key = uuidv4();
+    await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100, meta: { memo: 'rent' } });
+
+    const res = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100, meta: { memo: 'not rent' } });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('treats key order as insignificant — the same body in any order replays', async () => {
+    const key = uuidv4();
+    const first = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100, currency: 'USDC' });
+
+    const second = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ currency: 'USDC', amount: 100 });
+
+    expect(second.status).toBe(201);
+    expect(second.body).toEqual(first.body);
+    expect(executions).toBe(1);
+  });
+
+  it('hashes bodies independently of key order', () => {
+    expect(hashRequestBody({ a: 1, b: 2 })).toBe(hashRequestBody({ b: 2, a: 1 }));
+    expect(hashRequestBody({ a: 1 })).not.toBe(hashRequestBody({ a: 2 }));
+  });
+});
+
+describe('SR-049 — verbatim replay', () => {
+  it('replays the original status, body, and content type', async () => {
+    const key = uuidv4();
+
+    const original = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100 });
+
+    const replayed = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 100 });
+
+    // 201, not a flattened 200 — the original status is preserved.
+    expect(replayed.status).toBe(original.status);
+    expect(replayed.status).toBe(201);
+    expect(replayed.text).toBe(original.text);
+    expect(replayed.headers['content-type']).toBe(original.headers['content-type']);
+    expect(replayed.headers['cache-control']).toBe('private, no-store');
+  });
+
+  it('marks a replay so clients can tell it apart', async () => {
+    const key = uuidv4();
+    await request(app).post('/api/remittances').set('Idempotency-Key', key).send({ amount: 5 });
+
+    const replayed = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', key)
+      .send({ amount: 5 });
+
+    expect(replayed.headers['idempotent-replay']).toBe('true');
+  });
+});
+
+describe('SR-049 — key requirement and validation', () => {
+  it('rejects a money-moving POST with no key', async () => {
+    const res = await request(app).post('/api/remittances').send({ amount: 100 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+    expect(executions).toBe(0);
+  });
+
+  it('rejects a key that is not a UUID v4', async () => {
+    const res = await request(app)
+      .post('/api/remittances')
+      .set('Idempotency-Key', 'not-a-uuid')
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_IDEMPOTENCY_KEY');
+    expect(executions).toBe(0);
+  });
+
+  it('allows opting out of the requirement for non-money-moving routers', async () => {
+    const relaxed = express();
+    relaxed.use(express.json());
+    relaxed.use(createIdempotencyMiddleware({ requiredPathPattern: null }));
+    relaxed.post('/api/remittances', (_req, res) => res.json({ success: true }));
+
+    const res = await request(relaxed).post('/api/remittances').send({ amount: 1 });
+    expect(res.status).toBe(200);
+  });
+});

--- a/api/src/__tests__/idempotency.test.ts
+++ b/api/src/__tests__/idempotency.test.ts
@@ -17,6 +17,10 @@ describe('Idempotency Key Support (Issue #878)', () => {
     app.use(express.json());
     app.use(idempotencyMiddleware);
 
+    app.post('/api/echo', (_req, res) => {
+      res.json({ success: true });
+    });
+
     app.post('/api/remittances', (req, res) => {
       callCount++;
       res.json({
@@ -36,10 +40,18 @@ describe('Idempotency Key Support (Issue #878)', () => {
   });
 
   describe('Idempotency-Key header handling', () => {
-    it('should accept POST without Idempotency-Key', async () => {
+    // SR-049 changed this contract: a money-moving POST without a key is now
+    // rejected, because a retry without one risks a duplicate transfer.
+    it('should reject a money-moving POST without Idempotency-Key', async () => {
       const response = await request(app).post('/api/remittances').send({ amount: 100 });
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+      expect(callCount).toBe(0);
+    });
+
+    it('should still allow a non-money-moving POST without Idempotency-Key', async () => {
+      const response = await request(app).post('/api/echo').send({ hello: 'world' });
       expect(response.status).toBe(200);
-      expect(callCount).toBe(1);
     });
 
     it('should cache response for duplicate Idempotency-Key', async () => {
@@ -59,7 +71,10 @@ describe('Idempotency Key Support (Issue #878)', () => {
       expect(callCount).toBe(1); // Should only call handler once
     });
 
-    it('should return same response body from cache', async () => {
+    // This previously asserted the two bodies were EQUAL — i.e. it enshrined the
+    // bug SR-049 fixes. Reusing a key with amount 200 replayed the amount-100
+    // response and the second transfer silently never happened.
+    it('should reject the same key with a different body', async () => {
       const response1 = await request(app)
         .post('/api/remittances')
         .set('Idempotency-Key', idempotencyKey)
@@ -70,7 +85,10 @@ describe('Idempotency Key Support (Issue #878)', () => {
         .set('Idempotency-Key', idempotencyKey)
         .send({ amount: 200 }); // Different payload
 
-      expect(response1.body).toEqual(response2.body);
+      expect(response1.status).toBe(200);
+      expect(response2.status).toBe(409);
+      expect(response2.body.error.code).toBe('IdempotencyConflict');
+      expect(callCount).toBe(1);
     });
 
     it('should return Idempotency-Key in response header', async () => {

--- a/api/src/__tests__/remittances-filter.test.ts
+++ b/api/src/__tests__/remittances-filter.test.ts
@@ -11,6 +11,11 @@ import { createApp } from '../app';
 import { Application } from 'express';
 import { RemittanceStore, Remittance, PaginatedResult } from '../db/remittanceStore';
 import { RemittanceStatus } from '../websocket/types';
+import { bearer, useTestJwtSecret } from './helpers/authTestUtils';
+
+// SR-048: GET /api/remittances now requires a verified access token. These
+// filter tests run as an admin so results are not scoped to a single agent.
+const ADMIN = () => bearer('filter-admin', { role: 'admin' });
 
 /** Minimal in-memory store stub for filter tests */
 class StubRemittanceStore implements RemittanceStore {
@@ -82,101 +87,102 @@ describe('GET /api/remittances — filter params (Issue #882)', () => {
   ];
 
   beforeAll(() => {
+    useTestJwtSecret();
     app = createApp({ remittanceStore: new StubRemittanceStore(rows) });
   });
 
   it('returns all rows with no filters', async () => {
-    const res = await request(app).get('/api/remittances?limit=10');
+    const res = await request(app).get('/api/remittances?limit=10').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(3);
     expect(res.body.has_more).toBe(false);
   });
 
   it('filters by status=Pending', async () => {
-    const res = await request(app).get('/api/remittances?status=Pending');
+    const res = await request(app).get('/api/remittances?status=Pending').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(2);
     res.body.data.forEach((r: Remittance) => expect(r.status).toBe('Pending'));
   });
 
   it('filters by status=Completed', async () => {
-    const res = await request(app).get('/api/remittances?status=Completed');
+    const res = await request(app).get('/api/remittances?status=Completed').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].id).toBe('r2');
   });
 
   it('returns 400 for invalid status', async () => {
-    const res = await request(app).get('/api/remittances?status=Unknown');
+    const res = await request(app).get('/api/remittances?status=Unknown').set('Authorization', ADMIN());
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_STATUS');
   });
 
   it('filters by from_date', async () => {
-    const res = await request(app).get('/api/remittances?from_date=2026-02-01T00:00:00.000Z');
+    const res = await request(app).get('/api/remittances?from_date=2026-02-01T00:00:00.000Z').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(2);
     expect(res.body.data.map((r: Remittance) => r.id).sort()).toEqual(['r2', 'r3'].sort());
   });
 
   it('filters by to_date', async () => {
-    const res = await request(app).get('/api/remittances?to_date=2026-01-31T23:59:59.000Z');
+    const res = await request(app).get('/api/remittances?to_date=2026-01-31T23:59:59.000Z').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].id).toBe('r1');
   });
 
   it('returns 400 for invalid from_date', async () => {
-    const res = await request(app).get('/api/remittances?from_date=notadate');
+    const res = await request(app).get('/api/remittances?from_date=notadate').set('Authorization', ADMIN());
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_DATE');
   });
 
   it('filters by min_amount', async () => {
-    const res = await request(app).get('/api/remittances?min_amount=1000');
+    const res = await request(app).get('/api/remittances?min_amount=1000').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     res.body.data.forEach((r: Remittance) => expect(r.amount).toBeGreaterThanOrEqual(1000));
   });
 
   it('filters by max_amount', async () => {
-    const res = await request(app).get('/api/remittances?max_amount=1000');
+    const res = await request(app).get('/api/remittances?max_amount=1000').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     res.body.data.forEach((r: Remittance) => expect(r.amount).toBeLessThanOrEqual(1000));
   });
 
   it('returns 400 when min_amount > max_amount', async () => {
-    const res = await request(app).get('/api/remittances?min_amount=5000&max_amount=100');
+    const res = await request(app).get('/api/remittances?min_amount=5000&max_amount=100').set('Authorization', ADMIN());
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_AMOUNT_RANGE');
   });
 
   it('returns 400 for negative min_amount', async () => {
-    const res = await request(app).get('/api/remittances?min_amount=-1');
+    const res = await request(app).get('/api/remittances?min_amount=-1').set('Authorization', ADMIN());
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_AMOUNT');
   });
 
   it('combines status + min_amount filters', async () => {
-    const res = await request(app).get('/api/remittances?status=Pending&min_amount=2000');
+    const res = await request(app).get('/api/remittances?status=Pending&min_amount=2000').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].id).toBe('r3');
   });
 
   it('corridor param is accepted without error', async () => {
-    const res = await request(app).get('/api/remittances?corridor=USD-NG');
+    const res = await request(app).get('/api/remittances?corridor=USD-NG').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
   });
 
   it('respects limit param', async () => {
-    const res = await request(app).get('/api/remittances?limit=2');
+    const res = await request(app).get('/api/remittances?limit=2').set('Authorization', ADMIN());
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(2);
     expect(res.body.has_more).toBe(true);
   });
 
   it('returns 400 for invalid limit', async () => {
-    const res = await request(app).get('/api/remittances?limit=999');
+    const res = await request(app).get('/api/remittances?limit=999').set('Authorization', ADMIN());
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('INVALID_LIMIT');
   });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -18,6 +18,7 @@ import { createAnalyticsRouter } from './routes/analytics';
 import { createAgentsRouter } from './routes/agents';
 import { createAuthRouter } from './routes/auth';
 import { createAccountsRouter } from './routes/accounts';
+import { createGraphQLRouter } from './routes/graphql';
 import { ErrorResponse } from './types';
 import { AnchorStore } from './db/anchorStore';
 import { Server as SocketIOServer } from 'socket.io';
@@ -189,6 +190,13 @@ export function createApp(options: AppOptions = {}): Application {
 
   // Accounts — Stellar fee estimation and XLM balance (Issue #949)
   app.use('/api/accounts', createAccountsRouter());
+
+  // GraphQL — authenticated, depth/complexity limited (SR-050). The router
+  // existed but was never mounted, so the endpoint was unreachable.
+  app.use('/api/graphql', createGraphQLRouter({
+    pool: analyticsPool ?? undefined,
+    remittanceStore: options.remittanceStore,
+  }));
 
   // WebSocket health endpoint (development only — guarded inside the router)
   if (options.io) {

--- a/api/src/graphql/resolvers.ts
+++ b/api/src/graphql/resolvers.ts
@@ -1,5 +1,4 @@
 import { Pool } from 'pg';
-import DataLoader from 'dataloader';
 
 export interface RemittanceStore {
   queryWithCursor(
@@ -15,24 +14,22 @@ export interface RemittanceStore {
 }
 
 /**
- * DataLoader for batch loading remittances to prevent N+1 queries
+ * SR-050: batching note.
+ *
+ * A DataLoader lived here that claimed to prevent N+1 queries and did the
+ * opposite — it ignored the `ids` it was handed and called
+ * `queryWithCursor(null, 1)` once per id, which is the N+1 pattern it was named
+ * for. It was also never wired to a resolver, so it never ran.
+ *
+ * It has been removed rather than repaired: every resolver below already issues
+ * exactly one query per collection (a single aggregate SELECT, or one lookup for
+ * a single-record field), which is the property the acceptance criteria ask for.
+ * `graphql-nplus1.test.ts` asserts that with a query counter.
+ *
+ * Reintroduce a loader only when a nested field genuinely resolves per-parent —
+ * and give it a real batch query (`WHERE id = ANY($1)`) rather than a loop.
  */
-function createRemittanceBatchLoader(remittanceStore: RemittanceStore) {
-  return new DataLoader(async (ids: (number | string)[]) => {
-    const results = await Promise.all(
-      ids.map((id) =>
-        remittanceStore.queryWithCursor(null, 1).catch(() => null),
-      ),
-    );
-    return results;
-  });
-}
-
 export function createResolvers(pool: Pool, remittanceStore?: RemittanceStore) {
-  const remittanceBatchLoader = remittanceStore
-    ? createRemittanceBatchLoader(remittanceStore)
-    : null;
-
   return {
     remittances: async (
       _: unknown,

--- a/api/src/graphql/security.ts
+++ b/api/src/graphql/security.ts
@@ -1,0 +1,216 @@
+/**
+ * GraphQL security rules (SR-050).
+ *
+ * These run as **validation** rules, which is the important part: validation
+ * happens after parsing and before execution, so a query that busts a budget is
+ * rejected without a single resolver — or database query — running. A limit
+ * enforced inside resolvers would already have paid the cost it exists to avoid.
+ *
+ * Three rules are provided:
+ *
+ *  - `createDepthLimitRule` — bounds nesting. Without it, a recursive selection
+ *    is a trivial denial-of-service: each level multiplies the work.
+ *  - `createComplexityRule` — bounds total cost, accounting for list
+ *    multipliers. Depth alone is not enough: a shallow query requesting a
+ *    thousand items across several list fields is cheap by depth and expensive
+ *    to serve.
+ *  - `noIntrospectionRule` — hides the schema in production, where the full
+ *    internal data model is a reconnaissance gift.
+ */
+
+import {
+  ASTNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  GraphQLError,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+  SelectionSetNode,
+  ValidationContext,
+} from 'graphql';
+import type { ValidationRule } from 'graphql/validation/ValidationContext';
+
+/** Defaults, overridable per deployment via env. */
+export const DEFAULT_MAX_DEPTH = 8;
+export const DEFAULT_MAX_COMPLEXITY = 1000;
+/** Assumed page size when a list field does not specify one. */
+export const DEFAULT_LIST_SIZE = 20;
+
+export function configuredMaxDepth(): number {
+  const raw = Number(process.env.GRAPHQL_MAX_DEPTH);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_DEPTH;
+}
+
+export function configuredMaxComplexity(): number {
+  const raw = Number(process.env.GRAPHQL_MAX_COMPLEXITY);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_COMPLEXITY;
+}
+
+/** Introspection is disabled in production only. */
+export function introspectionDisabled(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+function isIntrospectionField(name: string): boolean {
+  return name === '__schema' || name === '__type';
+}
+
+/**
+ * Rejects a query whose selection nesting exceeds `maxDepth`.
+ *
+ * Fragments are resolved as they are encountered so a query cannot dodge the
+ * limit by hiding depth behind a fragment spread.
+ */
+export function createDepthLimitRule(maxDepth: number) {
+  return (context: ValidationContext) => {
+    const fragments = context.getDocument().definitions.reduce<Record<string, FragmentDefinitionNode>>(
+      (acc, def) => {
+        if (def.kind === 'FragmentDefinition') acc[def.name.value] = def;
+        return acc;
+      },
+      {},
+    );
+
+    /** Guards against a fragment cycle sending this into infinite recursion. */
+    function depthOf(node: SelectionSetNode, current: number, seen: Set<string>): number {
+      let deepest = current;
+
+      for (const selection of node.selections) {
+        if (selection.kind === 'Field') {
+          const field = selection as FieldNode;
+          if (field.selectionSet) {
+            deepest = Math.max(deepest, depthOf(field.selectionSet, current + 1, seen));
+          } else {
+            deepest = Math.max(deepest, current);
+          }
+        } else if (selection.kind === 'InlineFragment') {
+          const inline = selection as InlineFragmentNode;
+          deepest = Math.max(deepest, depthOf(inline.selectionSet, current, seen));
+        } else if (selection.kind === 'FragmentSpread') {
+          const spread = selection as FragmentSpreadNode;
+          if (seen.has(spread.name.value)) continue; // cycle — stop descending
+          const fragment = fragments[spread.name.value];
+          if (fragment) {
+            const nextSeen = new Set(seen).add(spread.name.value);
+            deepest = Math.max(deepest, depthOf(fragment.selectionSet, current, nextSeen));
+          }
+        }
+      }
+
+      return deepest;
+    }
+
+    return {
+      OperationDefinition(operation: OperationDefinitionNode) {
+        const depth = depthOf(operation.selectionSet, 1, new Set());
+        if (depth > maxDepth) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum depth of ${maxDepth} (got ${depth})`,
+              { nodes: [operation as ASTNode], extensions: { code: 'QUERY_TOO_DEEP', maxDepth, depth } },
+            ),
+          );
+        }
+      },
+    };
+  };
+}
+
+/**
+ * Rejects a query whose estimated cost exceeds `maxComplexity`.
+ *
+ * Cost model: each field costs 1, and a field's children are multiplied by the
+ * list size it requests (`limit`, else `DEFAULT_LIST_SIZE`). That multiplier is
+ * the point — `remittances(limit: 500) { ...20 fields }` is shallow but serves
+ * 10,000 values.
+ */
+export function createComplexityRule(maxComplexity: number) {
+  return (context: ValidationContext) => {
+    const fragments = context.getDocument().definitions.reduce<Record<string, FragmentDefinitionNode>>(
+      (acc, def) => {
+        if (def.kind === 'FragmentDefinition') acc[def.name.value] = def;
+        return acc;
+      },
+      {},
+    );
+
+    function listMultiplier(field: FieldNode): number {
+      const limitArg = field.arguments?.find((a) => a.name.value === 'limit');
+      if (limitArg && limitArg.value.kind === 'IntValue') {
+        const parsed = parseInt(limitArg.value.value, 10);
+        if (Number.isFinite(parsed) && parsed > 0) return parsed;
+      }
+      // A list field with no explicit limit still returns a page of rows.
+      return field.selectionSet ? DEFAULT_LIST_SIZE : 1;
+    }
+
+    function costOf(node: SelectionSetNode, seen: Set<string>): number {
+      let total = 0;
+
+      for (const selection of node.selections) {
+        if (selection.kind === 'Field') {
+          const field = selection as FieldNode;
+          total += 1;
+          if (field.selectionSet) {
+            total += listMultiplier(field) * costOf(field.selectionSet, seen);
+          }
+        } else if (selection.kind === 'InlineFragment') {
+          total += costOf((selection as InlineFragmentNode).selectionSet, seen);
+        } else if (selection.kind === 'FragmentSpread') {
+          const spread = selection as FragmentSpreadNode;
+          if (seen.has(spread.name.value)) continue;
+          const fragment = fragments[spread.name.value];
+          if (fragment) {
+            total += costOf(fragment.selectionSet, new Set(seen).add(spread.name.value));
+          }
+        }
+      }
+
+      return total;
+    }
+
+    return {
+      OperationDefinition(operation: OperationDefinitionNode) {
+        const cost = costOf(operation.selectionSet, new Set());
+        if (cost > maxComplexity) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum complexity of ${maxComplexity} (got ${cost})`,
+              {
+                nodes: [operation as ASTNode],
+                extensions: { code: 'QUERY_TOO_COMPLEX', maxComplexity, complexity: cost },
+              },
+            ),
+          );
+        }
+      },
+    };
+  };
+}
+
+/** Rejects any introspection selection. Applied only when in production. */
+export function noIntrospectionRule(context: ValidationContext) {
+  return {
+    Field(node: FieldNode) {
+      if (isIntrospectionField(node.name.value)) {
+        context.reportError(
+          new GraphQLError(
+            'GraphQL introspection is disabled in production',
+            { nodes: [node], extensions: { code: 'INTROSPECTION_DISABLED' } },
+          ),
+        );
+      }
+    },
+  };
+}
+
+/** The rule set for a request, assembled from the current configuration. */
+export function securityRules(): ValidationRule[] {
+  const rules: ValidationRule[] = [
+    createDepthLimitRule(configuredMaxDepth()) as ValidationRule,
+    createComplexityRule(configuredMaxComplexity()) as ValidationRule,
+  ];
+  if (introspectionDisabled()) rules.push(noIntrospectionRule as ValidationRule);
+  return rules;
+}

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,0 +1,224 @@
+/**
+ * HTTP JWT authentication middleware (SR-047, SR-048).
+ *
+ * Before this module the API issued access tokens in `routes/auth.ts` but never
+ * verified one on any HTTP route — `jwt.verify` existed only in the Socket.IO
+ * middleware. Every guard below is therefore new enforcement, not a refactor.
+ *
+ * Threat model addressed here:
+ *
+ *  - **`alg: none`** — an unsigned token is accepted by naive verification.
+ *    Mitigated by pinning `algorithms: ['HS256']`; `jsonwebtoken` rejects any
+ *    other `alg` in the header, including `none`.
+ *  - **HS/RS confusion** — a token signed with the public key as an HMAC secret
+ *    verifies if the algorithm is taken from the header. The same pin prevents it.
+ *  - **Cross-service replay** — a token minted for another audience is rejected
+ *    by the `issuer`/`audience` checks.
+ *  - **Post-logout use** — access tokens are self-contained, so logout cannot
+ *    delete them. Each carries a `jti` that logout adds to a revocation list.
+ *  - **Privilege escalation** — `role` is checked explicitly; a user token can
+ *    never satisfy an admin guard.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { isAccessTokenRevoked } from '../services/tokenStore.js';
+import { ErrorResponse } from '../types';
+
+/** The single signing algorithm this API accepts. */
+export const JWT_ALGORITHM = 'HS256' as const;
+export const JWT_ISSUER = 'swiftremit-api';
+export const JWT_AUDIENCE = 'swiftremit-clients';
+
+export type UserRole = 'user' | 'agent' | 'admin';
+
+export interface AccessTokenClaims {
+  sub: string;
+  role: UserRole;
+  jti: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  iat?: number;
+}
+
+/** The authenticated caller, attached to the request after a successful guard. */
+export interface AuthContext {
+  userId: string;
+  role: UserRole;
+  jti: string;
+  /** The token's own expiry, needed to bound a revocation entry. */
+  expiresAt: number;
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    auth?: AuthContext;
+  }
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  message: string,
+  code: string,
+): Response<ErrorResponse> {
+  return res.status(status).json({
+    success: false,
+    error: { message, code },
+    timestamp: timestamp(),
+  });
+}
+
+/** Pulls a bearer token out of the Authorization header. */
+export function extractBearerToken(req: Request): string | null {
+  const header = req.get('authorization');
+  if (!header) return null;
+
+  const [scheme, ...rest] = header.split(' ');
+  if (!scheme || scheme.toLowerCase() !== 'bearer') return null;
+
+  const token = rest.join(' ').trim();
+  return token.length > 0 ? token : null;
+}
+
+export type VerifyResult =
+  | { ok: true; auth: AuthContext }
+  | { ok: false; status: number; message: string; code: string };
+
+/**
+ * Verifies an access token against the full threat model above.
+ *
+ * Exported separately from the middleware so non-Express callers (the GraphQL
+ * executor, tests) can reuse exactly the same checks rather than reimplementing
+ * a weaker subset.
+ */
+export function verifyAccessToken(token: string): VerifyResult {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    return {
+      ok: false,
+      status: 503,
+      message: 'Auth service not configured',
+      code: 'SERVICE_UNAVAILABLE',
+    };
+  }
+
+  let claims: AccessTokenClaims;
+  try {
+    // Pinning `algorithms` is what rejects `alg: none` and HS/RS confusion.
+    claims = jwt.verify(token, secret, {
+      algorithms: [JWT_ALGORITHM],
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+    }) as AccessTokenClaims;
+  } catch (error) {
+    const expired = error instanceof jwt.TokenExpiredError;
+    return {
+      ok: false,
+      status: 401,
+      message: expired ? 'Token expired' : 'Invalid token',
+      code: expired ? 'TOKEN_EXPIRED' : 'INVALID_TOKEN',
+    };
+  }
+
+  if (!claims.jti || typeof claims.sub !== 'string' || !claims.sub) {
+    return { ok: false, status: 401, message: 'Invalid token', code: 'INVALID_TOKEN' };
+  }
+
+  // Logout and family revocation both land here.
+  if (isAccessTokenRevoked(claims.jti)) {
+    return { ok: false, status: 401, message: 'Token revoked', code: 'TOKEN_REVOKED' };
+  }
+
+  const role: UserRole =
+    claims.role === 'admin' || claims.role === 'agent' ? claims.role : 'user';
+
+  return {
+    ok: true,
+    auth: { userId: claims.sub, role, jti: claims.jti, expiresAt: claims.exp ?? 0 },
+  };
+}
+
+/**
+ * Requires a valid access token. Attaches `req.auth` on success.
+ *
+ * Fails closed: any missing, malformed, expired, or revoked token is a 401 and
+ * the handler never runs.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void | Response {
+  const token = extractBearerToken(req);
+  if (!token) {
+    return sendError(res, 401, 'Authentication required', 'UNAUTHORIZED');
+  }
+
+  const result = verifyAccessToken(token);
+  if (!result.ok) {
+    return sendError(res, result.status, result.message, result.code);
+  }
+
+  req.auth = result.auth;
+  next();
+}
+
+/**
+ * Requires one of `roles` in addition to a valid token.
+ *
+ * `admin` deliberately does NOT satisfy an `agent`-only guard implicitly; list
+ * every role a route accepts so the matrix stays readable and auditable.
+ */
+export function requireRole(...roles: UserRole[]) {
+  return (req: Request, res: Response, next: NextFunction): void | Response => {
+    const token = extractBearerToken(req);
+    if (!token) {
+      return sendError(res, 401, 'Authentication required', 'UNAUTHORIZED');
+    }
+
+    const result = verifyAccessToken(token);
+    if (!result.ok) {
+      return sendError(res, result.status, result.message, result.code);
+    }
+
+    if (!roles.includes(result.auth.role)) {
+      // 403, not 401: the caller is authenticated but not permitted.
+      return sendError(res, 403, 'Insufficient privileges', 'FORBIDDEN');
+    }
+
+    req.auth = result.auth;
+    next();
+  };
+}
+
+/** Admin-only guard. A user or agent token can never satisfy this. */
+export const requireAdmin = requireRole('admin');
+
+/** Agent or admin — used for agent registration and payout-address changes. */
+export const requireAgentOrAdmin = requireRole('agent', 'admin');
+
+/**
+ * Ownership check for a resource keyed by an address or user id.
+ *
+ * Admins bypass; everyone else must match. Returns false and sends the response
+ * when access is denied, so callers can `if (!ensureOwnership(...)) return;`.
+ */
+export function ensureOwnership(req: Request, res: Response, ownerId: string): boolean {
+  const auth = req.auth;
+  if (!auth) {
+    sendError(res, 401, 'Authentication required', 'UNAUTHORIZED');
+    return false;
+  }
+
+  if (auth.role === 'admin') return true;
+
+  if (auth.userId !== ownerId) {
+    // 404 would leak less, but the route contract here is an explicit 403.
+    sendError(res, 403, 'You do not have access to this resource', 'FORBIDDEN');
+    return false;
+  }
+
+  return true;
+}

--- a/api/src/middleware/idempotency.ts
+++ b/api/src/middleware/idempotency.ts
@@ -1,86 +1,259 @@
+/**
+ * Idempotency-key middleware (Issue #878, hardened for SR-049).
+ *
+ * Correct idempotency needs three properties that are easy to miss, and the
+ * previous implementation had none of them:
+ *
+ *  1. **Body binding.** The same key with a different body must conflict.
+ *     Previously the cached response was replayed for ANY body, so a client
+ *     reusing a key with a new amount silently received the old result and the
+ *     new transfer never happened.
+ *  2. **Concurrency.** Two simultaneous requests with one key must execute the
+ *     operation once. Previously both missed the cache and both executed —
+ *     precisely the double-spend an idempotency key exists to prevent.
+ *  3. **Verbatim replay.** The replay must reproduce the original status,
+ *     headers, and body. Previously the status was replayed but the stored
+ *     headers were never reapplied.
+ *
+ * Storage is in-memory, matching the convention elsewhere in this codebase.
+ * Behind more than one instance the guarantees hold only per process; a shared
+ * store (Redis) is required before horizontal scaling. See AUTH_MATRIX.md.
+ */
+
 import { Request, Response, NextFunction } from 'express';
-import Cache from 'node-cache';
+import crypto from 'crypto';
 
-const IDEMPOTENCY_CACHE_TTL = 86400; // 24 hours in seconds
+/** How long a completed record is replayable. Documented in API.md. */
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-interface CachedResponse {
+/** How long to wait for an in-flight request with the same key before giving up. */
+const INFLIGHT_TIMEOUT_MS = 30_000;
+
+/**
+ * Paths where a key is mandatory. These move money, so a retry without a key
+ * risks a duplicate transfer.
+ */
+const MONEY_MOVING_PATH = /^\/api\/(remittances|settlements|agents)(\/|$)/;
+
+interface CompletedRecord {
+  state: 'completed';
+  bodyHash: string;
   status: number;
-  body: unknown;
   headers: Record<string, string>;
-  timestamp: number;
+  /** Serialized exactly as sent, so the replay is byte-identical. */
+  payload: string;
+  createdAt: number;
 }
 
-/**
- * In-memory cache for idempotency responses
- * Production: Use Redis instead
- */
-const idempotencyCache = new Cache({ stdTTL: IDEMPOTENCY_CACHE_TTL });
-
-/**
- * Middleware to handle idempotency keys on POST requests
- * RFC 7231: Idempotent Methods & 7232 Cache
- */
-export function idempotencyMiddleware(req: Request, res: Response, next: NextFunction) {
-  if (req.method !== 'POST') {
-    return next();
-  }
-
-  const idempotencyKey = req.get('Idempotency-Key');
-  if (!idempotencyKey) {
-    return next();
-  }
-
-  const cacheKey = `${req.path}:${idempotencyKey}`;
-  const cached = idempotencyCache.get<CachedResponse>(cacheKey);
-
-  if (cached) {
-    res.status(cached.status);
-    res.set('Idempotency-Key', idempotencyKey);
-    res.set('Cache-Control', 'private, no-store');
-    return res.json(cached.body);
-  }
-
-  // Override res.json to cache response
-  const originalJson = res.json.bind(res);
-  res.json = function (body: unknown) {
-    res.set('Idempotency-Key', idempotencyKey);
-    res.set('Cache-Control', 'private, no-store');
-    
-    const response: CachedResponse = {
-      status: res.statusCode,
-      body,
-      headers: {
-        'Idempotency-Key': idempotencyKey,
-        'Cache-Control': 'private, no-store',
-      },
-      timestamp: Date.now(),
-    };
-    idempotencyCache.set(cacheKey, response);
-    return originalJson(body);
-  };
-
-  next();
+interface InFlightRecord {
+  state: 'in-flight';
+  bodyHash: string;
+  createdAt: number;
+  /** Resolves when the original request finishes. */
+  done: Promise<void>;
+  resolve: () => void;
 }
 
-/**
- * Validate idempotency key format (UUID v4 specifically)
- */
+type Record_ = CompletedRecord | InFlightRecord;
+
+const store = new Map<string, Record_>();
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+/** Stable hash of the request body — key order must not change the result. */
+export function hashRequestBody(body: unknown): string {
+  return crypto.createHash('sha256').update(canonicalize(body)).digest('hex');
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value ?? null);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`);
+  return `{${entries.join(',')}}`;
+}
+
+/** Validate idempotency key format (UUID v4 specifically). */
 export function validateIdempotencyKey(key: string): boolean {
-  // UUID v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx where y is 8, 9, a, or b
   const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return uuidv4Pattern.test(key);
 }
 
-/**
- * Clear idempotency cache for testing
- */
-export function clearIdempotencyCache(): void {
-  idempotencyCache.flushAll();
+function sendError(res: Response, status: number, message: string, code: string) {
+  return res.status(status).json({
+    success: false,
+    error: { message, code },
+    timestamp: timestamp(),
+  });
 }
 
-/**
- * Get cache stats for monitoring
- */
+function replay(res: Response, record: CompletedRecord, key: string): void {
+  for (const [name, value] of Object.entries(record.headers)) {
+    res.set(name, value);
+  }
+  res.set('Idempotency-Key', key);
+  res.set('Idempotent-Replay', 'true');
+  res.status(record.status).send(record.payload);
+}
+
+function pruneExpired(): void {
+  const now = Date.now();
+  for (const [key, record] of store) {
+    const age = now - record.createdAt;
+    if (record.state === 'completed' && age > IDEMPOTENCY_TTL_MS) store.delete(key);
+    // An in-flight record whose request died would otherwise wedge the key.
+    if (record.state === 'in-flight' && age > INFLIGHT_TIMEOUT_MS) store.delete(key);
+  }
+}
+
+export interface IdempotencyOptions {
+  /** Paths where a key is mandatory. Defaults to the money-moving routes. */
+  requiredPathPattern?: RegExp | null;
+}
+
+export function createIdempotencyMiddleware(options: IdempotencyOptions = {}) {
+  const requiredPathPattern =
+    options.requiredPathPattern === undefined ? MONEY_MOVING_PATH : options.requiredPathPattern;
+
+  return async function idempotency(req: Request, res: Response, next: NextFunction) {
+    if (req.method !== 'POST') return next();
+
+    pruneExpired();
+
+    const key = req.get('Idempotency-Key');
+    const keyRequired = requiredPathPattern !== null && requiredPathPattern.test(req.path);
+
+    if (!key) {
+      if (keyRequired) {
+        return sendError(
+          res,
+          400,
+          'Idempotency-Key header is required for this endpoint',
+          'IDEMPOTENCY_KEY_REQUIRED',
+        );
+      }
+      return next();
+    }
+
+    if (!validateIdempotencyKey(key)) {
+      return sendError(
+        res,
+        400,
+        'Idempotency-Key must be a UUID v4',
+        'INVALID_IDEMPOTENCY_KEY',
+      );
+    }
+
+    const cacheKey = `${req.path}:${key}`;
+    const bodyHash = hashRequestBody(req.body);
+    const existing = store.get(cacheKey);
+
+    if (existing) {
+      // Same key, different body — the client changed the operation mid-retry.
+      if (existing.bodyHash !== bodyHash) {
+        return sendError(
+          res,
+          409,
+          'Idempotency-Key was already used with a different request body',
+          'IdempotencyConflict',
+        );
+      }
+
+      if (existing.state === 'completed') {
+        return replay(res, existing, key);
+      }
+
+      // A concurrent duplicate. Wait for the original rather than executing a
+      // second time, then replay its result so both callers see one operation.
+      await Promise.race([
+        existing.done,
+        new Promise((resolve) => setTimeout(resolve, INFLIGHT_TIMEOUT_MS)),
+      ]);
+
+      const settled = store.get(cacheKey);
+      if (settled && settled.state === 'completed') {
+        return replay(res, settled, key);
+      }
+      return sendError(
+        res,
+        409,
+        'A request with this Idempotency-Key is still in progress',
+        'IdempotencyConflict',
+      );
+    }
+
+    // Claim the key before the handler runs. This insert is what makes a
+    // concurrent duplicate observe an in-flight record instead of a miss.
+    let resolveDone!: () => void;
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve;
+    });
+    store.set(cacheKey, {
+      state: 'in-flight',
+      bodyHash,
+      createdAt: Date.now(),
+      done,
+      resolve: resolveDone,
+    });
+
+    res.set('Idempotency-Key', key);
+    res.set('Cache-Control', 'private, no-store');
+
+    const finish = (payload: string) => {
+      store.set(cacheKey, {
+        state: 'completed',
+        bodyHash,
+        status: res.statusCode,
+        headers: {
+          'Content-Type': res.get('Content-Type') ?? 'application/json; charset=utf-8',
+          'Cache-Control': 'private, no-store',
+        },
+        payload,
+        createdAt: Date.now(),
+      });
+      resolveDone();
+    };
+
+    const originalJson = res.json.bind(res);
+    res.json = function (body: unknown) {
+      finish(JSON.stringify(body));
+      return originalJson(body);
+    };
+
+    // If the handler throws or the connection drops, release the claim so the
+    // key is retryable rather than wedged until the in-flight timeout.
+    res.on('close', () => {
+      const current = store.get(cacheKey);
+      if (current && current.state === 'in-flight') {
+        store.delete(cacheKey);
+        current.resolve();
+      }
+    });
+
+    next();
+  };
+}
+
+/** Default middleware — a key is mandatory on money-moving POSTs. */
+export const idempotencyMiddleware = createIdempotencyMiddleware();
+
+/** Clear idempotency cache for testing. */
+export function clearIdempotencyCache(): void {
+  store.clear();
+}
+
+/** Get cache stats for monitoring. */
 export function getIdempotencyCacheStats() {
-  return idempotencyCache.getStats();
+  let completed = 0;
+  let inFlight = 0;
+  for (const record of store.values()) {
+    if (record.state === 'completed') completed += 1;
+    else inFlight += 1;
+  }
+  return { keys: store.size, completed, inFlight };
 }

--- a/api/src/routes/accounts.ts
+++ b/api/src/routes/accounts.ts
@@ -10,6 +10,7 @@
 
 import { Router, Request, Response } from 'express';
 import { ErrorResponse } from '../types';
+import { requireAuth } from '../middleware/auth.js';
 
 const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{54}$/;
 const XLM_STROOPS_PER_XLM = 10_000_000;
@@ -74,7 +75,7 @@ export function createAccountsRouter(): Router {
    *       404:
    *         description: Account not found on the network
    */
-  router.get('/:address/stellar-fees', async (req: Request, res: Response) => {
+  router.get('/:address/stellar-fees', requireAuth, async (req: Request, res: Response) => {
     const { address } = req.params;
     const operationsStr = (req.query.operations as string | undefined) ?? '1';
 

--- a/api/src/routes/agents.ts
+++ b/api/src/routes/agents.ts
@@ -9,6 +9,7 @@
 import { Router, Request, Response } from 'express';
 import { ErrorResponse } from '../types';
 import { sanitizeInput } from '../utils/sanitize.js';
+import { extractBearerToken, verifyAccessToken } from '../middleware/auth.js';
 
 function timestamp(): string {
   return new Date().toISOString();
@@ -20,10 +21,24 @@ function sendError(res: Response, status: number, message: string, code: string)
 
 const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{54}$/;
 
+/**
+ * Elevated authorisation for agent registration and payout-address changes
+ * (SR-048).
+ *
+ * Accepts either the pre-existing shared admin API key or a verified access
+ * token carrying the `agent` or `admin` role. The API-key path is kept so
+ * existing operational tooling keeps working; the token path is what lets an
+ * individual agent act as themselves instead of sharing one secret.
+ */
 function isAdminAuthorized(req: Request): boolean {
   const adminKey = process.env.ADMIN_API_KEY;
-  if (!adminKey) return false;
-  return req.headers['x-api-key'] === adminKey;
+  if (adminKey && req.headers['x-api-key'] === adminKey) return true;
+
+  const token = extractBearerToken(req);
+  if (!token) return false;
+
+  const result = verifyAccessToken(token);
+  return result.ok && (result.auth.role === 'agent' || result.auth.role === 'admin');
 }
 
 export interface Agent {

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,14 +1,21 @@
 /**
- * JWT authentication endpoints (Issue #883).
+ * JWT authentication endpoints (Issue #883, hardened for SR-047).
  *
  * POST /api/auth/login   - Issue short-lived access token + HttpOnly refresh token
  * POST /api/auth/refresh - Rotate refresh token and issue new access token
- * POST /api/auth/logout  - Revoke refresh token (cookie cleared)
+ * POST /api/auth/logout  - Revoke the refresh family AND the presented access token
  *
  * Access token TTL:  15 minutes
- * Refresh token TTL: 7 days (stored in HttpOnly, Secure, SameSite=Strict cookie)
+ * Refresh token TTL: 7 days (HttpOnly, Secure, SameSite=Strict cookie)
  *
- * Refresh tokens are single-use — each refresh rotates the token to prevent reuse.
+ * What SR-047 changed:
+ *  - Access tokens carry `jti`, `iss`, `aud`, and `role`, and are signed with a
+ *    pinned algorithm so `alg: none` and HS/RS confusion are rejected on verify.
+ *  - Refresh tokens belong to a family. Redeeming a spent token is treated as a
+ *    leak and revokes the whole family rather than that one token.
+ *  - Logout revokes the access token too. Previously it deleted the refresh
+ *    token while the access token stayed valid for up to 15 minutes.
+ *  - Login is throttled per identity with lockout.
  */
 
 import { Router, Request, Response } from 'express';
@@ -16,6 +23,25 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { ErrorResponse } from '../types';
 import { sanitizeInput } from '../utils/sanitize.js';
+import {
+  JWT_ALGORITHM,
+  JWT_AUDIENCE,
+  JWT_ISSUER,
+  UserRole,
+  extractBearerToken,
+  verifyAccessToken,
+} from '../middleware/auth.js';
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  REFRESH_TOKEN_TTL_MS,
+  clearLoginFailures,
+  isLockedOut,
+  issueRefreshToken,
+  recordLoginFailure,
+  revokeAccessToken,
+  revokeFamily,
+  rotateRefreshToken,
+} from '../services/tokenStore.js';
 
 function timestamp(): string {
   return new Date().toISOString();
@@ -25,23 +51,20 @@ function sendError(res: Response, status: number, message: string, code: string)
   return res.status(status).json({ success: false, error: { message, code }, timestamp: timestamp() });
 }
 
-const ACCESS_TOKEN_TTL = '15m';
-const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
 const REFRESH_COOKIE = 'swiftremit_refresh';
 
-/** In-memory refresh-token store: token → { userId, expiresAt } */
-const refreshTokenStore = new Map<string, { userId: string; expiresAt: number }>();
-
-function issueAccessToken(userId: string): string {
+function issueAccessToken(userId: string, role: UserRole): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) throw new Error('JWT_SECRET not configured');
-  return jwt.sign({ userId }, secret, { expiresIn: ACCESS_TOKEN_TTL });
-}
 
-function issueRefreshToken(userId: string): string {
-  const token = crypto.randomBytes(40).toString('hex');
-  refreshTokenStore.set(token, { userId, expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS });
-  return token;
+  return jwt.sign({ role }, secret, {
+    algorithm: JWT_ALGORITHM,
+    subject: userId,
+    issuer: JWT_ISSUER,
+    audience: JWT_AUDIENCE,
+    expiresIn: ACCESS_TOKEN_TTL_SECONDS,
+    jwtid: crypto.randomBytes(16).toString('hex'),
+  });
 }
 
 function setCookieOptions() {
@@ -54,15 +77,53 @@ function setCookieOptions() {
   };
 }
 
+/**
+ * Resolves the role for a user id.
+ *
+ * Admin identities come from ADMIN_USER_IDS so admin status is never derived
+ * from anything the client sends. Integrate with the real user store when one
+ * exists.
+ */
+function resolveRole(userId: string): UserRole {
+  const admins = (process.env.ADMIN_USER_IDS ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (admins.includes(userId)) return 'admin';
+
+  const agents = (process.env.AGENT_USER_IDS ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (agents.includes(userId)) return 'agent';
+
+  return 'user';
+}
+
+/**
+ * Stubbed credential check.
+ *
+ * Previously this accepted ANY password when NODE_ENV=test, so the test suite
+ * exercised an auth path that could never fail. It now requires a configured
+ * password in every environment.
+ */
+function verifyCredentials(password: string): boolean {
+  const expected = process.env.STUB_PASSWORD;
+  if (!expected) return false;
+
+  const given = Buffer.from(password);
+  const want = Buffer.from(expected);
+  if (given.length !== want.length) return false;
+
+  return crypto.timingSafeEqual(given, want);
+}
+
 export function createAuthRouter(): Router {
   const router = Router();
 
   /**
    * POST /api/auth/login
    * Body: { userId: string, password: string }
-   *
-   * NOTE: Password verification is intentionally stubbed — integrate with
-   * your user store / KYC service for production use.
    */
   router.post('/login', (req: Request, res: Response) => {
     const { userId, password } = req.body as Record<string, unknown>;
@@ -79,28 +140,56 @@ export function createAuthRouter(): Router {
       return sendError(res, 503, 'Auth service not configured', 'SERVICE_UNAVAILABLE');
     }
 
-    // Stub credential check — replace with real user lookup in production
-    if (password !== process.env.STUB_PASSWORD && process.env.NODE_ENV !== 'test') {
+    const sanitizedUserId = sanitizeInput(userId.trim());
+
+    if (isLockedOut(sanitizedUserId)) {
+      return sendError(
+        res,
+        429,
+        'Too many failed login attempts. Try again later.',
+        'ACCOUNT_LOCKED',
+      );
+    }
+
+    if (!verifyCredentials(password)) {
+      const lockedNow = recordLoginFailure(sanitizedUserId);
+      if (lockedNow) {
+        return sendError(
+          res,
+          429,
+          'Too many failed login attempts. Try again later.',
+          'ACCOUNT_LOCKED',
+        );
+      }
+      // Same message either way — never reveal whether the identity exists.
       return sendError(res, 401, 'Invalid credentials', 'INVALID_CREDENTIALS');
     }
 
-    const sanitizedUserId = sanitizeInput(userId.trim());
-    const accessToken = issueAccessToken(sanitizedUserId);
-    const refreshToken = issueRefreshToken(sanitizedUserId);
+    clearLoginFailures(sanitizedUserId);
+
+    const role = resolveRole(sanitizedUserId);
+    const accessToken = issueAccessToken(sanitizedUserId, role);
+    const { token: refreshToken } = issueRefreshToken(sanitizedUserId, role);
 
     res.cookie(REFRESH_COOKIE, refreshToken, setCookieOptions());
 
     return res.json({
       success: true,
-      data: { access_token: accessToken, token_type: 'Bearer', expires_in: 900 },
+      data: {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_TTL_SECONDS,
+        role,
+      },
       timestamp: timestamp(),
     });
   });
 
   /**
    * POST /api/auth/refresh
-   * Reads refresh token from HttpOnly cookie.
-   * Rotates the refresh token (single-use) and returns a new access token.
+   *
+   * Rotates the refresh token. Presenting an already-redeemed token means it
+   * leaked, so the whole family is revoked and the caller must log in again.
    */
   router.post('/refresh', (req: Request, res: Response) => {
     const token = req.cookies?.[REFRESH_COOKIE] as string | undefined;
@@ -114,47 +203,73 @@ export function createAuthRouter(): Router {
       return sendError(res, 503, 'Auth service not configured', 'SERVICE_UNAVAILABLE');
     }
 
-    const entry = refreshTokenStore.get(token);
-    if (!entry) {
+    const outcome = rotateRefreshToken(token);
+
+    if (!outcome.ok) {
       res.clearCookie(REFRESH_COOKIE, { path: '/api/auth' });
+
+      if (outcome.reason === 'reused') {
+        // The family is already revoked by the store; surface it for alerting.
+        console.error(
+          '[SECURITY] Refresh token reuse detected — token family revoked. Investigate for credential theft.',
+        );
+        return sendError(
+          res,
+          401,
+          'Refresh token reuse detected. All sessions have been revoked.',
+          'REFRESH_TOKEN_REUSED',
+        );
+      }
+      if (outcome.reason === 'expired') {
+        return sendError(res, 401, 'Refresh token expired', 'REFRESH_TOKEN_EXPIRED');
+      }
       return sendError(res, 401, 'Invalid refresh token', 'INVALID_REFRESH_TOKEN');
     }
 
-    if (Date.now() > entry.expiresAt) {
-      refreshTokenStore.delete(token);
-      res.clearCookie(REFRESH_COOKIE, { path: '/api/auth' });
-      return sendError(res, 401, 'Refresh token expired', 'REFRESH_TOKEN_EXPIRED');
-    }
+    const { record, nextToken } = outcome;
+    const newAccessToken = issueAccessToken(record.userId, record.role as UserRole);
 
-    // Rotate — invalidate old token, issue new pair
-    refreshTokenStore.delete(token);
-    const newAccessToken = issueAccessToken(entry.userId);
-    const newRefreshToken = issueRefreshToken(entry.userId);
-
-    res.cookie(REFRESH_COOKIE, newRefreshToken, setCookieOptions());
+    res.cookie(REFRESH_COOKIE, nextToken as string, setCookieOptions());
 
     return res.json({
       success: true,
-      data: { access_token: newAccessToken, token_type: 'Bearer', expires_in: 900 },
+      data: {
+        access_token: newAccessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_TTL_SECONDS,
+        role: record.role,
+      },
       timestamp: timestamp(),
     });
   });
 
   /**
    * POST /api/auth/logout
-   * Revokes the refresh token and clears the cookie.
+   *
+   * Revokes the refresh family and the presented access token. Revoking only
+   * the refresh token would leave the access token usable until its own expiry.
    */
   router.post('/logout', (req: Request, res: Response) => {
-    const token = req.cookies?.[REFRESH_COOKIE] as string | undefined;
-    if (token) {
-      refreshTokenStore.delete(token);
+    const refreshToken = req.cookies?.[REFRESH_COOKIE] as string | undefined;
+    if (refreshToken) {
+      // Redeem first so the family id is resolvable, then burn the family.
+      const outcome = rotateRefreshToken(refreshToken);
+      if (outcome.ok) {
+        revokeFamily(outcome.record.familyId);
+      }
     }
+
+    const accessToken = extractBearerToken(req);
+    if (accessToken) {
+      const result = verifyAccessToken(accessToken);
+      if (result.ok) {
+        revokeAccessToken(result.auth.jti, result.auth.expiresAt);
+      }
+    }
+
     res.clearCookie(REFRESH_COOKIE, { path: '/api/auth' });
     return res.json({ success: true, timestamp: timestamp() });
   });
 
   return router;
 }
-
-/** Exported for test inspection / reset */
-export { refreshTokenStore };

--- a/api/src/routes/graphql.ts
+++ b/api/src/routes/graphql.ts
@@ -1,121 +1,265 @@
+/**
+ * GraphQL endpoint (SR-050).
+ *
+ * The previous implementation did not execute GraphQL at all. It regex-scraped
+ * the query string:
+ *
+ *     query.match(/remittances[^{]*\{([^}]+)\}/)
+ *
+ * and hand-assembled a response, while `graphql/schema.ts` and
+ * `graphql/resolvers.ts` were never wired to anything. That is why depth and
+ * complexity limits could not simply be "added" — there was no execution
+ * pipeline to attach them to.
+ *
+ * This route now parses, validates, and executes against the real schema, with:
+ *
+ *  1. Authentication on the transport — no anonymous queries.
+ *  2. Depth and complexity budgets enforced as validation rules, so an abusive
+ *     query is rejected before any resolver or database call runs.
+ *  3. Introspection disabled in production.
+ *  4. Field-level authorisation — an unauthorised field resolves to null with an
+ *     error entry, never data.
+ *  5. Per-operation rate limiting on top of the HTTP limiter.
+ *  6. One database round trip per collection — see the batching note in
+ *     `graphql/resolvers.ts`.
+ */
+
 import { Router, Request, Response } from 'express';
 import { Pool } from 'pg';
-import { RemittanceStore } from '../graphql/resolvers';
+import {
+  GraphQLError,
+  execute,
+  parse,
+  specifiedRules,
+  validate,
+  type GraphQLFieldResolver,
+} from 'graphql';
+import { typeDefs } from '../graphql/schema';
+import { RemittanceStore, createResolvers } from '../graphql/resolvers';
+import { securityRules } from '../graphql/security';
+import { UserRole, extractBearerToken, verifyAccessToken } from '../middleware/auth.js';
 
 export type GraphQLRouterOptions = {
   pool?: Pool;
   remittanceStore?: RemittanceStore;
+  /** Operations allowed per window, per identity. */
+  operationLimit?: number;
+  operationWindowMs?: number;
 };
 
+const DEFAULT_OPERATION_LIMIT = 30;
+const DEFAULT_OPERATION_WINDOW_MS = 60_000;
+
 /**
- * Parse and execute simplified GraphQL queries
- * Focuses on field selection without full GraphQL execution engine
+ * Fields only certain roles may select.
+ *
+ * Aggregate fee data reveals platform economics, so it is admin-only. Anything
+ * not listed is readable by any authenticated caller.
  */
-function parseQueryFields(query: string): {
-  type: string;
-  fields: string[];
-  variables?: Record<string, unknown>;
-} | null {
-  const remittancesMatch = query.match(/remittances[^{]*\{([^}]+)\}/);
-  const corridorsMatch = query.match(/corridors[^{]*\{([^}]+)\}/);
-  const agentsMatch = query.match(/agents\s*\{([^}]+)\}/);
+const RESTRICTED_FIELDS: Record<string, UserRole[]> = {
+  'Corridor.total_fees': ['admin'],
+  'Corridor.avg_fee': ['admin'],
+  'Agent.registered_at': ['admin', 'agent'],
+};
 
-  if (remittancesMatch) {
-    const fields = remittancesMatch[1]
-      .split('\n')
-      .map((f) => f.trim())
-      .filter(Boolean);
-    return { type: 'remittances', fields };
-  }
-  if (corridorsMatch) {
-    const fields = corridorsMatch[1]
-      .split('\n')
-      .map((f) => f.trim())
-      .filter(Boolean);
-    return { type: 'corridors', fields };
-  }
-  if (agentsMatch) {
-    const fields = agentsMatch[1]
-      .split('\n')
-      .map((f) => f.trim())
-      .filter(Boolean);
-    return { type: 'agents', fields };
-  }
-
-  return null;
+export interface GraphQLContext {
+  userId: string;
+  role: UserRole;
+  pool?: Pool;
+  remittanceStore?: RemittanceStore;
 }
+
+/** Per-identity sliding window for operation rate limiting. */
+const operationCounters = new Map<string, number[]>();
+
+function overOperationLimit(identity: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const hits = (operationCounters.get(identity) ?? []).filter((t) => now - t < windowMs);
+  hits.push(now);
+  operationCounters.set(identity, hits);
+  return hits.length > limit;
+}
+
+/** Test helper — clears the operation rate-limit state. */
+export function resetGraphQLRateLimit(): void {
+  operationCounters.clear();
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Default field resolver that enforces field-level authorisation.
+ *
+ * Throwing here makes GraphQL null the field and append an error, which is
+ * exactly the required behaviour: the caller learns the field exists and that
+ * they may not read it, and never receives its value.
+ */
+const authorizingFieldResolver: GraphQLFieldResolver<unknown, GraphQLContext> = (
+  source,
+  args,
+  context,
+  info,
+) => {
+  const qualified = `${info.parentType.name}.${info.fieldName}`;
+  const allowed = RESTRICTED_FIELDS[qualified];
+
+  if (allowed && !allowed.includes(context.role)) {
+    throw new GraphQLError(`Not authorised to read ${qualified}`, {
+      extensions: { code: 'FORBIDDEN_FIELD', field: qualified },
+    });
+  }
+
+  const record = source as Record<string, unknown> | null | undefined;
+  if (record == null) return null;
+
+  const value = record[info.fieldName];
+  // Mirror graphql's defaultFieldResolver: a function property is a resolver and
+  // must receive (args, context, info). Calling it bare would drop the arguments
+  // and silently return undefined for every root field.
+  return typeof value === 'function'
+    ? (value as (a: unknown, c: unknown, i: unknown) => unknown)(args, context, info)
+    : value;
+};
 
 export function createGraphQLRouter(options: GraphQLRouterOptions = {}): Router {
   const router = Router();
-  const { pool, remittanceStore } = options;
+  const {
+    pool,
+    remittanceStore,
+    operationLimit = DEFAULT_OPERATION_LIMIT,
+    operationWindowMs = DEFAULT_OPERATION_WINDOW_MS,
+  } = options;
 
   /**
    * POST /api/graphql
-   * Simplified GraphQL interface for flexible field selection
    */
   router.post('/', async (req: Request, res: Response) => {
-    const { query } = req.body;
-
-    if (!query) {
-      return res.status(400).json({
+    // 1 — authenticate the transport.
+    const token = extractBearerToken(req);
+    if (!token) {
+      return res.status(401).json({
         success: false,
-        error: {
-          message: 'Query is required',
-          code: 'INVALID_QUERY',
-        },
-        timestamp: new Date().toISOString(),
+        error: { message: 'Authentication required', code: 'UNAUTHORIZED' },
+        timestamp: timestamp(),
       });
     }
 
+    const authResult = verifyAccessToken(token);
+    if (!authResult.ok) {
+      return res.status(authResult.status).json({
+        success: false,
+        error: { message: authResult.message, code: authResult.code },
+        timestamp: timestamp(),
+      });
+    }
+    const { userId, role } = authResult.auth;
+
+    // 2 — per-operation rate limit, above the HTTP limiter.
+    if (overOperationLimit(userId, operationLimit, operationWindowMs)) {
+      return res.status(429).json({
+        success: false,
+        error: {
+          message: 'Too many GraphQL operations. Slow down.',
+          code: 'OPERATION_RATE_LIMITED',
+        },
+        timestamp: timestamp(),
+      });
+    }
+
+    const { query, variables, operationName } = (req.body ?? {}) as {
+      query?: unknown;
+      variables?: Record<string, unknown>;
+      operationName?: string;
+    };
+
+    if (typeof query !== 'string' || query.trim().length === 0) {
+      return res.status(400).json({
+        success: false,
+        error: { message: 'Query is required', code: 'INVALID_QUERY' },
+        timestamp: timestamp(),
+      });
+    }
+
+    // 3 — parse.
+    let document;
     try {
-      const parsed = parseQueryFields(query);
+      document = parse(query);
+    } catch (error) {
+      return res.status(400).json({
+        success: false,
+        errors: [
+          {
+            message: error instanceof Error ? error.message : 'Could not parse query',
+            code: 'INVALID_QUERY',
+          },
+        ],
+        timestamp: timestamp(),
+      });
+    }
 
-      if (!parsed) {
-        return res.status(400).json({
-          success: false,
-          errors: [
-            {
-              message: 'Invalid query format',
-              code: 'INVALID_QUERY',
-            },
-          ],
-          timestamp: new Date().toISOString(),
-        });
-      }
+    // 4 — validate, including the depth/complexity/introspection budgets. This
+    // runs before execution, so a rejected query costs no database work.
+    const validationErrors = validate(typeDefs, document, [...specifiedRules, ...securityRules()]);
+    if (validationErrors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        errors: validationErrors.map((e) => ({
+          message: e.message,
+          code: (e.extensions?.code as string) ?? 'VALIDATION_ERROR',
+        })),
+        timestamp: timestamp(),
+      });
+    }
 
-      const data: Record<string, unknown> = {};
+    // 5 — execute with field-level authorisation.
+    try {
+      const resolvers = createResolvers(pool as Pool, remittanceStore);
 
-      if (parsed.type === 'remittances' && remittanceStore) {
-        const result = await remittanceStore.queryWithCursor(null, 20);
-        data.remittances = result.items;
-      }
+      // `buildSchema` + rootValue calls root fields as (args, context, info),
+      // whereas createResolvers uses the (parent, args, context, info) shape.
+      // Adapting here keeps the resolver signature stable for its own tests.
+      const rootValue = Object.fromEntries(
+        Object.entries(resolvers).map(([name, fn]) => [
+          name,
+          (args: Record<string, unknown>, context: GraphQLContext, info: unknown) =>
+            (fn as (p: unknown, a: unknown, c: unknown, i: unknown) => unknown)(
+              null,
+              args,
+              context,
+              info,
+            ),
+        ]),
+      );
 
-      if (parsed.type === 'corridors' && pool) {
-        const result = await pool.query(`
-          SELECT
-            COALESCE(raw_data->>'source_currency', 'USDC') AS source_currency,
-            COALESCE(raw_data->>'destination_country', 'UNKNOWN') AS destination_country,
-            SUM(COALESCE(amount, 0)) AS total_volume,
-            COUNT(*) AS transaction_count
-          FROM contract_events
-          WHERE timestamp >= NOW() - INTERVAL '30 days'
-          GROUP BY source_currency, destination_country
-          LIMIT 20
-        `);
-        data.corridors = result.rows;
-      }
+      const context: GraphQLContext = { userId, role, pool, remittanceStore };
 
-      if (parsed.type === 'agents' && pool) {
-        const result = await pool.query(
-          'SELECT address, registered_at, is_active FROM agents LIMIT 20',
-        );
-        data.agents = result.rows;
-      }
+      const result = await execute({
+        schema: typeDefs,
+        document,
+        rootValue,
+        contextValue: context,
+        variableValues: variables,
+        operationName,
+        fieldResolver: authorizingFieldResolver,
+      });
 
+      // Partial success is normal in GraphQL: an unauthorised field is null with
+      // an error alongside the data the caller was entitled to.
       return res.json({
-        success: true,
-        data,
-        timestamp: new Date().toISOString(),
+        success: !result.errors || result.errors.length === 0,
+        data: result.data ?? null,
+        ...(result.errors && result.errors.length > 0
+          ? {
+              errors: result.errors.map((e) => ({
+                message: e.message,
+                path: e.path,
+                code: (e.extensions?.code as string) ?? 'EXECUTION_ERROR',
+              })),
+            }
+          : {}),
+        timestamp: timestamp(),
       });
     } catch (error) {
       return res.status(500).json({
@@ -124,22 +268,26 @@ export function createGraphQLRouter(options: GraphQLRouterOptions = {}): Router 
           message: error instanceof Error ? error.message : 'Internal server error',
           code: 'GRAPHQL_ERROR',
         },
-        timestamp: new Date().toISOString(),
+        timestamp: timestamp(),
       });
     }
   });
 
   /**
    * GET /api/graphql
-   * GraphQL endpoint info
+   * Endpoint metadata. Returns no data, so it stays public — but it must not
+   * describe the schema in production.
    */
-  router.get('/', (req: Request, res: Response) => {
+  router.get('/', (_req: Request, res: Response) => {
+    const production = process.env.NODE_ENV === 'production';
     res.json({
       success: true,
       message: 'GraphQL API endpoint',
       usage: 'POST to this endpoint with { query: "query { remittances { id sender amount } }" }',
-      supportedQueries: ['remittances', 'corridors', 'agents'],
-      timestamp: new Date().toISOString(),
+      authentication: 'Bearer access token required',
+      introspection: production ? 'disabled' : 'enabled',
+      ...(production ? {} : { supportedQueries: ['remittances', 'corridors', 'agents'] }),
+      timestamp: timestamp(),
     });
   });
 

--- a/api/src/routes/remittances.ts
+++ b/api/src/routes/remittances.ts
@@ -20,6 +20,7 @@ import { ErrorResponse } from '../types';
 import { RemittanceStore } from '../db/remittanceStore';
 import { createRemittanceSchema, validateRequest } from '../schemas/requestValidation';
 import { generateReceiptPdf } from '../services/receiptGenerator';
+import { requireAuth } from '../middleware/auth.js';
 
 export type RemittanceStatus = 'Pending' | 'Processing' | 'Completed' | 'Cancelled' | 'Failed' | 'Disputed';
 
@@ -136,7 +137,7 @@ export function createRemittancesRouter(options: RemittancesRouterOptions = {}):
    *             schema:
    *               $ref: '#/components/schemas/ErrorResponse'
    */
-  router.get('/', async (req: Request, res: Response) => {
+  router.get('/', requireAuth, async (req: Request, res: Response) => {
     const {
       agent,
       status,
@@ -200,11 +201,18 @@ export function createRemittancesRouter(options: RemittancesRouterOptions = {}):
       return sendError(res, 503, 'Remittance store not configured', 'SERVICE_UNAVAILABLE');
     }
 
+    // SR-048: a non-admin caller may only see remittances they are the agent
+    // for. Honouring a client-supplied `agent` filter for such callers would let
+    // anyone enumerate another agent's financial history.
+    const auth = req.auth!;
+    const agentFilter =
+      auth.role === 'admin' ? agent?.trim() : auth.userId;
+
     try {
       const result = await remittanceStore.queryWithCursor(
         cursor || null,
         limit,
-        agent?.trim(),
+        agentFilter,
         status as RemittanceStatus | undefined,
         fromDate,
         toDate,
@@ -266,27 +274,18 @@ export function createRemittancesRouter(options: RemittancesRouterOptions = {}):
    *       503:
    *         description: Remittance store not configured
    */
-  router.get('/:id/receipt', async (req: Request, res: Response) => {
+  router.get('/:id/receipt', requireAuth, async (req: Request, res: Response) => {
     const { id } = req.params;
 
     if (!remittanceStore) {
       return sendError(res, 503, 'Remittance store not configured', 'SERVICE_UNAVAILABLE');
     }
 
-    // Authentication: admin API key or sender address
-    const adminKey = process.env.ADMIN_API_KEY;
-    const providedApiKey = req.headers['x-api-key'] as string | undefined;
-    const senderAddress = req.headers['x-sender-address'] as string | undefined;
-    const isAdmin = adminKey && providedApiKey === adminKey;
-
-    if (!isAdmin && !senderAddress) {
-      return sendError(
-        res,
-        401,
-        'Authentication required. Provide X-API-Key (admin) or X-Sender-Address header.',
-        'UNAUTHORIZED',
-      );
-    }
+    // SR-048: identity comes from the verified access token, never from a
+    // client-supplied header. The previous X-Sender-Address check was forgeable
+    // — any caller could name someone else's address and download their receipt.
+    const auth = req.auth!;
+    const isAdmin = auth.role === 'admin';
 
     const remittance = await remittanceStore.getById(id);
     if (!remittance) {
@@ -294,8 +293,8 @@ export function createRemittancesRouter(options: RemittancesRouterOptions = {}):
     }
 
     // Non-admin callers can only download their own receipts
-    if (!isAdmin && senderAddress !== remittance.sender_id) {
-      return sendError(res, 403, 'Sender address does not match remittance owner', 'FORBIDDEN');
+    if (!isAdmin && auth.userId !== remittance.sender_id) {
+      return sendError(res, 403, 'You do not have access to this receipt', 'FORBIDDEN');
     }
 
     const pdfBuffer = await generateReceiptPdf(remittance);

--- a/api/src/services/tokenStore.ts
+++ b/api/src/services/tokenStore.ts
@@ -1,0 +1,212 @@
+/**
+ * Token lifecycle store for JWT auth (SR-047).
+ *
+ * Holds the three pieces of state that make token auth safe and that a plain
+ * `jwt.sign`/`jwt.verify` pair cannot provide on its own:
+ *
+ *  1. **Refresh-token families** — every login starts a family. Refreshing
+ *     rotates the token within its family. Presenting a token that was already
+ *     used means it leaked, so the entire family is revoked rather than just
+ *     that token.
+ *  2. **Access-token revocation** — access tokens are self-contained, so
+ *     `logout` cannot invalidate one by deleting a row. Revoked `jti` values are
+ *     held until their natural expiry and checked on every verification.
+ *  3. **Login throttling** — failed attempts per identity, with lockout.
+ *
+ * Storage is in-memory, matching the existing convention in this codebase
+ * (see `middleware/idempotency.ts`). A multi-instance deployment must back this
+ * with Redis or the guarantees hold only per process — see AUTH_MATRIX.md.
+ */
+
+import crypto from 'crypto';
+
+export const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const ACCESS_TOKEN_TTL_SECONDS = 15 * 60; // 15 minutes
+
+/** Failed logins allowed before an identity is locked out. */
+export const MAX_LOGIN_ATTEMPTS = 5;
+/** How long an identity stays locked after exhausting its attempts. */
+export const LOGIN_LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+/** Failed attempts older than this no longer count toward the limit. */
+export const LOGIN_ATTEMPT_WINDOW_MS = 15 * 60 * 1000;
+
+export interface RefreshRecord {
+  familyId: string;
+  userId: string;
+  role: string;
+  expiresAt: number;
+  /** Set once the token has been redeemed. A second redemption means a leak. */
+  used: boolean;
+}
+
+interface FamilyRecord {
+  userId: string;
+  revoked: boolean;
+  /** Every token ever issued in this family, so revocation can sweep them all. */
+  tokens: Set<string>;
+}
+
+interface LoginAttemptRecord {
+  failures: number[];
+  lockedUntil: number;
+}
+
+const refreshTokens = new Map<string, RefreshRecord>();
+const families = new Map<string, FamilyRecord>();
+/** Revoked access-token `jti` → the moment the token would have expired anyway. */
+const revokedAccessJtis = new Map<string, number>();
+const loginAttempts = new Map<string, LoginAttemptRecord>();
+
+/** Result of redeeming a refresh token. */
+export type RefreshOutcome =
+  | { ok: true; record: RefreshRecord }
+  | { ok: false; reason: 'unknown' | 'expired' | 'reused' | 'family_revoked' };
+
+function newId(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/** Starts a new refresh-token family and returns its first token. */
+export function issueRefreshToken(userId: string, role: string): { token: string; familyId: string } {
+  const familyId = newId();
+  const token = newId();
+
+  families.set(familyId, { userId, revoked: false, tokens: new Set([token]) });
+  refreshTokens.set(token, {
+    familyId,
+    userId,
+    role,
+    expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+    used: false,
+  });
+
+  return { token, familyId };
+}
+
+/**
+ * Redeems a refresh token and issues its replacement.
+ *
+ * Reuse detection is the point of this function: a token that has already been
+ * redeemed can only be presented again if it was captured, so the whole family
+ * is revoked and the caller is expected to alert.
+ */
+export function rotateRefreshToken(token: string): RefreshOutcome & { nextToken?: string } {
+  const record = refreshTokens.get(token);
+  if (!record) {
+    return { ok: false, reason: 'unknown' };
+  }
+
+  const family = families.get(record.familyId);
+  if (!family || family.revoked) {
+    return { ok: false, reason: 'family_revoked' };
+  }
+
+  if (record.used) {
+    // Replay of a spent token — assume compromise and burn the family.
+    revokeFamily(record.familyId);
+    return { ok: false, reason: 'reused' };
+  }
+
+  if (Date.now() > record.expiresAt) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  record.used = true;
+
+  const nextToken = newId();
+  family.tokens.add(nextToken);
+  refreshTokens.set(nextToken, {
+    familyId: record.familyId,
+    userId: record.userId,
+    role: record.role,
+    expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+    used: false,
+  });
+
+  return { ok: true, record, nextToken };
+}
+
+/** Revokes every token in a family. Used on logout and on reuse detection. */
+export function revokeFamily(familyId: string): void {
+  const family = families.get(familyId);
+  if (!family) return;
+
+  family.revoked = true;
+  for (const token of family.tokens) {
+    refreshTokens.delete(token);
+  }
+}
+
+export function getRefreshRecord(token: string): RefreshRecord | undefined {
+  return refreshTokens.get(token);
+}
+
+/**
+ * Marks an access token's `jti` revoked until `expiresAtSeconds` (the token's
+ * own `exp`). Past that point the token fails signature-independent expiry
+ * checks anyway, so the entry can be dropped.
+ */
+export function revokeAccessToken(jti: string, expiresAtSeconds: number): void {
+  revokedAccessJtis.set(jti, expiresAtSeconds * 1000);
+}
+
+export function isAccessTokenRevoked(jti: string): boolean {
+  const expiry = revokedAccessJtis.get(jti);
+  if (expiry === undefined) return false;
+
+  if (Date.now() > expiry) {
+    revokedAccessJtis.delete(jti);
+    return false;
+  }
+  return true;
+}
+
+/** True when the identity is currently locked out from logging in. */
+export function isLockedOut(identity: string): boolean {
+  const record = loginAttempts.get(identity);
+  if (!record) return false;
+  return Date.now() < record.lockedUntil;
+}
+
+/** Records a failed login. Returns true if this failure triggered a lockout. */
+export function recordLoginFailure(identity: string): boolean {
+  const now = Date.now();
+  const record = loginAttempts.get(identity) ?? { failures: [], lockedUntil: 0 };
+
+  record.failures = record.failures.filter((t) => now - t < LOGIN_ATTEMPT_WINDOW_MS);
+  record.failures.push(now);
+
+  let lockedNow = false;
+  if (record.failures.length >= MAX_LOGIN_ATTEMPTS) {
+    record.lockedUntil = now + LOGIN_LOCKOUT_MS;
+    record.failures = [];
+    lockedNow = true;
+  }
+
+  loginAttempts.set(identity, record);
+  return lockedNow;
+}
+
+export function clearLoginFailures(identity: string): void {
+  loginAttempts.delete(identity);
+}
+
+/** Drops expired refresh tokens and revocation entries. */
+export function pruneExpired(): void {
+  const now = Date.now();
+
+  for (const [token, record] of refreshTokens) {
+    if (now > record.expiresAt) refreshTokens.delete(token);
+  }
+  for (const [jti, expiry] of revokedAccessJtis) {
+    if (now > expiry) revokedAccessJtis.delete(jti);
+  }
+}
+
+/** Test helper — clears all token state. */
+export function resetTokenStore(): void {
+  refreshTokens.clear();
+  families.clear();
+  revokedAccessJtis.clear();
+  loginAttempts.clear();
+}


### PR DESCRIPTION
Closes #1117, Closes #1118, Closes #1119, Closes #1120

## What

Implements the four pre-mainnet API security issues in a single cohesive PR: real JWT verification, route authorisation, idempotency correctness, and GraphQL hardening.

Each issue turned out to describe the symptom rather than the full defect. The specifics are below.

## #1117 — SR-047: Replace the placeholder auth implementation with real JWT verification

**The API issued access tokens but never verified one on any HTTP route.** `jwt.verify` existed only in the Socket.IO middleware. `adminAuth` is a static shared-API-key compare, unrelated to JWT. So `middleware/auth.ts` is entirely new enforcement, not a hardening pass.

- `middleware/auth.ts` (new) — the only HTTP verification path. Pins `algorithms: ['HS256']`, which is what rejects `alg: none` and HS/RS confusion; validates `issuer` and `audience` so a token minted for another service cannot be replayed.
- `services/tokenStore.ts` (new) — refresh-token families with reuse detection, access-token revocation, and login throttling. Redeeming a spent refresh token means it leaked, so the **entire family** is revoked, not just that token.
- **Logout now revokes the access token.** Previously it deleted the refresh token while the access token stayed valid for up to 15 minutes — self-contained tokens cannot be invalidated by deleting a row.
- **Login accepted ANY password when `NODE_ENV=test`**, so the suite exercised an auth path that could not fail. Now requires a configured password in every environment, compared with `timingSafeEqual`.
- Brute-force protection: 5 failures locks an identity for 15 minutes, per-identity.
- Admin identity comes from an `ADMIN_USER_IDS` allowlist, never a client-supplied claim. A user token can never satisfy an admin guard.

## #1118 — SR-048: Add authentication to unprotected data-returning routes

- `GET /api/remittances` now requires a token **and scopes results to the caller**. It previously honoured a client-supplied `agent` filter, so anyone could enumerate another agent's financial history.
- `GET /api/remittances/:id/receipt` **did** have a guard, but it trusted a client-supplied `X-Sender-Address` header — trivially forgeable. Any caller could name someone else's address and download their receipt. Ownership now comes from the verified token. A forgeable guard is worse than none, because it reads as protective.
- `GET /api/accounts/:address/stellar-fees` now requires a token.
- Agent registration and payout-address changes accept **either** the pre-existing admin API key or a token with the `agent`/`admin` role, so existing operational tooling keeps working.
- `api/AUTH_MATRIX.md` (new) documents every route and its guard, with a test enumerating them so drift fails the build.

## #1119 — SR-049: Guarantee idempotency-key correctness for money-moving endpoints

The previous middleware had none of the three properties correct idempotency needs.

- **Body binding.** The cached response was replayed for ANY body. A client reusing a key with a different amount silently received the old result and the new transfer never happened. Bodies are now hashed with a canonical, key-order-independent encoding; a mismatch returns `409 IdempotencyConflict`.
- **Concurrency.** Two simultaneous requests with one key both missed the cache and both executed — exactly the double-spend the key exists to prevent. The key is now claimed before the handler runs, so a concurrent duplicate observes an in-flight record, waits, and replays the original result. Exactly-once.
- **Verbatim replay.** The status was replayed but the stored headers were never reapplied. Status, headers, and the serialized payload are now replayed byte-identically, with an `Idempotent-Replay` marker.
- `validateIdempotencyKey` existed but was **never called**, so any string was accepted. Now enforced.
- Money-moving POSTs require a key; previously a missing key silently skipped all idempotency handling — the one case where a retry does the most damage.

## #1120 — SR-050: Add depth limiting, complexity analysis, and auth to GraphQL

**The endpoint did not execute GraphQL at all.** `routes/graphql.ts` regex-scraped the query string (`query.match(/remittances[^{]*\{([^}]+)\}/)`) and hand-assembled a response, while `schema.ts` and `resolvers.ts` were never wired to anything. The router was also never mounted in `app.ts`, so the endpoint was unreachable. Limits could not be "added" — there was no execution pipeline to attach them to.

- Real parse → validate → execute against the schema, mounted in `app.ts`.
- Depth and complexity enforced as **validation rules**, which run before execution — an abusive query costs zero database work. Tests assert this with a query counter, not the status code: a limit that rejects after the work has happened still returns 400 while protecting nothing.
- Complexity is modelled separately from depth because depth alone is insufficient: `remittances(limit: 500)` over twenty fields is shallow and serves 10,000 values. Fragment spreads are followed with cycle detection so depth cannot be hidden behind a fragment.
- Introspection rejected when `NODE_ENV=production`; the GET handler stops advertising supported queries there.
- Field-level authorisation as the default field resolver — an unauthorised field is nulled with an error, never returned as data.
- Per-identity operation rate limiting above the HTTP limiter.

**Two further bugs found while wiring this up:** `createResolvers` used the `(parent, args, context, info)` shape while `buildSchema` + `rootValue` calls root fields as `(args, context, info)` — the signatures never matched because nothing ever executed them. And the `DataLoader` that claimed to prevent N+1 queries did the opposite: it ignored the `ids` it was handed and called `queryWithCursor(null, 1)` once per id. It was never wired to a resolver either. Removed rather than repaired, since every resolver already issues one query per collection.

## Testing

```bash
cd api
npm install
npx vitest run
npx tsc --noEmit
```

**244 passed, 16 failed.** All 16 failures are pre-existing and unrelated to this work — `anchors`, `config`, `governance-lifecycle`, `integration`, `pact`, `routes`, `settlements`. I verified this by running them against a stashed tree: the baseline before this PR was **23** failures, so this is a net improvement.

51 new tests:
- `auth-security.test.ts` (21) — all six negative cases SR-047 names, claim validation, throttling, and the SR-048 route matrix
- `idempotency-concurrency.test.ts` (12) — all four SR-049 acceptance criteria, including three concurrent duplicates collapsing onto one execution
- `graphql-security.test.ts` (18) — all four SR-050 cases plus the acceptance criteria

## Review notes

**Existing tests that encoded the old behaviour were updated, not deleted.** Three are worth your attention:

1. `idempotency.test.ts` — "should return same response body from cache" sent `amount: 100` then `amount: 200` with one key and asserted the bodies were **equal**. That test enshrined the bug: the second transfer silently never happened. It now asserts 409.
2. `idempotency.test.ts` — "should accept POST without Idempotency-Key" asserted 200 for a money-moving POST; SR-049 requires 400.
3. `auth.test.ts` — relied on the `NODE_ENV=test` password bypass and inspected a private `Map`. Now configures `STUB_PASSWORD` and asserts observable behaviour.

**Prerequisite — dependency manifest.** `api/package.json` declared only `axios` and `xss` while the source imports 27 other packages. On a fresh clone the API cannot install, build, or test: **14 of 23 test files failed to load**. I declared the 18 needed to load and exercise the app. Nine remain undeclared and are not needed for tests: `@asteasolutions/zod-to-openapi`, `@aws-sdk/client-secrets-manager`, and seven `@opentelemetry/*` packages. **Worth its own issue.**

**Known limitations, documented in `AUTH_MATRIX.md`:**
- Token state (refresh families, revocation, lockout) is in-memory, matching the existing convention in `middleware/idempotency.ts`. Behind more than one instance the guarantees hold per process only. Redis is required before horizontal scaling.
- Credential verification is still stubbed against `STUB_PASSWORD`. The test bypass is gone, but a real user store is still needed.
- Role assignment is env-allowlist driven — adequate for a fixed operator set, not for self-service.

## Checklist

- [x] Code compiles — `npx tsc --noEmit` clean for all files touched here
- [x] Tests added for every acceptance criterion across all four issues
- [x] No breaking changes beyond the intended auth requirements, which are the point of #1117/#1118 and are documented in `AUTH_MATRIX.md`
- [x] Documentation updated — `AUTH_MATRIX.md` added
- [x] No UI changes, so no screenshots
