### PR TITLE
SR-029: Add resilience tests and enforcement for FX rate failover

### DIFF
--- a/backend/src/__tests__/fx-provider.test.ts
+++ b/backend/src/__tests__/fx-provider.test.ts
@@ -76,6 +76,49 @@ describe('FailoverFxService', () => {
     await expect(svc.getRate('USD', 'EUR')).rejects.toThrow('no rate available');
   });
 
+  it('rejects a stale cached rate beyond the max staleness threshold', async () => {
+    let callCount = 0;
+    const primary = makeProvider('primary', async () => {
+      callCount++;
+      if (callCount === 1) return 1.25; // first call succeeds → populates stale cache
+      throw new Error('primary down');
+    });
+    const secondary = makeProvider('secondary', async () => { throw new Error('secondary down'); });
+    const svc = new FailoverFxService(primary, secondary, 0, -1); // maxStalenessSeconds = -1 → always exceeded
+
+    await svc.getRate('USD', 'EUR'); // success → stale cache set
+    await expect(svc.getRate('USD', 'EUR')).rejects.toThrow('exceeds max staleness');
+  });
+
+  it('rejects a rate deviating beyond the sanity bound and fails over', async () => {
+    const primary = makeProvider('primary', async () => 1.25);
+    const secondary = makeProvider('secondary', async () => 1.30);
+    const svc = new FailoverFxService(primary, secondary, 60_000, 300, 10); // max 10% deviation
+
+    expect(await svc.getRate('USD', 'EUR')).toBe(1.25); // seeds last-known-good
+
+    (primary.getRate as ReturnType<typeof vi.fn>).mockImplementation(async () => 5.0); // >>10% deviation
+    const rate = await svc.getRate('USD', 'EUR');
+    expect(rate).toBe(1.30); // fell through to secondary since primary rate was rejected
+  });
+
+  it('invokes the metrics observer on provider failure, failover, and rejection', async () => {
+    const observer = {
+      onProviderFailure: vi.fn(),
+      onFailover: vi.fn(),
+      onRateRejected: vi.fn(),
+    };
+    const primary = makeProvider('primary', async () => { throw new Error('down'); });
+    const secondary = makeProvider('secondary', async () => 1.30);
+    const svc = new FailoverFxService(primary, secondary);
+    svc.setMetricsObserver(observer);
+
+    await svc.getRate('USD', 'EUR');
+
+    expect(observer.onProviderFailure).toHaveBeenCalledWith('primary', 'USD/EUR');
+    expect(observer.onFailover).toHaveBeenCalledWith('primary', 'secondary', 'USD/EUR');
+  });
+
   it('logs fx_provider_switch alert JSON on primary failure', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const primary = makeProvider('primary', async () => { throw new Error('timeout'); });

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -26,6 +26,7 @@ import { KycUpsertService } from './kyc-upsert-service';
 import { createTransferGuard, AuthenticatedRequest } from './transfer-guard';
 import { AgentKycService } from './agent-kyc-service';
 import { getFxRateCache } from './fx-rate-cache';
+import { getFailoverFxService } from './fx-provider';
 import { correlationIdMiddleware, createLogger } from './correlation-id';
 import { getMetricsService } from './metrics';
 import { sanitizeInput } from './sanitizer';
@@ -47,6 +48,11 @@ const pool = getPool();
 const metricsService = getMetricsService(pool);
 fxRateCache.setMetricsObserver((from, to, stalenessSeconds) => {
   metricsService.setFxRateStalenessMetric(from, to, stalenessSeconds);
+});
+getFailoverFxService().setMetricsObserver({
+  onProviderFailure: provider => metricsService.recordFxProviderFailure(provider),
+  onFailover: () => metricsService.recordFxProviderFailover(),
+  onRateRejected: (_pair, reason) => metricsService.recordFxRateRejected(reason),
 });
 
 // Security middleware

--- a/backend/src/fx-provider.ts
+++ b/backend/src/fx-provider.ts
@@ -72,53 +72,103 @@ function isCircuitOpen(cb: CircuitBreaker): boolean {
 
 // ── Failover service ──────────────────────────────────────────────────────────
 
+export interface FxMetricsObserver {
+  onProviderFailure?(provider: string, pair: string): void;
+  onFailover?(fromProvider: string, toProvider: string, pair: string): void;
+  onStaleServed?(pair: string, stalenessSeconds: number): void;
+  onRateRejected?(pair: string, reason: 'stale' | 'sanity'): void;
+}
+
 export class FailoverFxService {
   private primary: FxRateProvider;
   private secondary: FxRateProvider;
   private cb: CircuitBreaker;
   private staleCache = new Map<string, { rate: number; ts: number }>();
+  private maxStalenessSeconds: number;
+  private maxDeviationPercent: number;
+  private metricsObserver?: FxMetricsObserver;
 
   constructor(
     primary: FxRateProvider = new PrimaryFxProvider(),
     secondary: FxRateProvider = new SecondaryFxProvider(),
-    halfOpenAfterMs = 60_000
+    halfOpenAfterMs = 60_000,
+    maxStalenessSeconds = 300,
+    maxDeviationPercent = 20
   ) {
     this.primary = primary;
     this.secondary = secondary;
     this.cb = { open: false, openedAt: 0, halfOpenAfterMs };
+    this.maxStalenessSeconds = maxStalenessSeconds;
+    this.maxDeviationPercent = maxDeviationPercent;
+  }
+
+  setMetricsObserver(observer: FxMetricsObserver): void {
+    this.metricsObserver = observer;
   }
 
   async getRate(from: string, to: string): Promise<number> {
     const key = `${from}_${to}`;
+    const pair = `${from}/${to}`;
 
     if (!isCircuitOpen(this.cb)) {
       try {
         const rate = await this.primary.getRate(from, to);
-        this.staleCache.set(key, { rate, ts: Date.now() });
-        return rate;
+        return this.acceptRate(key, pair, rate);
       } catch (err) {
+        this.metricsObserver?.onProviderFailure?.(this.primary.name, pair);
         this.openCircuit(from, to, err);
       }
     }
 
     try {
       const rate = await this.secondary.getRate(from, to);
-      this.staleCache.set(key, { rate, ts: Date.now() });
-      return rate;
+      return this.acceptRate(key, pair, rate);
     } catch (err) {
+      this.metricsObserver?.onProviderFailure?.(this.secondary.name, pair);
       const stale = this.staleCache.get(key);
       if (stale) {
-        console.warn(`[FailoverFxService] Both providers failed for ${from}/${to}; serving stale rate (${Math.floor((Date.now() - stale.ts) / 1000)}s old)`);
+        const stalenessSeconds = Math.floor((Date.now() - stale.ts) / 1000);
+        if (stalenessSeconds > this.maxStalenessSeconds) {
+          this.metricsObserver?.onRateRejected?.(pair, 'stale');
+          throw new Error(`FailoverFxService: cached rate for ${pair} exceeds max staleness (${stalenessSeconds}s > ${this.maxStalenessSeconds}s)`);
+        }
+        console.warn(`[FailoverFxService] Both providers failed for ${pair}; serving stale rate (${stalenessSeconds}s old)`);
+        this.metricsObserver?.onStaleServed?.(pair, stalenessSeconds);
         return stale.rate;
       }
-      throw new Error(`FailoverFxService: no rate available for ${from}/${to}`);
+      throw new Error(`FailoverFxService: no rate available for ${pair}`);
     }
+  }
+
+  /**
+   * Validate a freshly fetched rate against the last known good value before
+   * trusting it — a corrupted/malformed provider response can still parse to
+   * a finite number that is wildly wrong (e.g. off by 100x).
+   */
+  private acceptRate(key: string, pair: string, rate: number): number {
+    if (!Number.isFinite(rate) || rate <= 0) {
+      this.metricsObserver?.onRateRejected?.(pair, 'sanity');
+      throw new Error(`FailoverFxService: invalid rate for ${pair}`);
+    }
+
+    const lastGood = this.staleCache.get(key);
+    if (lastGood) {
+      const deviationPercent = (Math.abs(rate - lastGood.rate) / lastGood.rate) * 100;
+      if (deviationPercent > this.maxDeviationPercent) {
+        this.metricsObserver?.onRateRejected?.(pair, 'sanity');
+        throw new Error(`FailoverFxService: rate for ${pair} deviates ${deviationPercent.toFixed(1)}% from last known good value (max ${this.maxDeviationPercent}%)`);
+      }
+    }
+
+    this.staleCache.set(key, { rate, ts: Date.now() });
+    return rate;
   }
 
   private openCircuit(from: string, to: string, err: unknown): void {
     const reason = err instanceof Error ? err.message : String(err);
     this.cb.open = true;
     this.cb.openedAt = Date.now();
+    this.metricsObserver?.onFailover?.(this.primary.name, this.secondary.name, `${from}/${to}`);
     console.warn(JSON.stringify({
       event: 'fx_provider_switch',
       from: this.primary.name,

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -37,6 +37,11 @@ export class MetricsService {
   private jobLastRunTimestamp: Map<string, number> = new Map();
   private jobFailureTotal: Map<string, number> = new Map();
 
+  // FX provider resilience metrics (SR-029)
+  private fxProviderFailuresTotal: Map<string, number> = new Map();
+  private fxProviderFailoversTotal = 0;
+  private fxRateRejectedTotal: Map<string, number> = new Map();
+
   constructor(pool: Pool, fxRateCache?: FxRateCache) {
     this.pool = pool;
     this.fxRateCache = fxRateCache;
@@ -224,6 +229,21 @@ export class MetricsService {
     this.jobFailureTotal.set(jobName, (this.jobFailureTotal.get(jobName) ?? 0) + 1);
   }
 
+  /** Record an FX provider call failure (e.g. timeout, 5xx, malformed response). */
+  recordFxProviderFailure(provider: string): void {
+    this.fxProviderFailuresTotal.set(provider, (this.fxProviderFailuresTotal.get(provider) ?? 0) + 1);
+  }
+
+  /** Record a failover from the primary to the secondary FX provider. */
+  recordFxProviderFailover(): void {
+    this.fxProviderFailoversTotal += 1;
+  }
+
+  /** Record a rejected FX rate (stale-beyond-threshold or failed sanity check). */
+  recordFxRateRejected(reason: 'stale' | 'sanity'): void {
+    this.fxRateRejectedTotal.set(reason, (this.fxRateRejectedTotal.get(reason) ?? 0) + 1);
+  }
+
   /**
    * Update the contract event indexer lag (ledgers behind the chain tip).
    * Call this from the Stellar event listener after each poll.
@@ -370,6 +390,23 @@ export class MetricsService {
     lines.push('# TYPE swiftremit_job_failure_total counter');
     this.jobFailureTotal.forEach((count, jobName) => {
       lines.push(`swiftremit_job_failure_total{job_name="${this.sanitizeLabelValue(jobName)}"} ${count}`);
+    });
+
+    // FX provider resilience metrics (SR-029)
+    lines.push('# HELP fx_provider_failures_total Total number of FX provider call failures by provider');
+    lines.push('# TYPE fx_provider_failures_total counter');
+    this.fxProviderFailuresTotal.forEach((count, provider) => {
+      lines.push(`fx_provider_failures_total{provider="${this.sanitizeLabelValue(provider)}"} ${count}`);
+    });
+
+    lines.push('# HELP fx_provider_failovers_total Total number of failovers from primary to secondary FX provider');
+    lines.push('# TYPE fx_provider_failovers_total counter');
+    lines.push(`fx_provider_failovers_total ${this.fxProviderFailoversTotal}`);
+
+    lines.push('# HELP fx_rate_rejected_total Total number of FX rates rejected by reason (stale, sanity)');
+    lines.push('# TYPE fx_rate_rejected_total counter');
+    this.fxRateRejectedTotal.forEach((count, reason) => {
+      lines.push(`fx_rate_rejected_total{reason="${this.sanitizeLabelValue(reason)}"} ${count}`);
     });
 
     return lines.join('\n') + '\n';


### PR DESCRIPTION
## Summary
- `FailoverFxService` now rejects cached rates once they exceed a configurable max staleness instead of serving them indefinitely (fail-closed).
- Added a rate-sanity guard that rejects a freshly fetched rate deviating more than a configurable percentage from the last known good value, falling over to the next provider.
- Added a metrics observer hook (`setMetricsObserver`) wired into `MetricsService`/`api.ts` to export `fx_provider_failures_total`, `fx_provider_failovers_total`, and `fx_rate_rejected_total` to Prometheus.
- Added tests covering: failover ordering, total outage with cold cache (fail-closed), max-staleness rejection, rate-sanity rejection, and metrics observer invocation.

## Closes
Closes #1099

## Validation
- `npx vitest run src/__tests__/fx-provider.test.ts` — 10/10 passed
- `npx eslint` on changed files — clean
- `npx tsc --noEmit` — no new errors (pre-existing unrelated error: `scheduler.ts` cannot resolve `@swiftremit/sdk` workspace package, present on `main` too)