### PR TITLE
SR-031: Add circuit breaking and health-gated routing for anchor calls

### DIFF
--- a/backend/src/__tests__/anchor-circuit-breaker.test.ts
+++ b/backend/src/__tests__/anchor-circuit-breaker.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AnchorCircuitBreaker } from '../anchor-circuit-breaker';
+
+describe('AnchorCircuitBreaker', () => {
+  it('stays closed below the failure threshold', () => {
+    const cb = new AnchorCircuitBreaker({ failureThreshold: 3 });
+    cb.recordFailure('anchor-1');
+    cb.recordFailure('anchor-1');
+    expect(cb.getState('anchor-1')).toBe('closed');
+    expect(cb.shouldSkip('anchor-1')).toBe(false);
+  });
+
+  it('opens the circuit after the configured threshold and skips further calls', () => {
+    const onOpen = vi.fn();
+    const cb = new AnchorCircuitBreaker({ failureThreshold: 3, onOpen });
+    cb.recordFailure('anchor-1');
+    cb.recordFailure('anchor-1');
+    cb.recordFailure('anchor-1');
+
+    expect(cb.getState('anchor-1')).toBe('open');
+    expect(cb.shouldSkip('anchor-1')).toBe(true);
+    expect(onOpen).toHaveBeenCalledWith('anchor-1');
+    expect(onOpen).toHaveBeenCalledOnce(); // only fires on the closed→open transition
+  });
+
+  it('moves to half-open once the reset timeout elapses, and closes on a successful probe', () => {
+    const onClose = vi.fn();
+    const cb = new AnchorCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50, onClose });
+    cb.recordFailure('anchor-1'); // opens immediately (threshold 1)
+    expect(cb.getState('anchor-1')).toBe('open');
+    expect(cb.shouldSkip('anchor-1')).toBe(true); // still within reset window
+
+    return new Promise<void>(resolve => {
+      setTimeout(() => {
+        expect(cb.shouldSkip('anchor-1')).toBe(false); // half-open probe allowed through
+        expect(cb.getState('anchor-1')).toBe('half-open');
+
+        cb.recordSuccess('anchor-1');
+        expect(cb.getState('anchor-1')).toBe('closed');
+        expect(onClose).toHaveBeenCalledWith('anchor-1');
+        resolve();
+      }, 60);
+    });
+  });
+
+  it('re-opens the circuit when the half-open probe fails', () => {
+    const onOpen = vi.fn();
+    const cb = new AnchorCircuitBreaker({ failureThreshold: 1, resetTimeoutMs: 50, onOpen });
+    cb.recordFailure('anchor-1'); // opens
+
+    return new Promise<void>(resolve => {
+      setTimeout(() => {
+        expect(cb.shouldSkip('anchor-1')).toBe(false); // half-open
+        cb.recordFailure('anchor-1'); // probe fails
+        expect(cb.getState('anchor-1')).toBe('open');
+        expect(cb.shouldSkip('anchor-1')).toBe(true); // reset timer restarted
+        resolve();
+      }, 60);
+    });
+  });
+
+  it('tracks circuit state independently per anchor', () => {
+    const cb = new AnchorCircuitBreaker({ failureThreshold: 1 });
+    cb.recordFailure('anchor-1');
+    expect(cb.getState('anchor-1')).toBe('open');
+    expect(cb.getState('anchor-2')).toBe('closed');
+  });
+});

--- a/backend/src/anchor-circuit-breaker.ts
+++ b/backend/src/anchor-circuit-breaker.ts
@@ -1,0 +1,125 @@
+export type AnchorCircuitState = 'closed' | 'open' | 'half-open';
+
+export interface AnchorCircuitBreakerOptions {
+  /** Consecutive failures before the circuit opens. */
+  failureThreshold?: number;
+  /** How long the circuit stays open before allowing a half-open probe. */
+  resetTimeoutMs?: number;
+  onOpen?(anchorId: string): void;
+  onClose?(anchorId: string): void;
+}
+
+interface AnchorCircuitEntry {
+  state: AnchorCircuitState;
+  consecutiveFailures: number;
+  openedAt: number;
+}
+
+/**
+ * Per-anchor circuit breaker (closed → open → half-open) gating anchor calls
+ * (KYC polling, health checks) so a persistently failing anchor stops being
+ * retried until a half-open probe succeeds.
+ */
+export class AnchorCircuitBreaker {
+  private entries = new Map<string, AnchorCircuitEntry>();
+  private failureThreshold: number;
+  private resetTimeoutMs: number;
+  private onOpen?: (anchorId: string) => void;
+  private onClose?: (anchorId: string) => void;
+
+  constructor(options: AnchorCircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 3;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? 60_000;
+    this.onOpen = options.onOpen;
+    this.onClose = options.onClose;
+  }
+
+  private getEntry(anchorId: string): AnchorCircuitEntry {
+    let entry = this.entries.get(anchorId);
+    if (!entry) {
+      entry = { state: 'closed', consecutiveFailures: 0, openedAt: 0 };
+      this.entries.set(anchorId, entry);
+    }
+    return entry;
+  }
+
+  /**
+   * Whether the anchor should be skipped right now (circuit open and not yet
+   * due for a half-open probe). Calling this transitions an expired open
+   * circuit into 'half-open' so the caller knows to attempt exactly one probe.
+   */
+  shouldSkip(anchorId: string): boolean {
+    const entry = this.getEntry(anchorId);
+    if (entry.state === 'closed') return false;
+
+    if (entry.state === 'open') {
+      if (Date.now() - entry.openedAt >= this.resetTimeoutMs) {
+        entry.state = 'half-open';
+        return false;
+      }
+      return true;
+    }
+
+    // half-open: a probe is already in flight conceptually; allow it through.
+    return false;
+  }
+
+  recordSuccess(anchorId: string): void {
+    const entry = this.getEntry(anchorId);
+    const wasOpen = entry.state !== 'closed';
+    entry.state = 'closed';
+    entry.consecutiveFailures = 0;
+    entry.openedAt = 0;
+    if (wasOpen) this.onClose?.(anchorId);
+  }
+
+  recordFailure(anchorId: string): void {
+    const entry = this.getEntry(anchorId);
+
+    if (entry.state === 'half-open') {
+      // Half-open probe failed — re-open and restart the reset timer.
+      entry.state = 'open';
+      entry.openedAt = Date.now();
+      this.onOpen?.(anchorId);
+      return;
+    }
+
+    entry.consecutiveFailures += 1;
+    if (entry.consecutiveFailures >= this.failureThreshold) {
+      const wasClosed = entry.state === 'closed';
+      entry.state = 'open';
+      entry.openedAt = Date.now();
+      if (wasClosed) this.onOpen?.(anchorId);
+    }
+  }
+
+  getState(anchorId: string): AnchorCircuitState {
+    return this.getEntry(anchorId).state;
+  }
+
+  isOpen(anchorId: string): boolean {
+    return this.getEntry(anchorId).state === 'open';
+  }
+
+  reset(anchorId: string): void {
+    this.entries.delete(anchorId);
+  }
+}
+
+let instance: AnchorCircuitBreaker | null = null;
+export function getAnchorCircuitBreaker(): AnchorCircuitBreaker {
+  if (!instance) {
+    instance = new AnchorCircuitBreaker({
+      onOpen: anchorId => {
+        console.warn(JSON.stringify({ event: 'anchor_circuit_open', anchor_id: anchorId }));
+      },
+      onClose: anchorId => {
+        console.warn(JSON.stringify({ event: 'anchor_circuit_close', anchor_id: anchorId }));
+      },
+    });
+  }
+  return instance;
+}
+export function resetAnchorCircuitBreaker(): void {
+  instance = null;
+}

--- a/backend/src/anchor-health-checker.ts
+++ b/backend/src/anchor-health-checker.ts
@@ -5,6 +5,7 @@ import { URL } from 'url';
 import { getEnabledAnchors, saveAnchorHealthCheck, getLatestAnchorHealth } from './database';
 import { createLogger } from './correlation-id';
 import { MetricsService } from './metrics';
+import { AnchorCircuitBreaker, getAnchorCircuitBreaker } from './anchor-circuit-breaker';
 
 const logger = createLogger('AnchorHealthChecker');
 
@@ -78,10 +79,12 @@ function classifyHealth(probeResult: { ok: boolean; status: number; durationMs: 
 export class AnchorHealthChecker {
   private pool: Pool;
   private metricsService?: MetricsService;
+  private circuitBreaker: AnchorCircuitBreaker;
 
-  constructor(pool: Pool, metricsService?: MetricsService) {
+  constructor(pool: Pool, metricsService?: MetricsService, circuitBreaker: AnchorCircuitBreaker = getAnchorCircuitBreaker()) {
     this.pool = pool;
     this.metricsService = metricsService;
+    this.circuitBreaker = circuitBreaker;
   }
 
   async checkAllAnchors(): Promise<AnchorHealthResult[]> {
@@ -92,9 +95,21 @@ export class AnchorHealthChecker {
       const results: AnchorHealthResult[] = [];
 
       for (const anchor of anchors) {
+        if (this.circuitBreaker.shouldSkip(anchor.id)) {
+          logger.info(`Skipping anchor ${anchor.id}: circuit open`);
+          this.metricsService?.recordAnchorAvailability(anchor.id, 'circuit_open');
+          continue;
+        }
+
         try {
           const result = await this.checkSingleAnchor(anchor.id, anchor.domain);
           results.push(result);
+
+          if (result.status === 'offline') {
+            this.circuitBreaker.recordFailure(anchor.id);
+          } else {
+            this.circuitBreaker.recordSuccess(anchor.id);
+          }
 
           await saveAnchorHealthCheck({
             anchor_id: result.anchor_id,
@@ -119,6 +134,10 @@ export class AnchorHealthChecker {
       logger.error('Failed to check all anchors', error);
       return [];
     }
+  }
+
+  getCircuitState(anchorId: string) {
+    return this.circuitBreaker.getState(anchorId);
   }
 
   async checkSingleAnchor(anchorId: string, domain: string): Promise<AnchorHealthResult> {

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -19,6 +19,8 @@ import {
   saveAssetReport,
   getWebhookSubscriberById,
   rotateWebhookSecret,
+  getEnabledAnchors,
+  getLatestAnchorHealth,
 } from './database';
 import { storeVerificationOnChain, simulateSettlement } from './stellar';
 import { VerificationStatus, AnchorKycConfig } from './types';
@@ -26,6 +28,7 @@ import { KycUpsertService } from './kyc-upsert-service';
 import { createTransferGuard, AuthenticatedRequest } from './transfer-guard';
 import { AgentKycService } from './agent-kyc-service';
 import { getFxRateCache } from './fx-rate-cache';
+import { getAnchorCircuitBreaker } from './anchor-circuit-breaker';
 import { correlationIdMiddleware, createLogger } from './correlation-id';
 import { getMetricsService } from './metrics';
 import { sanitizeInput } from './sanitizer';
@@ -915,6 +918,26 @@ app.get('/api/admin/jobs', adminLimiter, async (req: Request, res: Response) => 
   } catch (error) {
     logger.error('Error fetching job summaries', error);
     res.status(500).json({ error: 'Failed to fetch job summaries' });
+  }
+});
+
+// Per-anchor circuit breaker state, gating anchor calls (SR-031)
+app.get('/api/admin/anchors/health', adminLimiter, async (req: Request, res: Response) => {
+  try {
+    const anchors = await getEnabledAnchors();
+    const circuitBreaker = getAnchorCircuitBreaker();
+    const health = await Promise.all(
+      anchors.map(async anchor => ({
+        anchor_id: anchor.id,
+        name: anchor.name,
+        circuit_state: circuitBreaker.getState(anchor.id),
+        latest_health: await getLatestAnchorHealth(anchor.id),
+      }))
+    );
+    res.json({ anchors: health });
+  } catch (error) {
+    logger.error('Error fetching anchor health', error);
+    res.status(500).json({ error: 'Failed to fetch anchor health' });
   }
 });
 

--- a/backend/src/kyc-service.ts
+++ b/backend/src/kyc-service.ts
@@ -3,6 +3,7 @@ import { KycStatus, DbUserKycStatus, AnchorKycConfig } from './types';
 import { getAnchorKycConfigs, getUsersNeedingKycCheck, saveUserKycStatus, getApprovedUsers, getPool, saveAnchorPollFailure } from './database';
 import { getMetricsService } from './metrics';
 import { updateKycStatusOnChain } from './stellar';
+import { getAnchorCircuitBreaker } from './anchor-circuit-breaker';
 
 interface Sep12KycResponse {
   id: string;
@@ -37,6 +38,7 @@ function calcBackoff(attempt: number, baseDelayMs: number): number {
 export class KycService {
   private configs: Map<string, AnchorKycConfig> = new Map();
   private metricsService = getMetricsService(getPool());
+  private circuitBreaker = getAnchorCircuitBreaker();
 
   async initialize(): Promise<void> {
     const configs = await getAnchorKycConfigs();
@@ -48,9 +50,16 @@ export class KycService {
     this.metricsService.recordKycPollerRun();
 
     for (const [anchorId, config] of this.configs) {
+      if (this.circuitBreaker.shouldSkip(anchorId)) {
+        console.log(`Skipping KYC poll for anchor ${anchorId}: circuit open`);
+        continue;
+      }
+
       try {
         await this.pollAnchorKycStatus(anchorId, config);
+        this.circuitBreaker.recordSuccess(anchorId);
       } catch (error) {
+        this.circuitBreaker.recordFailure(anchorId);
         this.metricsService.recordKycPollFailure();
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(`Failed to poll KYC status for anchor ${anchorId}:`, error);


### PR DESCRIPTION
## Summary
- Adds `AnchorCircuitBreaker` (closed → open → half-open), a per-anchor circuit breaker with a configurable failure threshold and reset timeout, following the same pattern as the existing FX provider circuit breaker.
- Wires the breaker into `AnchorHealthChecker.checkAllAnchors`: open-circuit anchors are skipped from probing until the reset timeout elapses, at which point exactly one half-open probe is attempted; success closes the circuit, failure re-opens it and restarts the timer.
- Wires the same shared breaker into `KycService.pollAllAnchors` so a persistently failing anchor also stops being polled for KYC status, instead of retrying indefinitely.
- Emits a structured `anchor_circuit_open` / `anchor_circuit_close` alert log on state transitions.
- Adds `GET /api/admin/anchors/health` surfacing each anchor's circuit state alongside its latest recorded health check.
- Adds `anchor-circuit-breaker.test.ts` covering the full state cycle: stays closed under threshold, opens after threshold (single alert fire), half-open transition after reset timeout, half-open success closes, half-open failure re-opens, and per-anchor isolation.

Note: the frontend `AnchorSelector` calls a `GET /api/anchors` endpoint that doesn't exist yet in this backend — hiding open-circuit anchors from that endpoint is out of scope here since the endpoint itself isn't implemented; `/api/admin/anchors/health` covers the "surface circuit state" criterion for now.

## Closes
Closes #1101

## Validation
- `npx vitest run src/__tests__/anchor-circuit-breaker.test.ts src/__tests__/kyc-service.test.ts` — 12/12 passed
- `npx tsc --noEmit` — no new errors (pre-existing unrelated error in `scheduler.ts` resolving `@swiftremit/sdk`, present on `main` too)
- `npx eslint` on changed files — clean