### PR TITLE
SR-030: Test distributed-lock concurrency and KYC status idempotency

### DIFF
--- a/backend/src/__tests__/distributed-lock.test.ts
+++ b/backend/src/__tests__/distributed-lock.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Pool, PoolClient } from 'pg';
+import { withAdvisoryLock } from '../distributed-lock';
+
+/** Simulates a single shared Postgres advisory-lock table across "replicas". */
+function makeSharedLockPool(): { pool: Pool; heldLocks: Set<number> } {
+  const heldLocks = new Set<number>();
+
+  function makeClient(): Partial<PoolClient> {
+    return {
+      query: vi.fn().mockImplementation((sql: string, params: unknown[] = []) => {
+        if (sql.includes('pg_try_advisory_lock')) {
+          const lockId = params[0] as number;
+          if (heldLocks.has(lockId)) {
+            return Promise.resolve({ rows: [{ acquired: false }] });
+          }
+          heldLocks.add(lockId);
+          return Promise.resolve({ rows: [{ acquired: true }] });
+        }
+        if (sql.includes('pg_advisory_unlock')) {
+          const lockId = params[0] as number;
+          heldLocks.delete(lockId);
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.resolve({ rows: [] });
+      }),
+      release: vi.fn(),
+    };
+  }
+
+  const pool = {
+    connect: vi.fn().mockImplementation(() => Promise.resolve(makeClient())),
+  } as unknown as Pool;
+
+  return { pool, heldLocks };
+}
+
+describe('withAdvisoryLock', () => {
+  it('runs fn and releases the lock when acquired', async () => {
+    const { pool, heldLocks } = makeSharedLockPool();
+    const fn = vi.fn().mockResolvedValue(undefined);
+
+    const ran = await withAdvisoryLock(pool, 'poll-kyc-statuses', fn);
+
+    expect(ran).toBe(true);
+    expect(fn).toHaveBeenCalledOnce();
+    expect(heldLocks.size).toBe(0); // released after run
+  });
+
+  it('skips fn when another replica already holds the lock', async () => {
+    const { pool } = makeSharedLockPool();
+    const fn = vi.fn().mockResolvedValue(undefined);
+
+    // First replica acquires and holds the lock (never resolves within this tick)
+    let releaseFirst!: () => void;
+    const firstRun = withAdvisoryLock(pool, 'poll-kyc-statuses', () => new Promise(resolve => {
+      releaseFirst = resolve;
+    }));
+
+    // Give the first call a chance to acquire the lock before the second attempts it
+    await new Promise(resolve => setImmediate(resolve));
+
+    const secondRan = await withAdvisoryLock(pool, 'poll-kyc-statuses', fn);
+    expect(secondRan).toBe(false);
+    expect(fn).not.toHaveBeenCalled();
+
+    releaseFirst();
+    expect(await firstRun).toBe(true);
+  });
+
+  it('a lock is available again for the next poll after the holder releases it (no permanent hold on crash/exit)', async () => {
+    const { pool, heldLocks } = makeSharedLockPool();
+
+    await withAdvisoryLock(pool, 'poll-kyc-statuses', async () => {});
+    expect(heldLocks.size).toBe(0);
+
+    const ranAgain = await withAdvisoryLock(pool, 'poll-kyc-statuses', async () => {});
+    expect(ranAgain).toBe(true);
+  });
+
+  it('still releases the lock when fn throws', async () => {
+    const { pool, heldLocks } = makeSharedLockPool();
+
+    await expect(
+      withAdvisoryLock(pool, 'poll-kyc-statuses', async () => { throw new Error('boom'); })
+    ).rejects.toThrow('boom');
+
+    expect(heldLocks.size).toBe(0);
+  });
+
+  it('produces exactly one job run when two replicas poll the same anchor concurrently', async () => {
+    const { pool } = makeSharedLockPool();
+    let writes = 0;
+    const job = async () => { writes++; };
+
+    const [ranA, ranB] = await Promise.all([
+      withAdvisoryLock(pool, 'poll-kyc-statuses', job),
+      withAdvisoryLock(pool, 'poll-kyc-statuses', job),
+    ]);
+
+    expect([ranA, ranB].filter(Boolean)).toHaveLength(1);
+    expect(writes).toBe(1);
+  });
+});

--- a/backend/src/__tests__/kyc-upsert-service.test.ts
+++ b/backend/src/__tests__/kyc-upsert-service.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Pool } from 'pg';
+import { KycUpsertService } from '../kyc-upsert-service';
+import { KycRecord } from '../types';
+
+function makeRecord(overrides: Partial<KycRecord> = {}): KycRecord {
+  return {
+    user_id: 'GABCUSER',
+    anchor_id: 'anchor-1',
+    kyc_status: 'approved',
+    verified_at: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('KycUpsertService idempotency', () => {
+  it('is a no-op on the second write of the same status (same verified_at)', async () => {
+    // Real ON CONFLICT ... WHERE user_kyc_status.verified_at < EXCLUDED.verified_at:
+    // simulate rowCount 0 when the incoming verified_at is not newer than what's stored.
+    let stored: Date | null = null;
+    const pool = {
+      query: vi.fn().mockImplementation((_sql: string, params: unknown[]) => {
+        const incomingVerifiedAt = params[5] as Date;
+        if (stored && incomingVerifiedAt <= stored) {
+          return Promise.resolve({ rowCount: 0, rows: [] });
+        }
+        stored = incomingVerifiedAt;
+        return Promise.resolve({ rowCount: 1, rows: [] });
+      }),
+    } as unknown as Pool;
+
+    const onChainSync = vi.fn().mockResolvedValue({ success: true });
+    const service = new KycUpsertService(pool, onChainSync);
+    const record = makeRecord();
+
+    await service.upsert(record);
+    await service.upsert(record); // duplicate — must not double-write or double-notify
+
+    expect(onChainSync).toHaveBeenCalledOnce();
+  });
+
+  it('applies a genuinely newer status transition', async () => {
+    let stored: Date | null = null;
+    const pool = {
+      query: vi.fn().mockImplementation((_sql: string, params: unknown[]) => {
+        const incomingVerifiedAt = params[5] as Date;
+        if (stored && incomingVerifiedAt <= stored) {
+          return Promise.resolve({ rowCount: 0, rows: [] });
+        }
+        stored = incomingVerifiedAt;
+        return Promise.resolve({ rowCount: 1, rows: [] });
+      }),
+    } as unknown as Pool;
+
+    const onChainSync = vi.fn().mockResolvedValue({ success: true });
+    const service = new KycUpsertService(pool, onChainSync);
+
+    await service.upsert(makeRecord({ verified_at: new Date('2026-01-01T00:00:00Z') }));
+    await service.upsert(makeRecord({ verified_at: new Date('2026-01-02T00:00:00Z') }));
+
+    expect(onChainSync).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
Audited `scheduler.ts` — every scheduled job (including `poll-kyc-statuses`) already acquires a named advisory lock via `withAdvisoryLock` before running, and `KycUpsertService.upsert` already applies status transitions idempotently via `ON CONFLICT ... WHERE verified_at < EXCLUDED.verified_at` (a duplicate write with the same `verified_at` is a no-op and does not double-fire the on-chain sync). This PR adds the missing test coverage for both guarantees:

- `distributed-lock.test.ts`: lock acquired/released around `fn`, a second replica is skipped while the lock is held, the lock is released even when `fn` throws (crash/error safety), and two concurrent callers against the same key produce exactly one job execution.
- `kyc-upsert-service.test.ts`: writing the same KYC status twice (same `verified_at`) is a no-op and does not trigger a duplicate on-chain sync/notification; a genuinely newer status transition is applied.

## Closes
Closes #1100

## Validation
- `npx vitest run src/__tests__/distributed-lock.test.ts src/__tests__/kyc-upsert-service.test.ts` — 7/7 passed
- `npx eslint` on new files — clean