### PR TITLE
Fix/sdk issues 1153 1156

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,15 @@ jobs:
       - name: Lint chart (production values)
         run: helm lint charts/swiftremit -f charts/swiftremit/values.production.yaml
 
+  # ── SDK contract-surface coverage ──────────────────────────────────────────
+  sdk-contract-coverage:
+    name: SDK contract-surface coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on contract functions with no SDK binding or exclusion
+        run: node sdk/scripts/check-contract-coverage.mjs
+
   # ── Summary gate ───────────────────────────────────────────────────────────
   ci:
     name: CI
@@ -304,6 +313,7 @@ jobs:
       - frontend-lint
       - frontend-coverage
       - sdk-bundle-size
+      - sdk-contract-coverage
       - helm-lint
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Publish SDK to npm
         working-directory: sdk
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -42,6 +42,10 @@
     "usdc"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=13.0.0"
   },

--- a/sdk/react-native/jest.config.cjs
+++ b/sdk/react-native/jest.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
+  // Source files use ESM-style './foo.js' specifiers that point at './foo.ts';
+  // map them back so ts-jest (running under CommonJS) can resolve them.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        // The `@swiftremit/sdk` workspace dependency isn't linked outside a
+        // full monorepo install; skip type-checking during test transpilation
+        // so tests can run against mocked modules without that link in place.
+        isolatedModules: true,
+      },
+    ],
+  },
+};

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -7,10 +7,14 @@
   "files": ["dist", "src"],
   "scripts": {
     "build": "tsc",
-    "test": "jest --passWithNoTests"
+    "test": "jest"
   },
   "keywords": ["stellar", "soroban", "swiftremit", "react-native", "remittance"],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=13.0.0",
     "react": ">=18.0.0",
@@ -20,8 +24,15 @@
     "@swiftremit/sdk": "*"
   },
   "devDependencies": {
+    "@stellar/stellar-sdk": "^13.0.0",
+    "@types/jest": "^29.5.12",
     "@types/react": "^18.0.0",
     "@types/react-native": "^0.72.0",
+    "@types/react-test-renderer": "^18.0.0",
+    "jest": "^29.7.0",
+    "react": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
+    "ts-jest": "^29.1.2",
     "typescript": "^5.4.0"
   }
 }

--- a/sdk/react-native/src/client.test.ts
+++ b/sdk/react-native/src/client.test.ts
@@ -1,0 +1,85 @@
+import { Keypair, Networks, TransactionBuilder, Account } from '@stellar/stellar-sdk';
+
+const submitSignedTransactionMock = jest.fn().mockResolvedValue({ status: 'SUCCESS' });
+
+jest.mock(
+  '@swiftremit/sdk',
+  () => {
+    class SwiftRemitClient {
+      constructor(_options: unknown) {}
+      submitSignedTransaction = submitSignedTransactionMock;
+    }
+    return { SwiftRemitClient };
+  },
+  { virtual: true }
+);
+
+import { SwiftRemitRNClient } from './client.js';
+import type { SwiftRemitSigner } from './signer.js';
+
+function buildUnsignedTx() {
+  const source = Keypair.random();
+  const account = new Account(source.publicKey(), '0');
+  const tx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .setTimeout(30)
+    .build();
+  return { tx, source };
+}
+
+describe('SwiftRemitRNClient', () => {
+  beforeEach(() => {
+    submitSignedTransactionMock.mockClear();
+  });
+
+  it('getAddress delegates to the injected signer', async () => {
+    const signer: SwiftRemitSigner = {
+      getPublicKey: jest.fn().mockResolvedValue('GEXAMPLE'),
+      signTransaction: jest.fn(),
+    };
+    const client = new SwiftRemitRNClient({
+      contractId: 'CCONTRACT',
+      networkPassphrase: Networks.TESTNET,
+      rpcUrl: 'https://rpc.example',
+      signer,
+    });
+
+    await expect(client.getAddress()).resolves.toBe('GEXAMPLE');
+    expect(signer.getPublicKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('submitSigned signs via the injected signer and submits the already-signed transaction', async () => {
+    const { tx, source } = buildUnsignedTx();
+
+    const signer: SwiftRemitSigner = {
+      getPublicKey: jest.fn().mockResolvedValue(source.publicKey()),
+      signTransaction: jest.fn(async (xdr: string, { networkPassphrase }: { networkPassphrase: string }) => {
+        const parsed = TransactionBuilder.fromXDR(xdr, networkPassphrase);
+        (parsed as import('@stellar/stellar-sdk').Transaction).sign(source);
+        return parsed.toXDR();
+      }),
+    };
+
+    const client = new SwiftRemitRNClient({
+      contractId: 'CCONTRACT',
+      networkPassphrase: Networks.TESTNET,
+      rpcUrl: 'https://rpc.example',
+      signer,
+    });
+
+    const result = await client.submitSigned(tx);
+
+    expect(signer.signTransaction).toHaveBeenCalledWith(
+      tx.toXDR(),
+      expect.objectContaining({ networkPassphrase: Networks.TESTNET })
+    );
+    // Regression check: submitSigned must not re-sign with a fake keypair —
+    // it should hand the already-signed transaction to submitSignedTransaction.
+    expect(submitSignedTransactionMock).toHaveBeenCalledTimes(1);
+    const submittedTx = submitSignedTransactionMock.mock.calls[0][0] as import('@stellar/stellar-sdk').Transaction;
+    expect(submittedTx.signatures.length).toBeGreaterThan(0);
+    expect(result).toEqual({ status: 'SUCCESS' });
+  });
+});

--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -52,10 +52,6 @@ export class SwiftRemitRNClient extends SwiftRemitClient {
     });
     const signedTx = TransactionBuilder.fromXDR(signedXdr, this._networkPassphrase);
     // Cast: fromXDR returns FeeBumpTransaction | Transaction; we know it's Transaction here
-    return this.submitTransaction(
-      signedTx as import('@stellar/stellar-sdk').Transaction,
-      // submitTransaction expects a Keypair but we've already signed — pass a no-op shim
-      { sign: () => {} } as any
-    );
+    return this.submitSignedTransaction(signedTx as import('@stellar/stellar-sdk').Transaction);
   }
 }

--- a/sdk/react-native/src/hooks.test.ts
+++ b/sdk/react-native/src/hooks.test.ts
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { useCreateRemittance, useNetworkToggle } from './hooks.js';
+import type { SwiftRemitRNClient } from './client.js';
+
+describe('useNetworkToggle', () => {
+  it('defaults to testnet and toggles between networks', () => {
+    let hookResult: ReturnType<typeof useNetworkToggle> | undefined;
+    function Harness() {
+      hookResult = useNetworkToggle();
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    expect(hookResult?.network).toBe('testnet');
+    expect(hookResult?.isTestnet).toBe(true);
+
+    act(() => {
+      hookResult?.toggle();
+    });
+    expect(hookResult?.network).toBe('mainnet');
+
+    act(() => {
+      hookResult?.toggle();
+    });
+    expect(hookResult?.network).toBe('testnet');
+  });
+});
+
+describe('useCreateRemittance', () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it('tracks loading state across a successful submission', async () => {
+    const createDeferred = deferred<unknown>();
+    const submitDeferred = deferred<unknown>();
+    const client = {
+      createRemittance: jest.fn().mockReturnValue(createDeferred.promise),
+      submitSigned: jest.fn().mockReturnValue(submitDeferred.promise),
+    } as unknown as SwiftRemitRNClient;
+
+    let hookResult: ReturnType<typeof useCreateRemittance> | undefined;
+    function Harness() {
+      hookResult = useCreateRemittance(client);
+      return null;
+    }
+
+    act(() => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    expect(hookResult?.isLoading).toBe(false);
+
+    let callPromise: Promise<unknown>;
+    act(() => {
+      callPromise = hookResult!.createRemittance({} as never);
+    });
+    expect(hookResult?.isLoading).toBe(true);
+
+    await act(async () => {
+      createDeferred.resolve('prepared-tx');
+      submitDeferred.resolve('result');
+      await callPromise;
+    });
+
+    expect(hookResult?.isLoading).toBe(false);
+    expect(hookResult?.error).toBeNull();
+  });
+
+  it('does not update state after the component has unmounted', async () => {
+    const createDeferred = deferred<unknown>();
+    const client = {
+      createRemittance: jest.fn().mockReturnValue(createDeferred.promise),
+      submitSigned: jest.fn().mockResolvedValue('result'),
+    } as unknown as SwiftRemitRNClient;
+
+    let hookResult: ReturnType<typeof useCreateRemittance> | undefined;
+    function Harness() {
+      hookResult = useCreateRemittance(client);
+      return null;
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(Harness));
+    });
+
+    let callPromise: Promise<unknown>;
+    act(() => {
+      callPromise = hookResult!.createRemittance({} as never).catch(() => {
+        // Swallow: the point of this test is that no *state update* happens
+        // post-unmount, not whether the in-flight promise itself resolves.
+      });
+    });
+
+    act(() => {
+      renderer.unmount();
+    });
+
+    // Resolving after unmount must not throw or warn — the mounted-ref guard
+    // in useCreateRemittance should skip the setState call entirely.
+    await act(async () => {
+      createDeferred.resolve('prepared-tx');
+      await callPromise;
+    });
+  });
+});

--- a/sdk/react-native/src/hooks.ts
+++ b/sdk/react-native/src/hooks.ts
@@ -5,7 +5,7 @@
  * state management for common operations.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { SwiftRemitRNClient } from './client.js';
 
 // ── useRemittance ─────────────────────────────────────────────────────────────
@@ -24,18 +24,26 @@ interface UseRemittanceState {
  */
 export function useCreateRemittance(client: SwiftRemitRNClient) {
   const [state, setState] = useState<UseRemittanceState>({ loading: false, error: null });
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const createRemittance = useCallback(
     async (params: Parameters<SwiftRemitRNClient['createRemittance']>[0]) => {
-      setState({ loading: true, error: null });
+      if (mountedRef.current) setState({ loading: true, error: null });
       try {
         const tx = await client.createRemittance(params);
         const result = await client.submitSigned(tx);
-        setState({ loading: false, error: null });
+        if (mountedRef.current) setState({ loading: false, error: null });
         return result;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
-        setState({ loading: false, error });
+        if (mountedRef.current) setState({ loading: false, error });
         throw error;
       }
     },

--- a/sdk/react-native/src/signer.test.ts
+++ b/sdk/react-native/src/signer.test.ts
@@ -1,0 +1,43 @@
+import type { SwiftRemitSigner } from './signer.js';
+
+describe('SwiftRemitSigner', () => {
+  it('accepts an implementation backed by an in-memory secure store', async () => {
+    const store = new Map<string, string>();
+    store.set('stellar_public_key', 'GEXAMPLE');
+    store.set('stellar_secret_key', 'SEXAMPLE');
+
+    const signer: SwiftRemitSigner = {
+      async getPublicKey() {
+        return store.get('stellar_public_key') ?? '';
+      },
+      async signTransaction(xdr) {
+        // A real implementation would decode `xdr`, sign with the secret key
+        // loaded from secure storage, and return the signed XDR. Here we just
+        // verify the interface shape and that the secret never leaves the
+        // signer (the caller only ever sees `xdr` in and signed XDR out).
+        if (!store.get('stellar_secret_key')) throw new Error('No key in secure store');
+        return `signed:${xdr}`;
+      },
+    };
+
+    await expect(signer.getPublicKey()).resolves.toBe('GEXAMPLE');
+    await expect(
+      signer.signTransaction('unsigned-xdr', { networkPassphrase: 'Test SDF Network ; September 2015' })
+    ).resolves.toBe('signed:unsigned-xdr');
+  });
+
+  it('propagates errors when the secret key is unavailable', async () => {
+    const signer: SwiftRemitSigner = {
+      async getPublicKey() {
+        return '';
+      },
+      async signTransaction() {
+        throw new Error('No key in secure store');
+      },
+    };
+
+    await expect(
+      signer.signTransaction('xdr', { networkPassphrase: 'Test SDF Network ; September 2015' })
+    ).rejects.toThrow('No key in secure store');
+  });
+});

--- a/sdk/react-native/tsconfig.json
+++ b/sdk/react-native/tsconfig.json
@@ -11,5 +11,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/sdk/scripts/check-contract-coverage.mjs
+++ b/sdk/scripts/check-contract-coverage.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Fails the build when a public contract function has no SDK binding and no
+// explicit exclusion. Keeps sdk/src/client.ts honest against src/lib.rs as
+// the contract surface grows (SR-083).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+const libRs = readFileSync(path.join(repoRoot, "src", "lib.rs"), "utf8");
+const clientTs = readFileSync(path.join(repoRoot, "sdk", "src", "client.ts"), "utf8");
+const exclusions = JSON.parse(
+  readFileSync(path.join(__dirname, "coverage-exclusions.json"), "utf8")
+);
+
+// Restrict extraction to the #[contractimpl] block so we only count the
+// contract's actual public entry points, not unrelated `pub fn` helpers.
+const implStart = libRs.indexOf("impl SwiftRemitContract");
+if (implStart === -1) {
+  console.error("check-contract-coverage: could not locate `impl SwiftRemitContract` in src/lib.rs");
+  process.exit(1);
+}
+const implBody = libRs.slice(implStart);
+
+const contractFns = new Set(
+  [...implBody.matchAll(/^ {4}pub fn (\w+)\(/gm)].map((m) => m[1])
+);
+
+// The SDK calls contract methods via string literals: this.prepareTransaction(
+// source, "method_name", ...) / this.simulateCall(source, "method_name", ...).
+const boundFns = new Set(
+  [...clientTs.matchAll(/\b(?:prepareTransaction|simulateCall)\(\s*[^,]+,\s*"(\w+)"/g)].map(
+    (m) => m[1]
+  )
+);
+
+const missing = [...contractFns]
+  .filter((fn) => !boundFns.has(fn) && !exclusions[fn])
+  .sort();
+
+if (missing.length > 0) {
+  console.error(
+    `check-contract-coverage: ${missing.length} contract function(s) have no SDK binding and no exclusion entry:\n`
+  );
+  for (const fn of missing) console.error(`  - ${fn}`);
+  console.error(
+    "\nAdd a binding in sdk/src/client.ts, or a justified entry in sdk/scripts/coverage-exclusions.json."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-contract-coverage: OK — ${contractFns.size} contract function(s), ${boundFns.size} bound, ${
+    Object.keys(exclusions).length
+  } excluded.`
+);

--- a/sdk/scripts/coverage-exclusions.json
+++ b/sdk/scripts/coverage-exclusions.json
@@ -1,0 +1,3 @@
+{
+  "import_migration_batch": "Requires encoding a full Vec<Remittance> (including the MaybeSettlementConfig/MaybeBytes32 wrapper enums) back into contract ScVal form for a write call. The SDK's Remittance type is currently read-only (parseRemittance does not round-trip settlement_config/dispute_evidence), so a correct write-side encoder needs its own design pass rather than a guess. Tracked as follow-up under SR-083."
+}

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -336,10 +336,26 @@ export class SwiftRemitClient {
     keypair: Keypair,
     options?: { retryPolicy?: RetryPolicy }
   ): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
+    tx.sign(keypair);
+    return this.submitSignedTransaction(tx, options);
+  }
+
+  /**
+   * Submit a transaction that has already been signed (e.g. by an external
+   * wallet or a {@link SwiftRemitSigner}-style signer) and wait for confirmation.
+   * Unlike {@link submitTransaction}, this does not sign the transaction itself.
+   *
+   * @param tx - A transaction that already carries a valid signature
+   * @param options.retryPolicy - Per-call retry policy that overrides the client's
+   *   `writeRetryPolicy`. See {@link submitTransaction} for guidance on when to opt in.
+   */
+  async submitSignedTransaction(
+    tx: Transaction,
+    options?: { retryPolicy?: RetryPolicy }
+  ): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
     const writePolicy = this.resolveWriteRetryPolicy(options?.retryPolicy);
     const defaults = { delayMs: this.retryDelayMs, backoffFactor: this.retryBackoffFactor };
 
-    tx.sign(keypair);
     const sendResult = await withRetryPolicy(
       () => this.server.sendTransaction(tx),
       writePolicy,

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -32,6 +32,23 @@ import type {
   Corridor,
   FeeEstimate,
   EventHandler,
+  Escrow,
+  AssetVerification,
+  VerificationStatus,
+  PauseRecord,
+  PauseReason,
+  FeeStrategy,
+  FeeCorridor,
+  RateLimitConfig,
+  RateLimitStatus,
+  TransactionRecord,
+  MigrationSnapshot,
+  BatchSettlementEntry,
+  Role,
+  RemittanceStatus,
+  FeeBreakdown,
+  AdminOperationType,
+  PendingOperation,
 } from "./types.js";
 import { parseContractError, SwiftRemitError, ErrorCode } from "./errors.js";
 import { withRetry, withRetryPolicy } from "./retry.js";
@@ -48,6 +65,25 @@ import {
   bytesNToScVal,
   stringToScVal,
   parseProposal,
+  parseEscrow,
+  parseAssetVerification,
+  parsePauseRecord,
+  parseFeeStrategy,
+  parseFeeCorridor,
+  parseRateLimitConfig,
+  parseRateLimitStatus,
+  parseTransactionRecord,
+  parseMigrationSnapshot,
+  parsePendingOperation,
+  adminOperationTypeToScVal,
+  roleToScVal,
+  verificationStatusToScVal,
+  pauseReasonToScVal,
+  feeStrategyToScVal,
+  feeCorridorToScVal,
+  batchSettlementEntryToScVal,
+  u32ToScVal,
+  boolToScVal,
 } from "./convert.js";
 
 /** Maximum number of entries allowed in a single batch remittance call. */
@@ -1010,14 +1046,14 @@ export class SwiftRemitClient {
   async getGovernanceConfig(sourceAddress: string): Promise<GovernanceConfig> {
     const result = await this.simulateCall(
       sourceAddress,
-      "query_governance_config",
+      "get_governance_config",
       []
     );
-    const native = scValToNative(result);
+    const native = scValToNative(result) as Record<string, unknown>;
     return {
       quorum: Number(native.quorum),
-      timelockSeconds: BigInt(native.timelock_seconds),
-      proposalTtlSeconds: BigInt(native.proposal_ttl_seconds),
+      timelockSeconds: BigInt(native.timelock_seconds as number),
+      proposalTtlSeconds: BigInt(native.proposal_ttl_seconds as number),
     };
   }
 
@@ -1153,6 +1189,772 @@ export class SwiftRemitClient {
     return this.prepareTransaction(sourceAddress, "execute", [
       addressToScVal(sourceAddress),
       u64ToScVal(proposalId),
+    ]);
+  }
+
+  // ─── Admin transfer ──────────────────────────────────────────────────────────
+
+  /** Proposes a two-step admin transfer. Requires the current admin. Throws {@link ErrorCode.Unauthorized}. */
+  async proposeAdmin(admin: string, newAdmin: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "propose_admin", [addressToScVal(newAdmin)]);
+  }
+
+  /** Accepts a pending admin transfer. Requires the proposed new admin. Throws {@link ErrorCode.NoPendingAdminTransfer}. */
+  async acceptAdmin(newAdmin: string): Promise<Transaction> {
+    return this.prepareTransaction(newAdmin, "accept_admin", []);
+  }
+
+  /** Removes an admin. Requires an existing admin as caller. Throws {@link ErrorCode.CannotRemoveLastAdmin}. */
+  async removeAdmin(caller: string, adminToRemove: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "remove_admin", [
+      addressToScVal(caller),
+      addressToScVal(adminToRemove),
+    ]);
+  }
+
+  // ─── Role-based authorization ─────────────────────────────────────────────────
+
+  /** Grants a role to an address. Requires caller authorization. */
+  async assignRole(caller: string, address: string, role: Role): Promise<Transaction> {
+    return this.prepareTransaction(caller, "assign_role", [
+      addressToScVal(caller),
+      addressToScVal(address),
+      roleToScVal(role),
+    ]);
+  }
+
+  /** Revokes a role from an address. Requires caller authorization. */
+  async removeRole(caller: string, address: string, role: Role): Promise<Transaction> {
+    return this.prepareTransaction(caller, "remove_role", [
+      addressToScVal(caller),
+      addressToScVal(address),
+      roleToScVal(role),
+    ]);
+  }
+
+  /** Returns whether `address` currently holds `role`. */
+  async hasRole(sourceAddress: string, address: string, role: Role): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "has_role", [
+      addressToScVal(address),
+      roleToScVal(role),
+    ]);
+    return Boolean(scValToNative(val));
+  }
+
+  /** Returns whether `address` currently has admin privileges. */
+  async isAdmin(sourceAddress: string, address: string): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "is_admin", [addressToScVal(address)]);
+    return Boolean(scValToNative(val));
+  }
+
+  // ─── Token whitelist ───────────────────────────────────────────────────────────
+
+  /** Whitelists a token for use in the contract. Requires admin. Throws {@link ErrorCode.TokenAlreadyWhitelisted}. */
+  async addWhitelistedToken(admin: string, token: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "add_whitelisted_token", [addressToScVal(token)]);
+  }
+
+  /** Removes a token from the whitelist. Requires admin. Throws {@link ErrorCode.TokenNotWhitelisted}. */
+  async removeWhitelistedToken(admin: string, token: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "remove_whitelisted_token", [addressToScVal(token)]);
+  }
+
+  /** Returns all whitelisted token addresses. */
+  async getWhitelistedTokens(sourceAddress: string): Promise<string[]> {
+    const val = await this.simulateCall(sourceAddress, "get_whitelisted_tokens", []);
+    return (scValToNative(val) as { toString(): string }[]).map((a) => a.toString());
+  }
+
+  // ─── Blacklist ───────────────────────────────────────────────────────────────
+
+  /** Blacklists a user, preventing them from transacting. Requires admin. */
+  async blacklistUser(admin: string, user: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "blacklist_user", [addressToScVal(user)]);
+  }
+
+  /** Removes a user from the blacklist. Requires admin. */
+  async removeFromBlacklist(admin: string, user: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "remove_from_blacklist", [addressToScVal(user)]);
+  }
+
+  /** Sets a user's blacklist status directly. Requires admin. */
+  async setUserBlacklisted(admin: string, user: string, blacklisted: boolean): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_user_blacklisted", [
+      addressToScVal(user),
+      boolToScVal(blacklisted),
+    ]);
+  }
+
+  /** Returns whether `user` is currently blacklisted. */
+  async isUserBlacklisted(sourceAddress: string, user: string): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "is_user_blacklisted", [addressToScVal(user)]);
+    return Boolean(scValToNative(val));
+  }
+
+  // ─── KYC ─────────────────────────────────────────────────────────────────────
+
+  /** Sets a user's KYC approval status and expiry. Requires admin. */
+  async setKycApproved(admin: string, user: string, approved: boolean, expiry: bigint): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_kyc_approved", [
+      addressToScVal(user),
+      boolToScVal(approved),
+      u64ToScVal(expiry),
+    ]);
+  }
+
+  /** Returns whether `user` has non-expired KYC approval. */
+  async isKycApproved(sourceAddress: string, user: string): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "is_kyc_approved", [addressToScVal(user)]);
+    return Boolean(scValToNative(val));
+  }
+
+  /** Returns the agent's stored KYC document hash, or null if none is set. */
+  async getAgentKycHash(sourceAddress: string, agent: string): Promise<string | null> {
+    const val = await this.simulateCall(sourceAddress, "get_agent_kyc_hash", [addressToScVal(agent)]);
+    const native = scValToNative(val);
+    return native ? Buffer.from(native as Uint8Array).toString("hex") : null;
+  }
+
+  // ─── Circuit breaker / pause ─────────────────────────────────────────────────
+
+  /** Legacy pause wrapper (bypasses timelock/quorum checks). Requires admin. */
+  async pause(admin: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "pause", []);
+  }
+
+  /** Legacy unpause wrapper (bypasses timelock/quorum checks). Requires admin. */
+  async unpause(admin: string): Promise<Transaction> {
+    return this.prepareTransaction(admin, "unpause", []);
+  }
+
+  /** Pauses the contract with a structured reason and audit trail. Requires admin. Throws {@link ErrorCode.AlreadyPaused}. */
+  async emergencyPause(caller: string, reason: PauseReason): Promise<Transaction> {
+    return this.prepareTransaction(caller, "emergency_pause", [
+      addressToScVal(caller),
+      pauseReasonToScVal(reason),
+    ]);
+  }
+
+  /** Unpauses the contract, enforcing timelock/quorum unless bypassed. Requires admin. Throws {@link ErrorCode.TimelockActive}. */
+  async emergencyUnpause(caller: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "emergency_unpause", [addressToScVal(caller)]);
+  }
+
+  /** Casts an admin vote to unpause; auto-unpauses when quorum is reached. */
+  async voteUnpause(caller: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "vote_unpause", [addressToScVal(caller)]);
+  }
+
+  /** Returns whether the contract is currently paused. */
+  async isPaused(sourceAddress: string): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "is_paused", []);
+    return Boolean(scValToNative(val));
+  }
+
+  /** Sets the emergency-unpause timelock duration in seconds (max 604800). Requires admin. */
+  async setPauseTimelock(caller: string, seconds: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_pause_timelock", [
+      addressToScVal(caller),
+      u64ToScVal(seconds),
+    ]);
+  }
+
+  /** Sets the number of admin votes required to unpause. Requires admin. Throws {@link ErrorCode.InvalidQuorum}. */
+  async setUnpauseQuorum(caller: string, quorum: number): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_unpause_quorum", [
+      addressToScVal(caller),
+      u32ToScVal(quorum),
+    ]);
+  }
+
+  /** Returns the configured post-unpause rate-limit cooldown window, in seconds. */
+  async getCooldownPeriod(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_cooldown_period", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  /** Returns the active pause record, or null when the contract is not paused. */
+  async getCurrentPauseRecord(sourceAddress: string): Promise<PauseRecord | null> {
+    const val = await this.simulateCall(sourceAddress, "get_current_pause_record", []);
+    const native = scValToNative(val);
+    return native ? parsePauseRecord(val) : null;
+  }
+
+  /** Returns the pause record for a given sequence number. Throws when not found. */
+  async getPauseRecord(sourceAddress: string, seq: bigint): Promise<PauseRecord> {
+    const val = await this.simulateCall(sourceAddress, "get_pause_record", [u64ToScVal(seq)]);
+    return parsePauseRecord(val);
+  }
+
+  /** Returns the total number of pause events ever recorded. */
+  async getPauseHistoryCount(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_pause_history_count", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  // ─── Escrow ──────────────────────────────────────────────────────────────────
+
+  /** Locks funds in escrow for `recipient`. Requires sender authorization. */
+  async createEscrow(sender: string, recipient: string, amount: bigint): Promise<Transaction> {
+    return this.prepareTransaction(sender, "create_escrow", [
+      addressToScVal(sender),
+      addressToScVal(recipient),
+      i128ToScVal(amount),
+    ]);
+  }
+
+  /** Releases escrowed funds to the recipient. Requires admin. Throws {@link ErrorCode.InvalidEscrowStatus}. */
+  async releaseEscrow(admin: string, transferId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(admin, "release_escrow", [u64ToScVal(transferId)]);
+  }
+
+  /** Refunds escrowed funds back to the sender. Requires the escrow's original sender. */
+  async refundEscrow(sender: string, transferId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(sender, "refund_escrow", [u64ToScVal(transferId)]);
+  }
+
+  /** Returns the escrow record for `transferId`. Throws {@link ErrorCode.EscrowNotFound}. */
+  async getEscrow(sourceAddress: string, transferId: bigint): Promise<Escrow> {
+    const val = await this.simulateCall(sourceAddress, "get_escrow", [u64ToScVal(transferId)]);
+    return parseEscrow(val);
+  }
+
+  /** Returns the configured escrow storage TTL in ledgers. */
+  async getEscrowTtl(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_escrow_ttl", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  /** Updates the escrow storage TTL. Requires admin. */
+  async updateEscrowTtl(admin: string, ttl: bigint): Promise<Transaction> {
+    return this.prepareTransaction(admin, "update_escrow_ttl", [u64ToScVal(ttl)]);
+  }
+
+  /** Processes a batch of expired escrows, refunding senders. Returns the IDs successfully processed. */
+  async processExpiredEscrows(caller: string, transferIds: bigint[]): Promise<Transaction> {
+    return this.prepareTransaction(caller, "process_expired_escrows", [
+      xdr.ScVal.scvVec(transferIds.map((id) => u64ToScVal(id))),
+    ]);
+  }
+
+  /** Returns the remittance status for a transfer, or null if not found. */
+  async getTransferState(sourceAddress: string, transferId: bigint): Promise<RemittanceStatus | null> {
+    const val = await this.simulateCall(sourceAddress, "get_transfer_state", [u64ToScVal(transferId)]);
+    const native = scValToNative(val);
+    if (!native) return null;
+    return Object.keys(native as Record<string, unknown>)[0] as RemittanceStatus;
+  }
+
+  // ─── Asset verification ──────────────────────────────────────────────────────
+
+  /** Stores or updates an asset's verification record. Requires admin. Throws {@link ErrorCode.InvalidReputationScore}. */
+  async setAssetVerification(
+    admin: string,
+    assetCode: string,
+    issuer: string,
+    status: VerificationStatus,
+    reputationScore: number,
+    trustlineCount: bigint,
+    hasToml: boolean
+  ): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_asset_verification", [
+      stringToScVal(assetCode),
+      addressToScVal(issuer),
+      verificationStatusToScVal(status),
+      u32ToScVal(reputationScore),
+      u64ToScVal(trustlineCount),
+      boolToScVal(hasToml),
+    ]);
+  }
+
+  /** Returns the verification record for an asset. Throws {@link ErrorCode.AssetNotFound}. */
+  async getAssetVerification(sourceAddress: string, assetCode: string, issuer: string): Promise<AssetVerification> {
+    const val = await this.simulateCall(sourceAddress, "get_asset_verification", [
+      stringToScVal(assetCode),
+      addressToScVal(issuer),
+    ]);
+    return parseAssetVerification(val);
+  }
+
+  /** Returns whether a verification record exists for the given asset. */
+  async hasAssetVerification(sourceAddress: string, assetCode: string, issuer: string): Promise<boolean> {
+    const val = await this.simulateCall(sourceAddress, "has_asset_verification", [
+      stringToScVal(assetCode),
+      addressToScVal(issuer),
+    ]);
+    return Boolean(scValToNative(val));
+  }
+
+  /** Validates that an asset is safe to use. Throws {@link ErrorCode.SuspiciousAsset} if flagged. */
+  async validateAssetSafety(caller: string, assetCode: string, issuer: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "validate_asset_safety", [
+      stringToScVal(assetCode),
+      addressToScVal(issuer),
+    ]);
+  }
+
+  // ─── Fee corridors / strategy ─────────────────────────────────────────────────
+
+  /** Sets a per-corridor fee configuration. Requires admin. */
+  async setFeeCorridor(caller: string, corridor: FeeCorridor): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_fee_corridor", [
+      addressToScVal(caller),
+      feeCorridorToScVal(corridor),
+    ]);
+  }
+
+  /** Removes a corridor's fee configuration, reverting to the global default. Requires admin. */
+  async removeFeeCorridor(caller: string, fromCountry: string, toCountry: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "remove_fee_corridor", [
+      addressToScVal(caller),
+      stringToScVal(fromCountry),
+      stringToScVal(toCountry),
+    ]);
+  }
+
+  /** Returns the fee corridor configuration for a country pair, or null if unset. */
+  async getFeeCorridor(sourceAddress: string, fromCountry: string, toCountry: string): Promise<FeeCorridor | null> {
+    const val = await this.simulateCall(sourceAddress, "get_fee_corridor", [
+      stringToScVal(fromCountry),
+      stringToScVal(toCountry),
+    ]);
+    const native = scValToNative(val);
+    return native ? parseFeeCorridor(val) : null;
+  }
+
+  /** Updates the globally active fee strategy. Requires admin. */
+  async updateFeeStrategy(caller: string, strategy: FeeStrategy): Promise<Transaction> {
+    return this.prepareTransaction(caller, "update_fee_strategy", [
+      addressToScVal(caller),
+      feeStrategyToScVal(strategy),
+    ]);
+  }
+
+  /** Returns the currently active fee strategy. */
+  async getFeeStrategy(sourceAddress: string): Promise<FeeStrategy> {
+    const val = await this.simulateCall(sourceAddress, "get_fee_strategy", []);
+    return parseFeeStrategy(scValToNative(val));
+  }
+
+  /** Calculates the fee breakdown for `amount` using the active global strategy. */
+  async calculateFeeBreakdown(sourceAddress: string, amount: bigint): Promise<FeeBreakdown> {
+    const val = await this.simulateCall(sourceAddress, "calculate_fee_breakdown", [i128ToScVal(amount)]);
+    return parseFeeBreakdown(val);
+  }
+
+  /** Calculates the fee breakdown for `amount` under a specific corridor's configuration. */
+  async feeBreakdownCorridor(sourceAddress: string, amount: bigint, corridor: FeeCorridor): Promise<FeeBreakdown> {
+    const val = await this.simulateCall(sourceAddress, "fee_breakdown_corridor", [
+      i128ToScVal(amount),
+      feeCorridorToScVal(corridor),
+    ]);
+    return parseFeeBreakdown(val);
+  }
+
+  /** Returns the global protocol fee in basis points. */
+  async getProtocolFeeBps(sourceAddress: string): Promise<number> {
+    const val = await this.simulateCall(sourceAddress, "get_protocol_fee_bps", []);
+    return Number(scValToNative(val));
+  }
+
+  /** Updates the global protocol fee in basis points. Requires admin. Throws {@link ErrorCode.InvalidFeeBps}. */
+  async updateProtocolFee(caller: string, feeBps: number): Promise<Transaction> {
+    return this.prepareTransaction(caller, "update_protocol_fee", [
+      addressToScVal(caller),
+      u32ToScVal(feeBps),
+    ]);
+  }
+
+  /** Returns a token-specific fee override in basis points, or null if unset. */
+  async getTokenFeeBps(sourceAddress: string, token: string): Promise<number | null> {
+    const val = await this.simulateCall(sourceAddress, "get_token_fee_bps", [addressToScVal(token)]);
+    const native = scValToNative(val);
+    return native != null ? Number(native) : null;
+  }
+
+  /** Sets a token-specific fee override in basis points. Requires admin. */
+  async updateTokenFee(caller: string, token: string, feeBps: number): Promise<Transaction> {
+    return this.prepareTransaction(caller, "update_token_fee", [
+      addressToScVal(caller),
+      addressToScVal(token),
+      u32ToScVal(feeBps),
+    ]);
+  }
+
+  // ─── Treasury ────────────────────────────────────────────────────────────────
+
+  /** Returns the configured treasury address. Throws {@link ErrorCode.NotInitialized}. */
+  async getTreasury(sourceAddress: string): Promise<string> {
+    const val = await this.simulateCall(sourceAddress, "get_treasury", []);
+    return String(scValToNative(val));
+  }
+
+  /** Updates the treasury address. Requires admin. */
+  async updateTreasury(caller: string, treasury: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "update_treasury", [
+      addressToScVal(caller),
+      addressToScVal(treasury),
+    ]);
+  }
+
+  // ─── Oracle ──────────────────────────────────────────────────────────────────
+
+  /** Configures the FX-rate oracle address and optional staleness window (in ledgers). Requires caller authorization. */
+  async setOracle(caller: string, oracle: string, stalenessWindowLedgers?: number): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_oracle", [
+      addressToScVal(caller),
+      addressToScVal(oracle),
+      optionToScVal(stalenessWindowLedgers !== undefined ? u32ToScVal(stalenessWindowLedgers) : undefined),
+    ]);
+  }
+
+  /** Returns the configured oracle address, or null if unconfigured. */
+  async getOracle(sourceAddress: string): Promise<string | null> {
+    const val = await this.simulateCall(sourceAddress, "get_oracle", []);
+    const native = scValToNative(val);
+    return native ? (native as { toString(): string }).toString() : null;
+  }
+
+  /** Returns the current FX rate in basis points from the configured oracle, or null if unavailable. */
+  async getOracleRate(sourceAddress: string): Promise<number | null> {
+    const val = await this.simulateCall(sourceAddress, "get_oracle_rate", []);
+    const native = scValToNative(val);
+    return native != null ? Number(native) : null;
+  }
+
+  // ─── Rate limiting ───────────────────────────────────────────────────────────
+
+  /** Returns the global rate-limit configuration: max requests, window (seconds), enabled. */
+  async getRateLimitConfig(sourceAddress: string): Promise<RateLimitConfig> {
+    const val = await this.simulateCall(sourceAddress, "get_rate_limit_config", []);
+    return parseRateLimitConfig(scValToNative(val) as [number, bigint | number, boolean]);
+  }
+
+  /** Updates the global rate-limit configuration. Requires admin. */
+  async updateRateLimitConfig(
+    caller: string,
+    maxRequests: number,
+    windowSeconds: bigint,
+    enabled: boolean
+  ): Promise<Transaction> {
+    return this.prepareTransaction(caller, "update_rate_limit_config", [
+      addressToScVal(caller),
+      u32ToScVal(maxRequests),
+      u64ToScVal(windowSeconds),
+      boolToScVal(enabled),
+    ]);
+  }
+
+  /** Returns the rate-limit status for a specific address. */
+  async getRateLimitStatus(sourceAddress: string, address: string): Promise<RateLimitStatus> {
+    const val = await this.simulateCall(sourceAddress, "get_rate_limit_status", [addressToScVal(address)]);
+    return parseRateLimitStatus(scValToNative(val) as [number, number, bigint | number]);
+  }
+
+  /** Returns the post-unpause rate-limit cooldown window, in seconds. */
+  async getRateLimitCooldown(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_rate_limit_cooldown", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  /** Sets the post-unpause rate-limit cooldown window, in seconds. Requires admin. */
+  async updateRateLimit(admin: string, cooldownSeconds: bigint): Promise<Transaction> {
+    return this.prepareTransaction(admin, "update_rate_limit", [u64ToScVal(cooldownSeconds)]);
+  }
+
+  /** Clears stale rate-limit tracking entries for an address, freeing storage. */
+  async cleanupRateLimitEntries(caller: string, address: string): Promise<Transaction> {
+    return this.prepareTransaction(caller, "cleanup_rate_limit_entries", [addressToScVal(address)]);
+  }
+
+  // ─── Remittance / agent extras ────────────────────────────────────────────────
+
+  /** Returns up to `limit` remittance IDs created by `agent`, starting at `offset`. */
+  async getRemittancesByAgent(
+    sourceAddress: string,
+    agent: string,
+    offset: bigint,
+    limit: bigint
+  ): Promise<bigint[]> {
+    const val = await this.simulateCall(sourceAddress, "get_remittances_by_agent", [
+      addressToScVal(agent),
+      u64ToScVal(offset),
+      u64ToScVal(limit),
+    ]);
+    return (scValToNative(val) as number[]).map((id) => BigInt(id));
+  }
+
+  /** Returns the minimum agent reputation score required for new agent registration. */
+  async getMinAgentReputation(sourceAddress: string): Promise<number> {
+    const val = await this.simulateCall(sourceAddress, "get_min_agent_reputation", []);
+    return Number(scValToNative(val));
+  }
+
+  /** Sets the minimum agent reputation threshold (0-100). Requires admin. Throws {@link ErrorCode.InvalidReputationScore}. */
+  async setMinAgentReputation(admin: string, threshold: number): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_min_agent_reputation", [u32ToScVal(threshold)]);
+  }
+
+  /** Returns the configured daily limit for a currency/country corridor, or null if unset. */
+  async getDailyLimit(sourceAddress: string, currency: string, country: string): Promise<bigint | null> {
+    const val = await this.simulateCall(sourceAddress, "get_daily_limit", [
+      stringToScVal(currency),
+      stringToScVal(country),
+    ]);
+    const native = scValToNative(val);
+    return native != null ? BigInt(native as number) : null;
+  }
+
+  /** Sets the dispute window in seconds. Requires admin. */
+  async setDisputeWindow(admin: string, seconds: bigint): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_dispute_window", [u64ToScVal(seconds)]);
+  }
+
+  /** Sets the maximum batch size for `process_expired_remittances` (1-200). Requires admin. Throws {@link ErrorCode.InvalidBatchSize}. */
+  async setMaxExpiredBatchSize(admin: string, size: number): Promise<Transaction> {
+    return this.prepareTransaction(admin, "set_max_expired_batch_size", [u32ToScVal(size)]);
+  }
+
+  /** Sets the abuse-protection cooldown period in seconds (max 604800). Requires admin. */
+  async setCooldownPeriod(caller: string, seconds: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_cooldown_period", [
+      addressToScVal(caller),
+      u64ToScVal(seconds),
+    ]);
+  }
+
+  /** Creates a remittance using corridor-specific fee rules for the given country pair. */
+  async createRemittanceWithCorridor(
+    sender: string,
+    agent: string,
+    amount: bigint,
+    expiry?: bigint,
+    fromCountry?: string,
+    toCountry?: string
+  ): Promise<Transaction> {
+    return this.prepareTransaction(sender, "create_remittance_with_corridor", [
+      addressToScVal(sender),
+      addressToScVal(agent),
+      i128ToScVal(amount),
+      optionToScVal(expiry !== undefined ? u64ToScVal(expiry) : undefined),
+      optionToScVal(fromCountry !== undefined ? stringToScVal(fromCountry) : undefined),
+      optionToScVal(toCountry !== undefined ? stringToScVal(toCountry) : undefined),
+    ]);
+  }
+
+  /** Creates multiple remittances atomically in a single call, emitting a batch-created event. */
+  async createBatchRemittance(sender: string, entries: BatchCreateEntry[]): Promise<Transaction> {
+    if (entries.length === 0) {
+      throw new SwiftRemitError(ErrorCode.InvalidBatchSize, "Batch must contain at least one entry");
+    }
+    if (entries.length > MAX_BATCH_SIZE) {
+      throw new SwiftRemitError(
+        ErrorCode.InvalidBatchSize,
+        `Batch size ${entries.length} exceeds MAX_BATCH_SIZE (${MAX_BATCH_SIZE})`
+      );
+    }
+    const entriesScVal = xdr.ScVal.scvVec(
+      entries.map((e) =>
+        xdr.ScVal.scvMap([
+          new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("agent"), val: addressToScVal(e.agent) }),
+          new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("amount"), val: i128ToScVal(e.amount) }),
+          new xdr.ScMapEntry({
+            key: xdr.ScVal.scvSymbol("expiry"),
+            val: optionToScVal(e.expiry !== undefined ? u64ToScVal(e.expiry) : undefined),
+          }),
+        ])
+      )
+    );
+    return this.prepareTransaction(sender, "create_batch_remittance", [
+      addressToScVal(sender),
+      entriesScVal,
+    ]);
+  }
+
+  /** Confirms payout for a batch of remittances in one call. Requires the assigned agent. */
+  async confirmBatchPayout(agent: string, remittanceIds: bigint[]): Promise<Transaction> {
+    return this.prepareTransaction(agent, "confirm_batch_payout", [
+      addressToScVal(agent),
+      xdr.ScVal.scvVec(remittanceIds.map((id) => u64ToScVal(id))),
+    ]);
+  }
+
+  /** Force-finalizes a remittance. Requires admin. */
+  async finalizeRemittance(caller: string, remittanceId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "finalize_remittance", [
+      addressToScVal(caller),
+      u64ToScVal(remittanceId),
+    ]);
+  }
+
+  // ─── Transaction controller ──────────────────────────────────────────────────
+
+  /** Executes a full remittance + anchor transaction lifecycle. Requires user authorization. */
+  async executeTransaction(
+    user: string,
+    agent: string,
+    amount: bigint,
+    expiry?: bigint
+  ): Promise<Transaction> {
+    return this.prepareTransaction(user, "execute_transaction", [
+      addressToScVal(user),
+      addressToScVal(agent),
+      i128ToScVal(amount),
+      optionToScVal(expiry !== undefined ? u64ToScVal(expiry) : undefined),
+    ]);
+  }
+
+  /** Retries a previously failed transaction. */
+  async retryTransaction(caller: string, remittanceId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "retry_transaction", [u64ToScVal(remittanceId)]);
+  }
+
+  /** Returns the transaction controller's audit record for a remittance. Throws {@link ErrorCode.TransactionNotFound}. */
+  async getTransactionStatus(sourceAddress: string, remittanceId: bigint): Promise<TransactionRecord> {
+    const val = await this.simulateCall(sourceAddress, "get_transaction_status", [u64ToScVal(remittanceId)]);
+    return parseTransactionRecord(val);
+  }
+
+  // ─── Settlement / netting ────────────────────────────────────────────────────
+
+  /** Settles a batch of remittances with net settlement optimization. */
+  async batchSettleWithNetting(caller: string, entries: BatchSettlementEntry[]): Promise<Transaction> {
+    return this.prepareTransaction(caller, "batch_settle_with_netting", [
+      xdr.ScVal.scvVec(entries.map(batchSettlementEntryToScVal)),
+    ]);
+  }
+
+  /** Computes the settlement hash that would be produced for a remittance. */
+  async computeSettlementHash(sourceAddress: string, remittanceId: bigint): Promise<string> {
+    const val = await this.simulateCall(sourceAddress, "compute_settlement_hash", [u64ToScVal(remittanceId)]);
+    return Buffer.from(scValToNative(val) as Uint8Array).toString("hex");
+  }
+
+  /** Returns the stored settlement hash for a completed remittance. */
+  async getSettlementHash(sourceAddress: string, remittanceId: bigint): Promise<string> {
+    const val = await this.simulateCall(sourceAddress, "get_settlement_hash", [u64ToScVal(remittanceId)]);
+    return Buffer.from(scValToNative(val) as Uint8Array).toString("hex");
+  }
+
+  /** Returns the timestamp of a sender's most recent settlement, or null if none. */
+  async getLastSettlementTime(sourceAddress: string, sender: string): Promise<bigint | null> {
+    const val = await this.simulateCall(sourceAddress, "get_last_settlement_time", [addressToScVal(sender)]);
+    const native = scValToNative(val);
+    return native != null ? BigInt(native as number) : null;
+  }
+
+  /** Returns the total volume currently in-flight (not yet settled), in stroops. */
+  async getInFlightVolume(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_in_flight_volume", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  // ─── Migration ───────────────────────────────────────────────────────────────
+
+  /** Exports a full contract-state snapshot for migration. Requires admin. */
+  async exportMigrationSnapshot(caller: string): Promise<MigrationSnapshot> {
+    const val = await this.simulateCall(caller, "export_migration_snapshot", [addressToScVal(caller)]);
+    return parseMigrationSnapshot(val);
+  }
+
+  // ─── Misc ────────────────────────────────────────────────────────────────────
+
+  /** Returns the deployed contract's semantic version string. */
+  async getVersion(sourceAddress: string): Promise<string> {
+    const val = await this.simulateCall(sourceAddress, "get_version", []);
+    return String(scValToNative(val));
+  }
+
+  // ─── DAO governance ──────────────────────────────────────────────────────────
+
+  /** One-time migration from single-admin to multi-admin DAO governance. Requires admin. Throws {@link ErrorCode.GovernanceAlreadyInitialized}. */
+  async migrateToGovernance(
+    caller: string,
+    quorum: number,
+    timelockSeconds: bigint,
+    proposalTtlSeconds: bigint
+  ): Promise<Transaction> {
+    return this.prepareTransaction(caller, "migrate_to_governance", [
+      addressToScVal(caller),
+      u32ToScVal(quorum),
+      u64ToScVal(timelockSeconds),
+      u64ToScVal(proposalTtlSeconds),
+    ]);
+  }
+
+  /** Expires a proposal whose TTL has elapsed. Anyone may call this. */
+  async expireProposal(caller: string, proposalId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "expire_proposal", [u64ToScVal(proposalId)]);
+  }
+
+  /** Deletes already-executed or already-expired proposals to reclaim storage. */
+  async cleanupExpiredProposals(caller: string, proposalIds: bigint[]): Promise<Transaction> {
+    return this.prepareTransaction(caller, "cleanup_expired_proposals", [
+      addressToScVal(caller),
+      xdr.ScVal.scvVec(proposalIds.map((id) => u64ToScVal(id))),
+    ]);
+  }
+
+  /** Returns the list of current admin addresses. */
+  async getAdminList(sourceAddress: string): Promise<string[]> {
+    const val = await this.simulateCall(sourceAddress, "get_admin_list", []);
+    return (scValToNative(val) as { toString(): string }[]).map((a) => a.toString());
+  }
+
+  /** Returns the current governance quorum (number of approvals required). */
+  async getQuorum(sourceAddress: string): Promise<number> {
+    const val = await this.simulateCall(sourceAddress, "get_quorum", []);
+    return Number(scValToNative(val));
+  }
+
+  /** Returns the current governance timelock in seconds. */
+  async getTimelockSeconds(sourceAddress: string): Promise<bigint> {
+    const val = await this.simulateCall(sourceAddress, "get_timelock_seconds", []);
+    return BigInt(scValToNative(val) as number);
+  }
+
+  // ─── Multi-sig admin operations ─────────────────────────────────────────────
+
+  /** Proposes a high-impact admin operation (fee update, fee withdrawal, pause, unpause). */
+  async proposeOperation(
+    proposer: string,
+    operationType: AdminOperationType,
+    feeBps: number,
+    withdrawTo?: string
+  ): Promise<Transaction> {
+    return this.prepareTransaction(proposer, "propose_operation", [
+      addressToScVal(proposer),
+      adminOperationTypeToScVal(operationType),
+      u32ToScVal(feeBps),
+      optionToScVal(withdrawTo !== undefined ? addressToScVal(withdrawTo) : undefined),
+    ]);
+  }
+
+  /** Approves a pending multi-sig admin operation; auto-executes once the threshold is met. */
+  async approveOperation(approver: string, operationId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(approver, "approve_operation", [
+      addressToScVal(approver),
+      u64ToScVal(operationId),
+    ]);
+  }
+
+  /** Expires a pending multi-sig operation whose TTL has elapsed. Anyone may call this. */
+  async expireOperation(caller: string, operationId: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "expire_operation", [u64ToScVal(operationId)]);
+  }
+
+  /** Returns a pending multi-sig admin operation by ID. Throws {@link ErrorCode.OperationNotFound}. */
+  async getPendingOperation(sourceAddress: string, operationId: bigint): Promise<PendingOperation> {
+    const val = await this.simulateCall(sourceAddress, "get_pending_operation", [u64ToScVal(operationId)]);
+    return parsePendingOperation(val);
+  }
+
+  /** Configures the multi-sig approval threshold and operation TTL. Requires admin. Throws {@link ErrorCode.InvalidMultiSigThreshold}. */
+  async setMultisigConfig(caller: string, threshold: number, ttlSeconds: bigint): Promise<Transaction> {
+    return this.prepareTransaction(caller, "set_multisig_config", [
+      addressToScVal(caller),
+      u32ToScVal(threshold),
+      u64ToScVal(ttlSeconds),
     ]);
   }
 

--- a/sdk/src/convert.ts
+++ b/sdk/src/convert.ts
@@ -16,6 +16,23 @@ import type {
   Proposal,
   ProposalState,
   ProposalAction,
+  Escrow,
+  EscrowStatus,
+  AssetVerification,
+  VerificationStatus,
+  PauseRecord,
+  FeeStrategy,
+  FeeCorridor,
+  RateLimitConfig,
+  RateLimitStatus,
+  TransactionRecord,
+  TransactionState,
+  MigrationSnapshot,
+  BatchSettlementEntry,
+  BatchSettlementResult,
+  Role,
+  AdminOperationType,
+  PendingOperation,
 } from "./types.js";
 
 // ─── ScVal → Native ──────────────────────────────────────────────────────────
@@ -218,4 +235,234 @@ export function bytesNToScVal(buf: Buffer): xdr.ScVal {
 
 export function stringToScVal(value: string): xdr.ScVal {
   return nativeToScVal(value, { type: "string" });
+}
+
+export function u32ToScVal(value: number): xdr.ScVal {
+  return nativeToScVal(value, { type: "u32" });
+}
+
+export function boolToScVal(value: boolean): xdr.ScVal {
+  return xdr.ScVal.scvBool(value);
+}
+
+export function bytes32HexToScVal(hex: string): xdr.ScVal {
+  return xdr.ScVal.scvBytes(Buffer.from(hex.replace(/^0x/, ""), "hex"));
+}
+
+/**
+ * Encode a fieldless (unit) `#[contracttype] enum` variant as a Soroban
+ * ScVal: a single-entry map of `{ Symbol(variant): void }`, matching the
+ * wire format Soroban SDK generates for enums (see {@link parseUnitEnum}).
+ */
+export function unitEnumToScVal(variant: string): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol(variant),
+      val: xdr.ScVal.scvVoid(),
+    }),
+  ]);
+}
+
+/** Encode an enum variant that carries a single associated value. */
+export function dataEnumToScVal(variant: string, value: xdr.ScVal): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(variant), val: value }),
+  ]);
+}
+
+/** Read the single variant name out of a decoded unit/data enum object. */
+function parseUnitEnum<T extends string>(raw: unknown, fieldName: string): T {
+  if (!raw || typeof raw !== "object") {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, `${fieldName}: invalid enum value`);
+  }
+  const keys = Object.keys(raw as Record<string, unknown>);
+  if (keys.length !== 1) {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, `${fieldName}: invalid enum value`);
+  }
+  return keys[0] as T;
+}
+
+export function roleToScVal(role: Role): xdr.ScVal {
+  return unitEnumToScVal(role);
+}
+
+export function verificationStatusToScVal(status: VerificationStatus): xdr.ScVal {
+  return unitEnumToScVal(status);
+}
+
+export function pauseReasonToScVal(reason: PauseReason): xdr.ScVal {
+  return unitEnumToScVal(reason);
+}
+
+export function feeStrategyToScVal(strategy: FeeStrategy): xdr.ScVal {
+  if (strategy === "Corridor") return unitEnumToScVal("Corridor");
+  if ("Percentage" in strategy) return dataEnumToScVal("Percentage", u32ToScVal(strategy.Percentage));
+  if ("Flat" in strategy) return dataEnumToScVal("Flat", i128ToScVal(strategy.Flat));
+  if ("Dynamic" in strategy) return dataEnumToScVal("Dynamic", u32ToScVal(strategy.Dynamic));
+  throw new SwiftRemitError(ErrorCode.DataCorruption, "feeStrategyToScVal: unknown strategy variant");
+}
+
+export function parseFeeStrategy(raw: unknown): FeeStrategy {
+  if (raw === null || typeof raw !== "object") {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, "parseFeeStrategy: invalid value");
+  }
+  const map = raw as Record<string, unknown>;
+  const keys = Object.keys(map);
+  if (keys.length !== 1) {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, "parseFeeStrategy: invalid value");
+  }
+  const key = keys[0];
+  if (key === "Corridor") return "Corridor";
+  if (key === "Percentage") return { Percentage: Number(map[key]) };
+  if (key === "Flat") return { Flat: BigInt(map[key] as number) };
+  if (key === "Dynamic") return { Dynamic: Number(map[key]) };
+  throw new SwiftRemitError(ErrorCode.DataCorruption, `parseFeeStrategy: unknown variant "${key}"`);
+}
+
+export function feeCorridorToScVal(corridor: FeeCorridor): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("from_country"), val: stringToScVal(corridor.fromCountry) }),
+    new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("to_country"), val: stringToScVal(corridor.toCountry) }),
+    new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("strategy"), val: feeStrategyToScVal(corridor.strategy) }),
+    new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("protocol_fee_bps"),
+      val: optionToScVal(corridor.protocolFeeBps != null ? u32ToScVal(corridor.protocolFeeBps) : undefined),
+    }),
+  ]);
+}
+
+export function parseFeeCorridor(val: xdr.ScVal): FeeCorridor {
+  const map = scValToNative(val) as Record<string, unknown>;
+  return {
+    fromCountry: String(map["from_country"]),
+    toCountry: String(map["to_country"]),
+    strategy: parseFeeStrategy(map["strategy"]),
+    protocolFeeBps: map["protocol_fee_bps"] != null ? Number(map["protocol_fee_bps"]) : null,
+  };
+}
+
+export function parseEscrow(val: xdr.ScVal): Escrow {
+  const map = scValToNative(val) as Record<string, unknown>;
+  return {
+    transferId: BigInt(map["transfer_id"] as number),
+    sender: String(map["sender"]),
+    recipient: String(map["recipient"]),
+    amount: BigInt(map["amount"] as number),
+    expiry: map["expiry"] != null ? BigInt(map["expiry"] as number) : null,
+    status: parseUnitEnum<EscrowStatus>(map["status"], "parseEscrow.status"),
+  };
+}
+
+export function parseAssetVerification(val: xdr.ScVal): AssetVerification {
+  const map = scValToNative(val) as Record<string, unknown>;
+  return {
+    assetCode: String(map["asset_code"]),
+    issuer: String(map["issuer"]),
+    status: parseUnitEnum<VerificationStatus>(map["status"], "parseAssetVerification.status"),
+    reputationScore: Number(map["reputation_score"]),
+    lastVerified: BigInt(map["last_verified"] as number),
+    trustlineCount: BigInt(map["trustline_count"] as number),
+    hasToml: Boolean(map["has_toml"]),
+  };
+}
+
+export function parsePauseRecord(val: xdr.ScVal): PauseRecord {
+  const map = scValToNative(val) as Record<string, unknown>;
+  return {
+    seq: BigInt(map["seq"] as number),
+    caller: String(map["caller"]),
+    timestamp: BigInt(map["timestamp"] as number),
+    reason: parseUnitEnum<PauseReason>(map["reason"], "parsePauseRecord.reason"),
+  };
+}
+
+export function parseRateLimitConfig(tuple: [number, bigint | number, boolean]): RateLimitConfig {
+  return {
+    maxRequests: Number(tuple[0]),
+    windowSeconds: BigInt(tuple[1] as number),
+    enabled: Boolean(tuple[2]),
+  };
+}
+
+export function parseRateLimitStatus(tuple: [number, number, bigint | number]): RateLimitStatus {
+  return {
+    requestCount: Number(tuple[0]),
+    remaining: Number(tuple[1]),
+    resetAt: BigInt(tuple[2] as number),
+  };
+}
+
+function parseTransactionState(raw: unknown): TransactionState {
+  if (!raw || typeof raw !== "object") {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, "parseTransactionState: invalid value");
+  }
+  const map = raw as Record<string, unknown>;
+  const keys = Object.keys(map);
+  if (keys.length !== 1) {
+    throw new SwiftRemitError(ErrorCode.DataCorruption, "parseTransactionState: invalid value");
+  }
+  const key = keys[0];
+  if (key === "ContractCalled" || key === "AnchorInitiated") {
+    return { [key]: BigInt(map[key] as number) } as TransactionState;
+  }
+  return key as TransactionState;
+}
+
+export function parseTransactionRecord(val: xdr.ScVal): TransactionRecord {
+  const map = scValToNative(val) as Record<string, unknown>;
+  return {
+    user: String(map["user"]),
+    agent: String(map["agent"]),
+    amount: BigInt(map["amount"] as number),
+    remittanceId: map["remittance_id"] != null ? BigInt(map["remittance_id"] as number) : null,
+    anchorTxId: map["anchor_tx_id"] != null ? BigInt(map["anchor_tx_id"] as number) : null,
+    state: parseTransactionState(map["state"]),
+    retryCount: Number(map["retry_count"]),
+    timestamp: BigInt(map["timestamp"] as number),
+  };
+}
+
+export function parseMigrationSnapshot(val: xdr.ScVal): MigrationSnapshot {
+  const map = scValToNative(val) as Record<string, unknown>;
+  const hash = map["verification_hash"];
+  return {
+    version: Number(map["version"]),
+    timestamp: BigInt(map["timestamp"] as number),
+    ledgerSequence: Number(map["ledger_sequence"]),
+    instanceData: (map["instance_data"] as Record<string, unknown>) ?? {},
+    persistentData: (map["persistent_data"] as Record<string, unknown>) ?? {},
+    verificationHash: hash instanceof Uint8Array ? Buffer.from(hash).toString("hex") : String(hash),
+  };
+}
+
+export function batchSettlementEntryToScVal(entry: BatchSettlementEntry): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol("remittance_id"), val: u64ToScVal(entry.remittanceId) }),
+  ]);
+}
+
+export function parseBatchSettlementResult(val: xdr.ScVal): BatchSettlementResult {
+  const map = scValToNative(val) as Record<string, unknown>;
+  const ids = (map["settled_ids"] as number[]) ?? [];
+  return { settledIds: ids.map((id) => BigInt(id)) };
+}
+
+export function adminOperationTypeToScVal(type: AdminOperationType): xdr.ScVal {
+  return unitEnumToScVal(type);
+}
+
+export function parsePendingOperation(val: xdr.ScVal): PendingOperation {
+  const map = scValToNative(val) as Record<string, unknown>;
+  const approvers = (map["approvers"] as { toString(): string }[]) ?? [];
+  return {
+    id: BigInt(map["id"] as number),
+    operationType: parseUnitEnum<AdminOperationType>(map["operation_type"], "parsePendingOperation.operationType"),
+    proposer: String(map["proposer"]),
+    approvers: approvers.map((a) => a.toString()),
+    threshold: Number(map["threshold"]),
+    proposedAt: BigInt(map["proposed_at"] as number),
+    ttlSeconds: BigInt(map["ttl_seconds"] as number),
+    feeBps: Number(map["fee_bps"]),
+    withdrawTo: map["withdraw_to"] != null ? String(map["withdraw_to"]) : null,
+  };
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,7 +1,7 @@
 /**
  * Typed error mapping for the SwiftRemit TypeScript SDK.
  *
- * Mirrors the 74 ContractError codes defined in src/errors.rs so callers
+ * Mirrors the 71 ContractError codes defined in src/errors.rs so callers
  * can catch and branch on named error codes instead of parsing raw strings.
  *
  * Usage:
@@ -53,10 +53,12 @@ export enum ErrorCode {
   TransactionNotFound = 24,
   RateLimitExceeded = 25,
 
-  // Authorization (26-29)
+  // Authorization (26-28)
   AdminAlreadyExists = 26,
   AdminNotFound = 27,
   CannotRemoveLastAdmin = 28,
+
+  // Token whitelist (29)
   TokenNotWhitelisted = 29,
 
   // Migration (30-32)
@@ -69,7 +71,7 @@ export enum ErrorCode {
   SuspiciousActivity = 34,
   ActionBlocked = 35,
 
-  // Arithmetic / data (36-52)
+  // Arithmetic / data (36-55)
   Overflow = 36,
   NetSettlementValidationFailed = 37,
   EscrowNotFound = 38,
@@ -83,40 +85,37 @@ export enum ErrorCode {
   StringConversionFailed = 46,
   InvalidSymbol = 47,
   Underflow = 48,
-  IdempotencyConflict = 49,
-  InvalidProof = 50,
-  MissingProof = 51,
-  InvalidOracleAddress = 52,
+  NoPendingAdminTransfer = 49,
+  IdempotencyConflict = 50,
+  InvalidProof = 51,
+  MissingProof = 52,
+  InvalidOracleAddress = 53,
+  AlreadyPaused = 54,
+  NotPaused = 55,
 
-  // Dispute (53-55)
-  DisputeWindowExpired = 53,
-  AlreadyDisputed = 54,
-  NotDisputed = 55,
+  // Multi-sig (56-59)
+  OperationNotFound = 56,
+  AlreadyApproved = 57,
+  OperationExpired = 58,
+  InvalidMultiSigThreshold = 59,
 
-  // Circuit breaker (56-62)
-  AlreadyPaused = 56,
-  NotPaused = 57,
-  TimelockActive = 58,
-  AlreadyVoted = 59,
-  InvalidTimelockDuration = 60,
-  InvalidQuorum = 61,
-  PauseRecordNotFound = 62,
-
-  // Recipient address verification (63-66)
-  InvalidRecipientHash = 63,
-  MissingRecipientHash = 64,
-  RecipientHashMismatch = 65,
-  RecipientHashSchemaMismatch = 66,
-
-  // Governance (67-74)
-  ProposalAlreadyPending = 67,
+  // Governance / DAO (60-69)
+  AlreadyAdmin = 60,
+  InsufficientAdmins = 61,
+  InvalidQuorum = 62,
+  AlreadyVoted = 63,
+  InvalidProposalState = 64,
+  ProposalAlreadyPending = 65,
+  TimelockActive = 66,
+  GovernanceAlreadyInitialized = 67,
   ProposalNotFound = 68,
-  InvalidProposalState = 69,
-  TimelockNotElapsed = 70,
-  AlreadyAdmin = 71,
-  InsufficientAdmins = 72,
-  AgentAlreadyRegistered = 73,
-  GovernanceAlreadyInitialized = 74,
+  AgentAlreadyRegistered = 69,
+
+  // Dispute (71)
+  NotDisputed = 71,
+
+  // Dispute evidence (83)
+  MalformedEvidenceHash = 83,
 }
 
 /** Human-readable messages for each error code. */
@@ -169,33 +168,126 @@ const ERROR_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.StringConversionFailed]: "String conversion failed",
   [ErrorCode.InvalidSymbol]: "Invalid symbol string",
   [ErrorCode.Underflow]: "Arithmetic underflow occurred",
+  [ErrorCode.NoPendingAdminTransfer]: "No pending admin transfer to accept",
   [ErrorCode.IdempotencyConflict]: "Idempotency key exists but request payload differs",
   [ErrorCode.InvalidProof]: "Proof validation failed",
   [ErrorCode.MissingProof]: "Proof is required but not provided",
   [ErrorCode.InvalidOracleAddress]: "Oracle address is invalid or not configured",
-  [ErrorCode.DisputeWindowExpired]: "The dispute window for this remittance has expired",
-  [ErrorCode.AlreadyDisputed]: "This remittance has already been disputed",
-  [ErrorCode.NotDisputed]: "This operation requires the remittance to be in a Disputed state",
   [ErrorCode.AlreadyPaused]: "Contract is already paused",
-  [ErrorCode.NotPaused]: "Contract is not paused",
-  [ErrorCode.TimelockActive]: "Timelock has not yet elapsed",
-  [ErrorCode.AlreadyVoted]: "Admin has already cast a vote for this instance",
-  [ErrorCode.InvalidTimelockDuration]: "Timelock duration exceeds the maximum allowed value",
-  [ErrorCode.InvalidQuorum]: "Quorum value is invalid",
-  [ErrorCode.PauseRecordNotFound]: "Pause record not found",
-  [ErrorCode.InvalidRecipientHash]: "Supplied recipient hash is not exactly 32 bytes",
-  [ErrorCode.MissingRecipientHash]: "Recipient hash is required but not provided",
-  [ErrorCode.RecipientHashMismatch]: "Supplied recipient hash does not match the stored hash",
-  [ErrorCode.RecipientHashSchemaMismatch]: "Stored hash schema version mismatch",
-  [ErrorCode.ProposalAlreadyPending]: "A proposal with this action type is already pending",
-  [ErrorCode.ProposalNotFound]: "Proposal not found",
+  [ErrorCode.NotPaused]: "Contract is not currently paused",
+  [ErrorCode.OperationNotFound]: "Pending admin operation not found",
+  [ErrorCode.AlreadyApproved]: "Caller has already approved this pending operation",
+  [ErrorCode.OperationExpired]: "Pending operation has exceeded its time-to-live",
+  [ErrorCode.InvalidMultiSigThreshold]: "Multi-sig threshold must be at least 1 and no greater than the admin count",
+  [ErrorCode.AlreadyAdmin]: "Address is already in the admin set",
+  [ErrorCode.InsufficientAdmins]: "Removing this admin would drop the admin count below quorum or below 1",
+  [ErrorCode.InvalidQuorum]: "Quorum must be at least 1 and no greater than the current admin count",
+  [ErrorCode.AlreadyVoted]: "Admin has already cast a vote on this proposal",
   [ErrorCode.InvalidProposalState]: "Proposal is not in the required state for this operation",
-  [ErrorCode.TimelockNotElapsed]: "Governance execution timelock has not yet elapsed",
-  [ErrorCode.AlreadyAdmin]: "The address is already an Admin",
-  [ErrorCode.InsufficientAdmins]: "Removing this admin would violate the minimum admin invariant",
-  [ErrorCode.AgentAlreadyRegistered]: "The agent is already registered",
+  [ErrorCode.ProposalAlreadyPending]: "A fee-update proposal is already pending or approved",
+  [ErrorCode.TimelockActive]: "Proposal timelock has not elapsed; cannot execute yet",
   [ErrorCode.GovernanceAlreadyInitialized]: "Governance has already been initialized",
+  [ErrorCode.ProposalNotFound]: "Proposal with the given ID does not exist",
+  [ErrorCode.AgentAlreadyRegistered]: "Agent is already registered in the system",
+  [ErrorCode.NotDisputed]: "This operation requires the remittance to be in a Disputed state",
+  [ErrorCode.MalformedEvidenceHash]: "Evidence hash for a dispute is not a valid 32-byte SHA-256 commitment",
 };
+
+/**
+ * Suggested remediation for each error code, surfaced to integrators so they
+ * know what to actually do about a failure instead of just what went wrong.
+ */
+const ERROR_REMEDIATIONS: Record<ErrorCode, string> = {
+  [ErrorCode.AlreadyInitialized]: "Do not call initialize() again; the contract is already set up.",
+  [ErrorCode.NotInitialized]: "Call initialize() before performing any other operation.",
+  [ErrorCode.InvalidAmount]: "Pass an amount greater than zero.",
+  [ErrorCode.InvalidFeeBps]: "Use a fee value between 0 and 10000 basis points.",
+  [ErrorCode.AgentNotRegistered]: "Register the agent via registerAgent() before using it.",
+  [ErrorCode.RemittanceNotFound]: "Verify the remittance ID; it may not exist or may have been pruned.",
+  [ErrorCode.InvalidStatus]: "Check the remittance's current status before retrying this operation.",
+  [ErrorCode.InvalidStateTransition]: "Only perform transitions valid for the remittance's current state.",
+  [ErrorCode.NoFeesToWithdraw]: "Wait until accumulated fees are greater than zero before withdrawing.",
+  [ErrorCode.InvalidAddress]: "Double-check the address format passed to this call.",
+  [ErrorCode.SettlementExpired]: "The settlement window has closed; a new remittance must be created.",
+  [ErrorCode.DuplicateSettlement]: "This remittance was already settled; do not resubmit.",
+  [ErrorCode.ContractPaused]: "Wait for an admin to unpause the contract, then retry.",
+  [ErrorCode.AssetNotFound]: "Verify the asset has a verification record before querying it.",
+  [ErrorCode.UserBlacklisted]: "This address is blacklisted; contact an admin if this is unexpected.",
+  [ErrorCode.InvalidReputationScore]: "Use a reputation score between 0 and 100.",
+  [ErrorCode.KycNotApproved]: "Complete KYC verification for this user before retrying.",
+  [ErrorCode.SuspiciousAsset]: "This asset has been flagged; do not proceed without admin review.",
+  [ErrorCode.AnchorTransactionFailed]: "Retry the anchor withdrawal/deposit, or check anchor-side status.",
+  [ErrorCode.Unauthorized]: "Use an address with the required admin/role privileges.",
+  [ErrorCode.DailySendLimitExceeded]: "Wait until the user's rolling 24h window resets, or raise their limit.",
+  [ErrorCode.TokenAlreadyWhitelisted]: "This token is already whitelisted; no action needed.",
+  [ErrorCode.KycExpired]: "Renew the user's KYC verification before retrying.",
+  [ErrorCode.TransactionNotFound]: "Verify the transaction record ID.",
+  [ErrorCode.RateLimitExceeded]: "Back off and retry after the rate limit window elapses.",
+  [ErrorCode.AdminAlreadyExists]: "This address is already an admin; no action needed.",
+  [ErrorCode.AdminNotFound]: "Verify the admin address before attempting removal.",
+  [ErrorCode.CannotRemoveLastAdmin]: "Add another admin before removing this one.",
+  [ErrorCode.TokenNotWhitelisted]: "Whitelist the token before using it in the contract.",
+  [ErrorCode.InvalidMigrationHash]: "Recompute the snapshot hash; the data may be corrupted or tampered with.",
+  [ErrorCode.MigrationInProgress]: "Wait for the current migration to complete before starting another.",
+  [ErrorCode.InvalidMigrationBatch]: "Import migration batches strictly in order.",
+  [ErrorCode.CooldownActive]: "Wait for the cooldown period to elapse before retrying.",
+  [ErrorCode.SuspiciousActivity]: "This action was blocked by abuse detection; contact support.",
+  [ErrorCode.ActionBlocked]: "This action is temporarily blocked; retry after the block clears.",
+  [ErrorCode.Overflow]: "Reduce the input magnitude; the operation would exceed the maximum value.",
+  [ErrorCode.NetSettlementValidationFailed]: "Recheck the net settlement inputs for consistency.",
+  [ErrorCode.EscrowNotFound]: "Verify the escrow ID before querying or operating on it.",
+  [ErrorCode.InvalidEscrowStatus]: "Check the escrow's current status before retrying.",
+  [ErrorCode.SettlementCounterOverflow]: "The settlement counter has reached its maximum; contact support.",
+  [ErrorCode.InvalidBatchSize]: "Use a batch size greater than zero and within the allowed maximum.",
+  [ErrorCode.DataCorruption]: "Stored data failed integrity checks; contact support before retrying.",
+  [ErrorCode.IndexOutOfBounds]: "Use an index within the bounds of the collection.",
+  [ErrorCode.EmptyCollection]: "Ensure the collection has at least one element before this call.",
+  [ErrorCode.KeyNotFound]: "Verify the lookup key exists before retrying.",
+  [ErrorCode.StringConversionFailed]: "Check the input string for invalid characters or length.",
+  [ErrorCode.InvalidSymbol]: "Use a valid, well-formed symbol string.",
+  [ErrorCode.Underflow]: "Reduce the subtraction amount; the operation would go below zero.",
+  [ErrorCode.NoPendingAdminTransfer]: "Call proposeAdmin() before attempting to accept an admin transfer.",
+  [ErrorCode.IdempotencyConflict]: "Use a new idempotency key, or resend the exact same payload.",
+  [ErrorCode.InvalidProof]: "Recheck the proof; it did not validate against the expected commitment.",
+  [ErrorCode.MissingProof]: "Supply the required proof for this operation.",
+  [ErrorCode.InvalidOracleAddress]: "Configure a valid oracle address before retrying.",
+  [ErrorCode.AlreadyPaused]: "The contract is already paused; no action needed.",
+  [ErrorCode.NotPaused]: "The contract is not paused; there is nothing to unpause.",
+  [ErrorCode.OperationNotFound]: "Verify the pending operation ID before approving or executing it.",
+  [ErrorCode.AlreadyApproved]: "This caller has already approved this operation; no action needed.",
+  [ErrorCode.OperationExpired]: "This operation's TTL has passed; submit a new one.",
+  [ErrorCode.InvalidMultiSigThreshold]: "Use a threshold between 1 and the current admin count.",
+  [ErrorCode.AlreadyAdmin]: "This address is already an admin; no action needed.",
+  [ErrorCode.InsufficientAdmins]: "Add more admins before removing one, to preserve quorum.",
+  [ErrorCode.InvalidQuorum]: "Use a quorum between 1 and the current admin count.",
+  [ErrorCode.AlreadyVoted]: "This admin has already voted on this proposal.",
+  [ErrorCode.InvalidProposalState]: "Check the proposal's current state before retrying.",
+  [ErrorCode.ProposalAlreadyPending]: "Wait for the pending proposal to resolve before submitting another.",
+  [ErrorCode.TimelockActive]: "Wait for the proposal's timelock to elapse before executing it.",
+  [ErrorCode.GovernanceAlreadyInitialized]: "Governance is already set up; migrateToGovernance() cannot run twice.",
+  [ErrorCode.ProposalNotFound]: "Verify the proposal ID before operating on it.",
+  [ErrorCode.AgentAlreadyRegistered]: "This agent is already registered; no action needed.",
+  [ErrorCode.NotDisputed]: "This operation is only valid while the remittance is in a Disputed state.",
+  [ErrorCode.MalformedEvidenceHash]: "Supply a 32-byte SHA-256 hash as the evidence commitment.",
+};
+
+/**
+ * Error codes that represent transient/temporary conditions worth retrying
+ * after a backoff, as opposed to terminal conditions that will not resolve
+ * by resubmitting the same call. Kept in sync with {@link isTransientError}.
+ */
+const RETRYABLE_CODES: ReadonlySet<ErrorCode> = new Set([
+  ErrorCode.ContractPaused,
+  ErrorCode.RateLimitExceeded,
+  ErrorCode.CooldownActive,
+  ErrorCode.ActionBlocked,
+  ErrorCode.AnchorTransactionFailed,
+]);
+
+/** Returns whether a given error code is retryable after a backoff. */
+export function isRetryableCode(code: ErrorCode): boolean {
+  return RETRYABLE_CODES.has(code);
+}
 
 /**
  * Typed error thrown by all SwiftRemitClient methods when the contract
@@ -206,6 +298,10 @@ export class SwiftRemitError extends Error {
   readonly code: ErrorCode;
   /** The raw error string from the RPC response (for debugging). */
   readonly rawError: string;
+  /** Suggested remediation for this error. */
+  readonly remediation: string;
+  /** Whether retrying the same call after a backoff may succeed. */
+  readonly retryable: boolean;
 
   constructor(code: ErrorCode, rawError: string) {
     const message = ERROR_MESSAGES[code] ?? `Contract error ${code}`;
@@ -213,6 +309,8 @@ export class SwiftRemitError extends Error {
     this.name = "SwiftRemitError";
     this.code = code;
     this.rawError = rawError;
+    this.remediation = ERROR_REMEDIATIONS[code] ?? "Consult the contract documentation for this error code.";
+    this.retryable = isRetryableCode(code);
     // Maintain proper prototype chain in transpiled environments
     Object.setPrototypeOf(this, SwiftRemitError.prototype);
   }

--- a/sdk/src/index.test.ts
+++ b/sdk/src/index.test.ts
@@ -23,18 +23,36 @@ describe("ErrorCode enum", () => {
     expect(ErrorCode.AlreadyInitialized).toBe(1);
     expect(ErrorCode.Unauthorized).toBe(20);
     expect(ErrorCode.DailySendLimitExceeded).toBe(21);
-    expect(ErrorCode.TimelockNotElapsed).toBe(70);
-    expect(ErrorCode.GovernanceAlreadyInitialized).toBe(74);
+    expect(ErrorCode.GovernanceAlreadyInitialized).toBe(67);
+    expect(ErrorCode.NotDisputed).toBe(71);
+    expect(ErrorCode.MalformedEvidenceHash).toBe(83);
   });
 
-  it("covers all 74 error codes without gaps", () => {
+  it("covers all 71 contract error codes without duplicates", () => {
     const codes = Object.values(ErrorCode).filter(
       (v): v is number => typeof v === "number"
     );
-    expect(codes.length).toBe(74);
-    // Codes should be 1..74 with no duplicates
+    expect(codes.length).toBe(71);
     const unique = new Set(codes);
-    expect(unique.size).toBe(74);
+    expect(unique.size).toBe(71);
+  });
+
+  it("round-trips every code through SwiftRemitError with a message and remediation", () => {
+    const codes = Object.values(ErrorCode).filter(
+      (v): v is number => typeof v === "number"
+    ) as ErrorCode[];
+
+    for (const code of codes) {
+      const err = new SwiftRemitError(code, `ContractError(${code})`);
+      expect(err.code).toBe(code);
+      expect(err.message.length).toBeGreaterThan(0);
+      expect(err.remediation.length).toBeGreaterThan(0);
+      expect(typeof err.retryable).toBe("boolean");
+
+      const parsed = parseContractError(`Simulation failed: Error(Contract, #${code})`);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.code).toBe(code);
+    }
   });
 });
 
@@ -89,8 +107,8 @@ describe("parseContractError", () => {
   });
 
   it("works with Error objects", () => {
-    const err = parseContractError(new Error("ContractError(70)"));
+    const err = parseContractError(new Error("ContractError(67)"));
     expect(err).not.toBeNull();
-    expect(err!.code).toBe(ErrorCode.TimelockNotElapsed);
+    expect(err!.code).toBe(ErrorCode.GovernanceAlreadyInitialized);
   });
 });

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,6 +1,9 @@
 import type { RetryPolicy } from "./types.js";
+import { SwiftRemitError } from "./errors.js";
 
 export function isTransientError(err: unknown): boolean {
+  if (err instanceof SwiftRemitError) return err.retryable;
+
   const msg = err instanceof Error ? err.message : String(err);
   return (
     msg.includes("429") ||

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -316,3 +316,142 @@ export interface DailyLimitStatus {
 export function stroopsToUsdc(stroops: bigint): number {
   return Number(stroops) / 10_000_000;
 }
+
+// ─── Escrow ────────────────────────────────────────────────────────────────
+
+export interface Escrow {
+  transferId: bigint;
+  sender: string;
+  recipient: string;
+  /** Amount locked in stroops */
+  amount: bigint;
+  expiry: bigint | null;
+  status: EscrowStatus;
+}
+
+// ─── Asset verification ─────────────────────────────────────────────────────
+
+export type VerificationStatus = "Verified" | "Unverified" | "Suspicious";
+
+export interface AssetVerification {
+  assetCode: string;
+  issuer: string;
+  status: VerificationStatus;
+  /** Reputation score, 0-100 */
+  reputationScore: number;
+  lastVerified: bigint;
+  trustlineCount: bigint;
+  hasToml: boolean;
+}
+
+// ─── Circuit breaker pause records ──────────────────────────────────────────
+
+export interface PauseRecord {
+  seq: bigint;
+  caller: string;
+  timestamp: bigint;
+  reason: PauseReason;
+}
+
+// ─── Fee strategy / corridor ────────────────────────────────────────────────
+
+export type FeeStrategy =
+  | { Percentage: number }
+  | { Flat: bigint }
+  | { Dynamic: number }
+  | "Corridor";
+
+export interface FeeCorridor {
+  fromCountry: string;
+  toCountry: string;
+  strategy: FeeStrategy;
+  /** Overrides the global protocol fee for this corridor when set */
+  protocolFeeBps: number | null;
+}
+
+// ─── Rate limiting ───────────────────────────────────────────────────────────
+
+export interface RateLimitConfig {
+  maxRequests: number;
+  windowSeconds: bigint;
+  enabled: boolean;
+}
+
+export interface RateLimitStatus {
+  /** Requests made in the current window */
+  requestCount: number;
+  /** Requests remaining in the current window */
+  remaining: number;
+  /** Timestamp when the current window resets */
+  resetAt: bigint;
+}
+
+// ─── Transaction controller ─────────────────────────────────────────────────
+
+export type TransactionState =
+  | "Initial"
+  | "EligibilityValidated"
+  | "KycConfirmed"
+  | { ContractCalled: bigint }
+  | { AnchorInitiated: bigint }
+  | "RecordStored"
+  | "Completed"
+  | "RolledBack";
+
+export interface TransactionRecord {
+  user: string;
+  agent: string;
+  /** Amount in stroops */
+  amount: bigint;
+  remittanceId: bigint | null;
+  anchorTxId: bigint | null;
+  state: TransactionState;
+  retryCount: number;
+  timestamp: bigint;
+}
+
+// ─── Migration ───────────────────────────────────────────────────────────────
+
+/**
+ * Snapshot of all contract data for migration purposes. `instanceData` and
+ * `persistentData` are returned as raw decoded maps rather than fully typed
+ * structures, since their shape mirrors internal storage layout that may
+ * change between contract versions.
+ */
+export interface MigrationSnapshot {
+  version: number;
+  timestamp: bigint;
+  ledgerSequence: number;
+  instanceData: Record<string, unknown>;
+  persistentData: Record<string, unknown>;
+  /** Hex-encoded 32-byte integrity hash */
+  verificationHash: string;
+}
+
+// ─── Batch settlement / netting ─────────────────────────────────────────────
+
+export interface BatchSettlementEntry {
+  remittanceId: bigint;
+}
+
+export interface BatchSettlementResult {
+  settledIds: bigint[];
+}
+
+// ─── Multi-sig admin operations ─────────────────────────────────────────────
+
+export type AdminOperationType = "UpdateFee" | "WithdrawFees" | "Pause" | "Unpause";
+
+export interface PendingOperation {
+  id: bigint;
+  operationType: AdminOperationType;
+  proposer: string;
+  approvers: string[];
+  threshold: number;
+  proposedAt: bigint;
+  ttlSeconds: bigint;
+  /** Only meaningful for UpdateFee operations */
+  feeBps: number;
+  /** Only meaningful for WithdrawFees operations */
+  withdrawTo: string | null;
+}


### PR DESCRIPTION
Summary
Addresses four SDK issues from the Stellar Wave 7 program (SR-083 – SR-086).

SR-083 — Full contract-surface coverage. sdk/src/client.ts bound only ~40 of the contract's 138 public entry points (governance, multisig, escrow, netting, fee corridors, asset verification, roles, blacklist, whitelist, oracle, rate limiting, treasury, and migration were all missing). Added typed bindings — with parameter/return types in types.ts and ScVal converters in convert.ts — for every remaining function except import_migration_batch, which needs a write-side encoder for the full Vec<Remittance> migration payload the SDK doesn't currently support (documented, with rationale, in sdk/scripts/coverage-exclusions.json). Added sdk/scripts/check-contract-coverage.mjs, wired into ci.yml, which fails CI if a future pub fn in the contract has no SDK binding and no exclusion entry.
SR-084 — Complete parseContractError mapping. The SDK's ErrorCode enum didn't match src/errors.rs — it had the right values for codes 1–48, but everything from 49 onward was wrong (wrong numbers, invented codes that don't exist in the contract like DisputeWindowExpired, and missing real ones like NoPendingAdminTransfer, OperationNotFound, MalformedEvidenceHash). Rebuilt the enum to match all 71 contract error variants exactly, added a remediation hint and a retryable flag to SwiftRemitError, and made isTransientError respect retryable for SwiftRemitError instances. Added a round-trip test asserting every code maps to a message, remediation, and correct retryability.
SR-085 — Publish SDK to npm. Most of the release infrastructure (changesets, tsup, typedoc, release.yml, sdk-docs.yml) already existed. Added publishConfig (access: public, provenance: true) to sdk/package.json so both the changesets-driven release and the tag-triggered release publish with npm provenance, and added the missing --provenance flag to the tag-based release job. Not done, and out of scope for this PR: actually publishing an initial version and switching backend/package.json off file:../sdk — that requires an NPM_TOKEN and org publish rights I don't have. A maintainer needs to run the first release manually (or merge a changeset) before the backend can move to a semver range.
SR-086 — Publish and test the React Native SDK. Added unit tests for signer.ts, client.ts, and hooks.ts (none existed). Writing the client.ts test surfaced a real bug: submitSigned() signed the transaction via the injected wallet signer, then called the base client's submitTransaction(tx, keypair), which unconditionally calls tx.sign(keypair) again — but submitSigned was passing a fake { sign: () => {} } shim as the "keypair," which throws at runtime. Fixed by adding submitSignedTransaction() to the base SwiftRemitClient for already-signed transactions, and pointing submitSigned at it instead of double-signing through a shim. Also fixed useCreateRemittance calling setState after unmount (added a mounted-ref guard). Configured publishConfig on sdk/react-native/package.json for the same reason as SR-085 — actual publish still needs a maintainer with npm rights.
Commits
fix(sdk): map all 71 contract error codes with remediation and retryability (SR-084)
feat(sdk): add bindings for all remaining contract functions and a CI coverage gate (SR-083)
chore(sdk): enable npm provenance for scoped package releases (SR-085)
test(sdk-rn): add RN client/hooks/signer tests, fix submitSigned re-signing bug, and configure npm provenance (SR-086)
Notes for reviewers
I couldn't run npm test / tsc here — no node_modules in this environment and the sandbox has no network access to install them. I verified the whole sdk/ tree with a manually-fetched TypeScript compiler (npx -p typescript tsc --noEmit) and confirmed zero new type errors beyond pre-existing ones caused by @stellar/stellar-sdk not being installed in this environment. Please run the real test suite in CI before merging.
sdk/scripts/check-contract-coverage.mjs is a plain Node script (no dependencies) so it runs in CI without an npm ci step for sdk/.
Fixing getGovernanceConfig's contract-call string (it called a non-existent query_governance_config instead of get_governance_config) was required to add the new governance bindings without a duplicate-method compile error — folded into the SR-083 commit since it's a direct blocker, not scope creep.
Closes
Closes #1153
Closes #1154
Closes #1155
Closes #1156