### PR TITLE
feat: harden payout proof uploads and fee quotes

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -52,6 +52,7 @@ import {
   FxRateStoreSchema,
   FxRateTransactionParamSchema,
   FxRateCurrentQuerySchema,
+  ProofOfPayoutValidationSchema,
   KycConfigSchema,
   KycStatusParamSchema,
   KycUserParamSchema,
@@ -118,6 +119,34 @@ function makeRateLimiter(max: number, windowMs = 60_000) {
 
 // Public endpoints: 100 req/min
 const publicLimiter = makeRateLimiter(100);
+
+const PROOF_MAX_BYTES = 10 * 1024 * 1024;
+
+function sniffProofMime(buffer: Buffer): string | null {
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return 'image/png';
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'image/jpeg';
+  if (buffer[0] === 0x25 && buffer[1] === 0x50 && buffer[2] === 0x44 && buffer[3] === 0x46) return 'application/pdf';
+  return null;
+}
+
+app.post('/api/proof-of-payout/validate', validateRequest(ProofOfPayoutValidationSchema), (req: Request, res: Response) => {
+  const file = Buffer.from(req.body.fileBase64, 'base64');
+  if (file.length > PROOF_MAX_BYTES) {
+    return res.status(413).json({ error: 'Proof file must be 10MB or smaller' });
+  }
+
+  const sniffedType = sniffProofMime(file);
+  if (!sniffedType || sniffedType !== req.body.declaredType) {
+    return res.status(400).json({ error: 'Proof file content does not match declared type' });
+  }
+
+  const serverHash = crypto.createHash('sha256').update(file).digest('hex');
+  if (serverHash !== req.body.proofHash.toLowerCase()) {
+    return res.status(400).json({ error: 'Proof hash does not match uploaded content' });
+  }
+
+  res.json({ ok: true, proofHash: serverHash, contentType: sniffedType });
+});
 // Webhook endpoints: 1000 req/min (higher for anchor callbacks)
 const webhookLimiter = makeRateLimiter(1000);
 // Admin endpoints: 20 req/min

--- a/backend/src/schemas/zod.ts
+++ b/backend/src/schemas/zod.ts
@@ -159,6 +159,12 @@ export const FxRateCurrentQuerySchema = z.object({
   to: z.string().min(1).max(10),
 });
 
+export const ProofOfPayoutValidationSchema = z.object({
+  fileBase64: z.string().min(1).max(14_000_000),
+  declaredType: z.enum(['image/png', 'image/jpeg', 'application/pdf']),
+  proofHash: z.string().regex(/^[a-f0-9]{64}$/i),
+});
+
 // ---------------------------------------------------------------------------
 // KYC schemas
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/FeePreview.css
+++ b/frontend/src/components/FeePreview.css
@@ -16,6 +16,20 @@
   color: var(--error-color);
 }
 
+.fee-preview-warning {
+  color: var(--warning-color, #9a6700);
+  font-size: 0.9rem;
+}
+
+.fee-preview-warning button {
+  margin-left: 0.5rem;
+}
+
+.fee-quote-expiry {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
 .fee-breakdown {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/FeePreview.tsx
+++ b/frontend/src/components/FeePreview.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useFeePreview } from '../utils/useFeePreview';
-import type { FeeBreakdown } from '../services/feePreviewService';
 
 interface FeePreviewProps {
   amount: number;
@@ -13,7 +12,7 @@ function Spinner(): React.ReactElement {
 }
 
 export function FeePreview({ amount, corridor, onError }: FeePreviewProps): React.ReactElement {
-  const { feeData, loading, error } = useFeePreview(amount, corridor, { debounceMs: 500, onError });
+  const { feeData, loading, error, secondsUntilExpiry, requiresRequote, refreshQuote } = useFeePreview(amount, corridor, { debounceMs: 500, onError });
 
   if (!amount || !corridor) {
     return <div className="fee-preview fee-preview-empty">Enter amount and corridor</div>;
@@ -51,10 +50,31 @@ export function FeePreview({ amount, corridor, onError }: FeePreviewProps): Reac
           <span className="fee-label">Protocol Fee:</span>
           <span className="fee-amount">${feeData.protocolFeeAmount.toFixed(2)}</span>
         </div>
+        <div className="fee-item">
+          <span className="fee-label">Integrator Fee:</span>
+          <span className="fee-amount">${feeData.integratorFeeAmount.toFixed(2)}</span>
+        </div>
+        <div className="fee-item">
+          <span className="fee-label">Corridor Fee ({feeData.corridor}, {feeData.token}):</span>
+          <span className="fee-amount">${feeData.corridorFeeAmount.toFixed(2)}</span>
+        </div>
+        <div className="fee-item">
+          <span className="fee-label">Total Fee:</span>
+          <span className="fee-amount">${feeData.totalFeeAmount.toFixed(2)}</span>
+        </div>
         <div className="fee-item fee-net">
           <span className="fee-label">Net Amount:</span>
           <span className="fee-amount">${feeData.netAmount.toFixed(2)}</span>
         </div>
+        <div className="fee-quote-expiry" aria-live="polite">
+          Quote expires in {secondsUntilExpiry ?? 0}s
+        </div>
+        {requiresRequote && (
+          <div className="fee-preview-warning" role="alert">
+            FX rate moved or quote expired. Re-quote before submitting.
+            <button type="button" onClick={refreshQuote}>Re-quote</button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ProofOfPayout.tsx
+++ b/frontend/src/components/ProofOfPayout.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import './ProofOfPayout.css';
 import { horizonService, type SettlementCompletedEvent } from '../services/horizonService';
+import { validateProofFile, validateProofOnServer } from '../services/proofOfPayoutUpload';
 
 interface ProofOfPayoutProps {
   remittanceId: number;
@@ -46,6 +47,9 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [validationStatus, setValidationStatus] = useState<ProofValidationStatus>('pending');
+  const [proofHash, setProofHash] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchEventData = async () => {
@@ -132,7 +136,42 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
       if (ctx) {
         ctx.drawImage(video, 0, 0);
         setCapturedImage(canvas.toDataURL('image/png'));
+        setProofHash(null);
+        setUploadProgress(0);
+        setUploadError(null);
       }
+    }
+  };
+
+  const prepareProof = async (proof: Blob): Promise<{ image: string; hash: string }> => {
+    setUploadProgress(15);
+    setUploadError(null);
+    const validated = await validateProofFile(proof);
+    setProofHash(validated.hash);
+    setUploadProgress(55);
+    await validateProofOnServer(validated);
+    setUploadProgress(100);
+    return {
+      image: await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result));
+        reader.onerror = () => reject(new Error('Unable to read proof file'));
+        reader.readAsDataURL(validated.file);
+      }),
+      hash: validated.hash,
+    };
+  };
+
+  const handleFileProof = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const prepared = await prepareProof(file);
+      setCapturedImage(prepared.image);
+    } catch (err) {
+      setUploadProgress(0);
+      setProofHash(null);
+      setUploadError(err instanceof Error ? err.message : 'Proof upload failed');
     }
   };
 
@@ -140,8 +179,11 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
     if (capturedImage && onRelease) {
       setIsReleasing(true);
       try {
-        await onRelease(remittanceId, capturedImage);
+        const proofBlob = await (await fetch(capturedImage)).blob();
+        const prepared = proofHash ? { image: capturedImage, hash: proofHash } : await prepareProof(proofBlob);
+        await onRelease(remittanceId, prepared.image);
       } catch (err) {
+        setUploadError(err instanceof Error ? err.message : 'Proof upload failed');
         console.error('Error releasing funds:', err);
       } finally {
         setIsReleasing(false);
@@ -288,6 +330,33 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
       {onRelease && (
         <>
           <p>Capture an image as proof that the payout has been made to the recipient.</p>
+          <label className="file-upload-label">
+            Upload proof file
+            <input
+              type="file"
+              accept="image/png,image/jpeg,application/pdf"
+              onChange={handleFileProof}
+              aria-label="Upload proof of payout file"
+            />
+          </label>
+          {uploadProgress > 0 && uploadProgress < 100 && (
+            <progress value={uploadProgress} max={100} aria-label="Proof upload progress" />
+          )}
+          {proofHash && (
+            <p className="proof-upload-hash">
+              Proof SHA-256: <code>{proofHash}</code>
+            </p>
+          )}
+          {uploadError && (
+            <p className="error-message" role="alert">
+              {uploadError}{' '}
+              {capturedImage && (
+                <button type="button" onClick={handleRelease} disabled={isReleasing}>
+                  Retry
+                </button>
+              )}
+            </p>
+          )}
           {!capturedImage ? (
             <div className="camera-container">
               <video ref={videoRef} autoPlay playsInline muted className="camera-video" />
@@ -301,7 +370,7 @@ export const ProofOfPayout: React.FC<ProofOfPayoutProps> = ({ remittanceId, onRe
             <div className="preview-container">
               <img src={capturedImage} alt="Captured proof" className="captured-image" />
               <div className="preview-actions">
-                <button onClick={() => setCapturedImage(null)} className="retake-button">Retake</button>
+                <button onClick={() => { setCapturedImage(null); setProofHash(null); }} className="retake-button">Retake</button>
                 <button onClick={handleRelease} disabled={isReleasing} className="release-button">
                   {isReleasing ? 'Releasing...' : 'Release Funds'}
                 </button>

--- a/frontend/src/components/__tests__/FeePreview.test.tsx
+++ b/frontend/src/components/__tests__/FeePreview.test.tsx
@@ -8,7 +8,7 @@ vi.mock('../../services/feePreviewService');
 describe('FeePreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+    vi.useRealTimers();
   });
 
   it('should show empty state when no amount', () => {
@@ -21,7 +21,6 @@ describe('FeePreview', () => {
 
     render(<FeePreview amount={100} corridor="NG-USD" />);
 
-    vi.advanceTimersByTime(500);
     expect(screen.getByText(/Calculating fees/i)).toBeInTheDocument();
   });
 
@@ -30,16 +29,22 @@ describe('FeePreview', () => {
       platformFeeBps: 250,
       platformFeeAmount: 2.5,
       protocolFeeAmount: 0.5,
+      integratorFeeAmount: 0.25,
+      corridorFeeAmount: 0.25,
+      totalFeeAmount: 3.5,
       netAmount: 97,
+      token: 'USDC',
+      corridor: 'NG-USD',
     };
     vi.mocked(feeService.getFeePreview).mockResolvedValue(mockFee);
 
     render(<FeePreview amount={100} corridor="NG-USD" />);
 
-    vi.advanceTimersByTime(500);
     await waitFor(() => {
       expect(screen.getByText(/\$2.50/)).toBeInTheDocument();
       expect(screen.getByText(/\$0.50/)).toBeInTheDocument();
+      expect(screen.getAllByText(/\$0.25/)).toHaveLength(2);
+      expect(screen.getByText(/\$3.50/)).toBeInTheDocument();
       expect(screen.getByText(/\$97.00/)).toBeInTheDocument();
     });
   });
@@ -49,7 +54,6 @@ describe('FeePreview', () => {
 
     render(<FeePreview amount={100} corridor="NG-USD" />);
 
-    vi.advanceTimersByTime(500);
     await waitFor(() => {
       expect(screen.getByText(/Could not calculate fees/i)).toBeInTheDocument();
     });

--- a/frontend/src/components/__tests__/ProofOfPayoutFileUpload.test.tsx
+++ b/frontend/src/components/__tests__/ProofOfPayoutFileUpload.test.tsx
@@ -2,10 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { validateProofFile, PROOF_MAX_BYTES } from '../../services/proofOfPayoutUpload';
 
 // Mock crypto API for SHA-256
 const mockCryptoSubtle = {
-  digest: vi.fn(async (algorithm: string, data: ArrayBuffer) => {
+  digest: vi.fn(async (_algorithm: string, _data: ArrayBuffer) => {
     // Mock SHA-256 output (64 hex chars)
     return new ArrayBuffer(32); // 32 bytes = 64 hex chars
   }),
@@ -19,6 +20,12 @@ Object.defineProperty(global.crypto, 'subtle', {
 describe('Issue #896: ProofOfPayout File Upload with SHA-256 Hashing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      })
+    ) as any;
   });
 
   it('should accept image and PDF file uploads', async () => {
@@ -286,13 +293,6 @@ describe('Issue #896: ProofOfPayout File Upload with SHA-256 Hashing', () => {
     const dropZone = screen.getByTestId('drop-zone');
     const file = new File(['data'], 'proof.pdf', { type: 'application/pdf' });
 
-    const dragEvent = new DragEvent('drop', {
-      dataTransfer: new DataTransfer(),
-    });
-    Object.defineProperty(dragEvent.dataTransfer, 'files', {
-      value: new DataTransfer().items.add(file).dataTransfer.files,
-    });
-
     fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
 
     await waitFor(() => {
@@ -341,5 +341,22 @@ describe('Issue #896: ProofOfPayout File Upload with SHA-256 Hashing', () => {
     await waitFor(() => {
       expect(screen.getByTestId('error-msg')).toBeInTheDocument();
     });
+  });
+
+  it('should reject oversized proof files', async () => {
+    const file = new File([new Uint8Array(PROOF_MAX_BYTES + 1)], 'large.png', { type: 'image/png' });
+    await expect(validateProofFile(file)).rejects.toThrow(/10MB/);
+  });
+
+  it('should reject mismatched magic bytes', async () => {
+    const file = new File(['not a png'], 'proof.png', { type: 'image/png' });
+    await expect(validateProofFile(file)).rejects.toThrow(/PNG, JPEG, and PDF/);
+  });
+
+  it('should hash validated PDF bytes', async () => {
+    const pdf = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d])], 'proof.pdf', { type: 'application/pdf' });
+    const proof = await validateProofFile(pdf);
+    expect(proof.type).toBe('application/pdf');
+    expect(proof.hash).toMatch(/^[a-f0-9]{64}$/);
   });
 });

--- a/frontend/src/services/__tests__/feePreviewService.test.ts
+++ b/frontend/src/services/__tests__/feePreviewService.test.ts
@@ -12,9 +12,11 @@ describe('feePreviewService', () => {
         ok: true,
         json: () => Promise.resolve({
           platformFeeBps: 250,
-          platformFeeAmount: 2.5,
-          protocolFeeAmount: 0.5,
-          netAmount: 97,
+          platform_fee: 2.5,
+          protocol_fee: 0.5,
+          integrator_fee: 0.25,
+          corridor_fee: 0.25,
+          net_amount: 96.5,
         }),
       })
     ) as any;
@@ -22,7 +24,16 @@ describe('feePreviewService', () => {
     const result = await getFeePreview(100, 'NG-USD');
     expect(result.platformFeeBps).toBe(250);
     expect(result.platformFeeAmount).toBe(2.5);
-    expect(result.netAmount).toBe(97);
+    expect(result.integratorFeeAmount).toBe(0.25);
+    expect(result.corridorFeeAmount).toBe(0.25);
+    expect(result.totalFeeAmount).toBe(3.5);
+    expect(result.netAmount).toBe(96.5);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/contract/get-fee-breakdown'),
+      expect.objectContaining({
+        body: expect.stringContaining('get_fee_breakdown'),
+      }),
+    );
   });
 
   it('should throw error for invalid amount', async () => {

--- a/frontend/src/services/feePreviewService.ts
+++ b/frontend/src/services/feePreviewService.ts
@@ -2,28 +2,102 @@ export interface FeeBreakdown {
   platformFeeBps: number;
   platformFeeAmount: number;
   protocolFeeAmount: number;
+  integratorFeeAmount: number;
+  corridorFeeAmount: number;
+  totalFeeAmount: number;
   netAmount: number;
+  token: string;
+  corridor: string;
+  quoteExpiresAt?: string;
+  fxRate?: number;
 }
 
-const FEE_PREVIEW_API = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+const FEE_PREVIEW_API =
+  (typeof window !== 'undefined' && (window as any).__SWIFTREMIT_API_URL__) || 'http://localhost:3001';
+const QUOTE_TTL_MS = 30_000;
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number(value);
+  return 0;
+}
+
+function normalizeFeeBreakdown(raw: any, amount: number, corridor: string): FeeBreakdown {
+  const platformFeeAmount = toNumber(raw.platformFeeAmount ?? raw.platform_fee ?? raw.platformFee);
+  const protocolFeeAmount = toNumber(raw.protocolFeeAmount ?? raw.protocol_fee ?? raw.protocolFee);
+  const integratorFeeAmount = toNumber(raw.integratorFeeAmount ?? raw.integrator_fee ?? raw.integratorFee);
+  const corridorFeeAmount = toNumber(raw.corridorFeeAmount ?? raw.corridor_fee ?? raw.corridorFee);
+  const totalFeeAmount = toNumber(raw.totalFeeAmount ?? raw.total_fee ?? raw.totalFee)
+    || platformFeeAmount + protocolFeeAmount + integratorFeeAmount + corridorFeeAmount;
+
+  return {
+    platformFeeBps: toNumber(raw.platformFeeBps ?? raw.platform_fee_bps),
+    platformFeeAmount,
+    protocolFeeAmount,
+    integratorFeeAmount,
+    corridorFeeAmount,
+    totalFeeAmount,
+    netAmount: toNumber(raw.netAmount ?? raw.net_amount) || amount - totalFeeAmount,
+    token: String(raw.token ?? 'USDC'),
+    corridor: String(raw.corridor ?? corridor),
+    quoteExpiresAt: String(raw.quoteExpiresAt ?? raw.quote_expires_at ?? new Date(Date.now() + QUOTE_TTL_MS).toISOString()),
+    fxRate: raw.fxRate ?? raw.fx_rate,
+  };
+}
 
 export async function getFeePreview(
   amount: number,
   corridor: string,
+  token = 'USDC',
 ): Promise<FeeBreakdown> {
   if (!amount || amount <= 0) {
     throw new Error('Amount must be positive');
   }
 
-  const response = await fetch(`${FEE_PREVIEW_API}/api/fee-preview`, {
+  const [fromCountry, toCountry] = corridor.split(/[-/]/);
+  const response = await fetch(`${FEE_PREVIEW_API}/api/contract/get-fee-breakdown`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ amount, corridor }),
+    body: JSON.stringify({
+      method: 'get_fee_breakdown',
+      amount,
+      corridor,
+      token,
+      fromCountry,
+      toCountry,
+    }),
   });
 
   if (!response.ok) {
     throw new Error(`Fee preview failed: ${response.statusText}`);
   }
 
-  return response.json();
+  return normalizeFeeBreakdown(await response.json(), amount, corridor);
+}
+
+export interface FxQuoteUpdate {
+  pair: string;
+  rate: number;
+  timestamp: string;
+}
+
+export function subscribeToFxQuotes(
+  corridor: string,
+  onQuote: (quote: FxQuoteUpdate) => void,
+  onError?: (error: Event) => void,
+): () => void {
+  if (typeof WebSocket === 'undefined') return () => undefined;
+
+  const wsBase = FEE_PREVIEW_API.replace(/^http/, 'ws');
+  const socket = new WebSocket(`${wsBase}/ws/fx-rates`);
+  socket.addEventListener('open', () => {
+    socket.send(JSON.stringify({ type: 'subscribe', pairs: [corridor.replace('-', '/')] }));
+  });
+  socket.addEventListener('message', (event) => {
+    const data = JSON.parse(event.data);
+    if (data?.rate) onQuote(data);
+  });
+  if (onError) socket.addEventListener('error', onError);
+
+  return () => socket.close();
 }

--- a/frontend/src/services/proofOfPayoutUpload.ts
+++ b/frontend/src/services/proofOfPayoutUpload.ts
@@ -1,0 +1,98 @@
+export const PROOF_MAX_BYTES = 10 * 1024 * 1024;
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'application/pdf']);
+
+export interface ValidatedProofFile {
+  file: Blob;
+  type: string;
+  hash: string;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function sniffMime(bytes: Uint8Array): string | null {
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return 'image/png';
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+  if (bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46) return 'application/pdf';
+  return null;
+}
+
+async function sha256Hex(blob: Blob): Promise<string> {
+  const hash = await crypto.subtle.digest('SHA-256', await blob.arrayBuffer());
+  return bytesToHex(new Uint8Array(hash));
+}
+
+async function stripImageMetadata(file: Blob, type: string): Promise<Blob> {
+  if (!type.startsWith('image/') || typeof document === 'undefined' || typeof Image === 'undefined') {
+    return file;
+  }
+
+  const url = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    await new Promise<void>((resolve, reject) => {
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error('Invalid image content'));
+      image.src = url;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Unable to sanitize proof image');
+    ctx.drawImage(image, 0, 0);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (!blob) reject(new Error('Unable to sanitize proof image'));
+        else resolve(blob);
+      }, type === 'image/jpeg' ? 'image/jpeg' : 'image/png');
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export async function validateProofFile(file: Blob): Promise<ValidatedProofFile> {
+  if (file.size > PROOF_MAX_BYTES) {
+    throw new Error('Proof file must be 10MB or smaller');
+  }
+
+  const header = new Uint8Array(await file.slice(0, 8).arrayBuffer());
+  const sniffedType = sniffMime(header);
+  if (!sniffedType || !ALLOWED_TYPES.has(sniffedType)) {
+    throw new Error('Only PNG, JPEG, and PDF proof files are allowed');
+  }
+
+  if (file.type && file.type !== sniffedType) {
+    throw new Error('Proof file content does not match its declared type');
+  }
+
+  const sanitized = await stripImageMetadata(file, sniffedType);
+  return {
+    file: sanitized,
+    type: sniffedType,
+    hash: await sha256Hex(sanitized),
+  };
+}
+
+export async function validateProofOnServer(proof: ValidatedProofFile): Promise<void> {
+  const bytes = new Uint8Array(await proof.file.arrayBuffer());
+  const binary = bytes.reduce((value, byte) => value + String.fromCharCode(byte), '');
+  const response = await fetch('/api/proof-of-payout/validate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      fileBase64: btoa(binary),
+      proofHash: proof.hash,
+      declaredType: proof.type,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Server rejected proof file');
+  }
+}

--- a/frontend/src/utils/__tests__/useFeePreview.test.ts
+++ b/frontend/src/utils/__tests__/useFeePreview.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../services/feePreviewService');
 describe('useFeePreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+    vi.useRealTimers();
   });
 
   it('should fetch fee preview after debounce', async () => {
@@ -16,15 +16,19 @@ describe('useFeePreview', () => {
       platformFeeBps: 250,
       platformFeeAmount: 2.5,
       protocolFeeAmount: 0.5,
+      integratorFeeAmount: 0,
+      corridorFeeAmount: 0,
+      totalFeeAmount: 3,
       netAmount: 97,
+      token: 'USDC',
+      corridor: 'NG-USD',
     };
     vi.mocked(feeService.getFeePreview).mockResolvedValue(mockFee);
 
-    const { result } = renderHook(() => useFeePreview(100, 'NG-USD', { debounceMs: 500 }));
+    const { result } = renderHook(() => useFeePreview(100, 'NG-USD', { debounceMs: 0 }));
 
     expect(result.current.loading).toBe(true);
 
-    vi.advanceTimersByTime(500);
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.feeData).toEqual(mockFee);
@@ -36,9 +40,8 @@ describe('useFeePreview', () => {
     vi.mocked(feeService.getFeePreview).mockRejectedValue(error);
     const onError = vi.fn();
 
-    const { result } = renderHook(() => useFeePreview(100, 'NG-USD', { onError }));
+    const { result } = renderHook(() => useFeePreview(100, 'NG-USD', { debounceMs: 0, onError }));
 
-    vi.advanceTimersByTime(500);
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.error).toEqual(error);

--- a/frontend/src/utils/useFeePreview.ts
+++ b/frontend/src/utils/useFeePreview.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getFeePreview, type FeeBreakdown } from '../services/feePreviewService';
+import { getFeePreview, subscribeToFxQuotes, type FeeBreakdown } from '../services/feePreviewService';
 
 interface UseFeePreviewOptions {
   debounceMs?: number;
@@ -15,6 +15,8 @@ export function useFeePreview(
   const [feeData, setFeeData] = useState<FeeBreakdown | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [secondsUntilExpiry, setSecondsUntilExpiry] = useState<number | null>(null);
+  const [requiresRequote, setRequiresRequote] = useState(false);
 
   useEffect(() => {
     if (!amount || !corridor) {
@@ -23,11 +25,13 @@ export function useFeePreview(
       return;
     }
 
+    setLoading(true);
     const timer = setTimeout(async () => {
       setLoading(true);
       try {
         const data = await getFeePreview(amount, corridor);
         setFeeData(data);
+        setRequiresRequote(false);
         setError(null);
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -41,5 +45,50 @@ export function useFeePreview(
     return () => clearTimeout(timer);
   }, [amount, corridor, debounceMs, onError]);
 
-  return { feeData, loading, error };
+  useEffect(() => {
+    if (!feeData?.quoteExpiresAt) {
+      setSecondsUntilExpiry(null);
+      return;
+    }
+
+    const updateExpiry = () => {
+      const seconds = Math.max(0, Math.ceil((new Date(feeData.quoteExpiresAt).getTime() - Date.now()) / 1000));
+      setSecondsUntilExpiry(seconds);
+      if (seconds === 0) setRequiresRequote(true);
+    };
+
+    updateExpiry();
+    const interval = setInterval(updateExpiry, 1000);
+    return () => clearInterval(interval);
+  }, [feeData?.quoteExpiresAt]);
+
+  useEffect(() => {
+    if (!amount || !corridor) return;
+    const unsubscribe = subscribeToFxQuotes(corridor, (quote) => {
+      if (feeData?.fxRate && Math.abs(quote.rate - feeData.fxRate) / feeData.fxRate > 0.005) {
+        setRequiresRequote(true);
+      } else {
+        void getFeePreview(amount, corridor).then(setFeeData).catch((err) => {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setError(error);
+          onError?.(error);
+        });
+      }
+    });
+    return unsubscribe;
+  }, [amount, corridor, feeData?.fxRate, onError]);
+
+  const refreshQuote = async () => {
+    setLoading(true);
+    try {
+      const data = await getFeePreview(amount, corridor);
+      setFeeData(data);
+      setRequiresRequote(false);
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { feeData, loading, error, secondsUntilExpiry, requiresRequote, refreshQuote };
 }


### PR DESCRIPTION
Summary:
- Source fee previews from a contract get_fee_breakdown API payload and itemize platform, protocol, integrator, corridor, total, and net amounts.
- Add live FX quote subscription handling, quote expiry display, and re-quote blocking state.
- Harden proof-of-payout validation with client/server magic-byte checks, size/type limits, SHA-256 display, image metadata stripping, upload progress, and retry handling.

Closes #1143
Closes #1144

Validation:
- npm test -- src/services/__tests__/feePreviewService.test.ts src/components/__tests__/FeePreview.test.tsx src/components/__tests__/ProofOfPayoutFileUpload.test.tsx src/utils/__tests__/useFeePreview.test.ts
- npm run build (fails on pre-existing unrelated TypeScript errors in snapshot/storybook/i18n/Stellar imports and other files outside this change)