### PR TITLE
feat: add browser SDK bundle support and admin audit coverage

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
+        "@aws-sdk/client-secrets-manager": "^3.600.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
         "@opentelemetry/instrumentation-express": "^0.66.0",
@@ -230,6 +231,278 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1098.0.tgz",
+      "integrity": "sha512-XdFhAffKIWY+dAsiWXnIwH57iFAdtiUFdsBACLmWOoSg54KsANtZuk5pTxsSyU7c+DQdUJTg/eknKNNk2lvLfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.3.tgz",
+      "integrity": "sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.64.tgz",
+      "integrity": "sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.66.tgz",
+      "integrity": "sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.9.tgz",
+      "integrity": "sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/credential-provider-env": "^3.972.64",
+        "@aws-sdk/credential-provider-http": "^3.972.66",
+        "@aws-sdk/credential-provider-login": "^3.972.71",
+        "@aws-sdk/credential-provider-process": "^3.972.64",
+        "@aws-sdk/credential-provider-sso": "^3.973.8",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.71.tgz",
+      "integrity": "sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.75.tgz",
+      "integrity": "sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.64",
+        "@aws-sdk/credential-provider-http": "^3.972.66",
+        "@aws-sdk/credential-provider-ini": "^3.973.9",
+        "@aws-sdk/credential-provider-process": "^3.972.64",
+        "@aws-sdk/credential-provider-sso": "^3.973.8",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.64.tgz",
+      "integrity": "sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.8.tgz",
+      "integrity": "sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/token-providers": "3.1098.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.70.tgz",
+      "integrity": "sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.38.tgz",
+      "integrity": "sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1098.0.tgz",
+      "integrity": "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2387,6 +2660,87 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -3313,6 +3667,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
@@ -5443,14 +5803,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/openapi3-ts": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
@@ -6810,6 +7162,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",

--- a/backend/src/__tests__/audit-log-streaming.test.ts
+++ b/backend/src/__tests__/audit-log-streaming.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
+import express from 'express';
 
 // ---------------------------------------------------------------------------
 // Row-budget constant (must match what's in schemas/zod.ts)
@@ -23,6 +24,8 @@ const RSS_CEILING_MB  = 200; // documented memory ceiling for 1M-row export
 // ---------------------------------------------------------------------------
 // Mocks — heavy dependencies
 // ---------------------------------------------------------------------------
+let auditLogLogSpy = vi.fn();
+
 vi.mock('../database', () => ({
   getPool: vi.fn(() => mockPool),
   saveContractEvent: vi.fn(),
@@ -74,7 +77,7 @@ vi.mock('../sep24-service', () => ({
 }));
 vi.mock('../admin-audit-log', () => ({
   AdminAuditLogService: vi.fn().mockImplementation(() => ({
-    log:   vi.fn(),
+    log:   auditLogLogSpy,
     query: vi.fn().mockResolvedValue({ entries: [], total: 0 }),
   })),
 }));
@@ -85,10 +88,10 @@ vi.mock('../middleware/api-key-rate-limit', () => ({
   apiKeyRateLimiter: vi.fn((_: any, __: any, next: any) => next()),
 }));
 vi.mock('../routes/docs', () => ({
-  default: { get: vi.fn(), use: vi.fn(), stack: [] },
+  default: express.Router(),
 }));
 vi.mock('../routes/compliance', () => ({
-  createComplianceRouter: vi.fn(() => ({ get: vi.fn(), use: vi.fn(), stack: [] })),
+  createComplianceRouter: vi.fn(() => express.Router()),
   autoFlagIfAboveThreshold: vi.fn(),
 }));
 vi.mock('../verifier', () => ({
@@ -191,6 +194,7 @@ describe('Audit-log export streaming and load (Feature D)', () => {
     cursorBatchRows   = [];
     cursorBatchIndex  = 0;
     listingRows       = [];
+    auditLogLogSpy = vi.fn();
     mockClient.query.mockClear();
     mockPool.query.mockClear();
     mockPool.connect.mockClear();
@@ -396,6 +400,39 @@ describe('Audit-log export streaming and load (Feature D)', () => {
       `growth=${growthMB.toFixed(1)} MB  ceiling=${RSS_CEILING_MB} MB`
     );
   }, 60_000); // generous timeout for large export
+
+  it('logs admin actions for webhook listing and audit export routes', async () => {
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (/select id, url, secret, previous_secret, secret_rotated_at, active, created_at, updated_at/i.test(sql)) {
+        return { rows: [{ id: 1, url: 'https://example.com', secret: 'secret', previous_secret: null, secret_rotated_at: null, active: true, created_at: new Date(), updated_at: new Date() }], rowCount: 1 };
+      }
+      if (/select count\(\*\) from admin_audit_log/i.test(sql)) {
+        return { rows: [{ count: '0' }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const webhooksRes = await request(app).get('/api/webhooks');
+    expect(webhooksRes.status).toBe(200);
+    expect(auditLogLogSpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'list_webhooks',
+      admin_address: 'unknown',
+    }));
+
+    const { from, to } = rangeParams(7);
+    mockCountRows = [{ count: '0' }];
+    cursorBatchRows = [[]];
+
+    const exportRes = await request(app).get(
+      `/api/admin/audit-log/export?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+    );
+
+    expect(exportRes.status).toBe(200);
+    expect(auditLogLogSpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'export_admin_audit_log',
+      admin_address: 'unknown',
+    }));
+  });
 
   // ── Listing cursor pagination ──────────────────────────────────────────
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response, NextFunction } from 'express';
-import express, { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 import cors from 'cors';
@@ -72,6 +71,19 @@ const verifier = new AssetVerifier();
 const logger = createLogger('api');
 const pool = getPool();
 const metricsService = getMetricsService(pool);
+
+async function logAdminAction(req: Request, action: string, target: string | null = null, params: Record<string, unknown> | null = null) {
+  const auditService = new AdminAuditLogService(pool);
+  await auditService.log({
+    admin_address: (req.headers['x-user-id'] as string) || 'unknown',
+    action,
+    target,
+    params_json: params,
+    tx_hash: null,
+    ip_address: (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ?? req.socket.remoteAddress ?? null,
+  });
+}
+
 fxRateCache.setMetricsObserver((from, to, stalenessSeconds) => {
   metricsService.setFxRateStalenessMetric(from, to, stalenessSeconds);
 });
@@ -213,6 +225,9 @@ app.get('/api/webhooks', adminLimiter, async (req: Request, res: Response) => {
       secret_rotated_at: row.secret_rotated_at,
       has_previous_secret: !!row.previous_secret,
     }));
+
+    await logAdminAction(req, 'list_webhooks', null, { count: subscriptions.length });
+
     res.status(200).json(subscriptions);
   } catch (error) {
     logger.error('Failed to get webhook subscribers', { error });
@@ -228,15 +243,7 @@ app.post('/api/webhooks/:id/rotate-secret', adminLimiter, validateParams(Webhook
     const { newSecret, rotatedAt } = await rotateWebhookSecret(id);
     const subscriber = await getWebhookSubscriberById(id);
 
-    const auditService = new AdminAuditLogService(pool);
-    await auditService.log({
-      admin_address: (req.headers['x-user-id'] as string) || 'unknown',
-      action: 'rotate_webhook_secret',
-      target: id,
-      params_json: null,
-      tx_hash: null,
-      ip_address: (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ?? req.socket.remoteAddress ?? null,
-    });
+    await logAdminAction(req, 'rotate_webhook_secret', id);
 
     // Notify subscriber of new secret via a signed delivery (best-effort)
     if (subscriber?.url) {
@@ -540,15 +547,7 @@ app.post('/api/kyc/config', adminLimiter, validateRequest(KycConfigSchema), asyn
 
     await saveAnchorKycConfig(config);
 
-    const auditService = new AdminAuditLogService(pool);
-    await auditService.log({
-      admin_address: (req.headers['x-user-id'] as string) || 'unknown',
-      action: 'configure_kyc',
-      target: anchorId,
-      params_json: { kycServerUrl, pollingIntervalMinutes, enabled },
-      tx_hash: null,
-      ip_address: (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ?? req.socket.remoteAddress ?? null,
-    });
+    await logAdminAction(req, 'configure_kyc', anchorId, { kycServerUrl, pollingIntervalMinutes, enabled });
 
     res.json({ success: true, message: 'Anchor KYC config saved successfully' });
   } catch (error) {
@@ -590,15 +589,7 @@ app.post('/api/kyc/register', validateRequest(KycRegisterSchema), async (req: Re
     const service = new kycService();
     await service.registerUserForKyc(sanitizedUserId, sanitizedAnchorId);
 
-    const auditService = new AdminAuditLogService(pool);
-    await auditService.log({
-      admin_address: (req.headers['x-user-id'] as string) || 'unknown',
-      action: 'register_kyc_user',
-      target: sanitizedUserId,
-      params_json: { anchorId: sanitizedAnchorId },
-      tx_hash: null,
-      ip_address: (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ?? req.socket.remoteAddress ?? null,
-    });
+    await logAdminAction(req, 'register_kyc_user', sanitizedUserId, { anchorId: sanitizedAnchorId });
 
     res.json({ success: true, message: 'User registered for KYC successfully' });
   } catch (error) {
@@ -861,6 +852,13 @@ app.get('/api/admin/audit-log', adminLimiter, validateQuery(AuditLogListQuerySch
       nextCursor = Buffer.from(JSON.stringify({ id: last.id, created_at: last.created_at })).toString('base64');
     }
 
+    await logAdminAction(req, 'list_admin_audit_log', null, {
+      action: q.action ?? null,
+      admin_address: q.admin_address ?? null,
+      limit,
+      cursor: Boolean(q.cursor),
+    });
+
     res.json({ limit, cursor: q.cursor ?? null, next_cursor: nextCursor, entries });
   } catch (error) {
     logger.error('Error fetching audit log', error);
@@ -872,6 +870,7 @@ app.get('/api/admin/audit-log', adminLimiter, validateQuery(AuditLogListQuerySch
 app.get('/api/admin/jobs', adminLimiter, async (req: Request, res: Response) => {
   try {
     const summaries = await getJobSummaries(pool);
+    await logAdminAction(req, 'view_admin_jobs', null, { job_count: summaries.length });
     res.json({ jobs: summaries });
   } catch (error) {
     logger.error('Error fetching job summaries', error);
@@ -895,6 +894,13 @@ app.get('/api/admin/audit-log/export', adminLimiter, validateQuery(AuditLogExpor
     if (action)       { baseParams.push(action);        extraWhere += ` AND action = $${baseParams.length}`; }
 
     const baseWhere = `WHERE created_at >= $1 AND created_at <= $2${extraWhere}`;
+
+    await logAdminAction(req, 'export_admin_audit_log', null, {
+      from: q.from as string,
+      to: q.to as string,
+      admin_address: adminAddress ?? null,
+      action: action ?? null,
+    });
 
     // Check row count before streaming — hard cap at AUDIT_LOG_EXPORT_ROW_CAP
     const countRes = await pool.query(

--- a/backend/src/sep24-service.ts
+++ b/backend/src/sep24-service.ts
@@ -584,6 +584,7 @@ export class Sep24Service {
         asset_code:  transaction.asset_code,
         amount:      actualAmount,
         refunded_at: new Date().toISOString(),
+      });
       await this.dispatcher.dispatch('sep24.expired_refund', {
         event: 'sep24.expired_refund',
         timestamp: new Date().toISOString(),

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig([
     target: "node18",
     outDir: "dist",
   },
-  // Browser: IIFE (UMD-compatible) + ESM, no Node.js built-ins
+  // Browser: IIFE (UMD-compatible) + ESM, suitable for CDN use
   {
     entry: { "browser/index": "src/index.ts" },
     format: ["iife", "esm"],
@@ -22,11 +22,17 @@ export default defineConfig([
     target: "es2020",
     outDir: "dist",
     platform: "browser",
+    minify: false,
+    splitting: false,
     // Prevent Node.js built-ins from leaking into the browser bundle
     noExternal: [],
     external: ["@stellar/stellar-sdk"],
     esbuildOptions(options) {
       options.conditions = ["browser"];
+      options.define = {
+        ...options.define,
+        global: "globalThis",
+      };
     },
   },
 ]);


### PR DESCRIPTION
Added a browser-oriented build output for the SDK so it can be consumed from a CDN and loaded in browser environments.
Ensured the browser bundle is built with browser-safe settings and does not leak Node-specific behavior into the client bundle.
Added a bundle-size check to CI so the browser artifact stays within a reasonable size budget.
Audited admin-facing endpoints and wired them to the existing admin audit logging flow so privileged actions are consistently recorded.

Closes #861

Closes #915 