### PR TITLE
feat(sdk): add browser bundle, CDN docs, and SDK input validation

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -1,0 +1,79 @@
+name: SDK CI
+
+on:
+  push:
+    paths:
+      - "sdk/**"
+  pull_request:
+    paths:
+      - "sdk/**"
+
+jobs:
+  # ── Build + unit tests ─────────────────────────────────────────────────────
+  sdk-test:
+    name: SDK — build & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run lint
+
+      - name: Run unit tests (including browser smoke test)
+        run: npm test
+
+      - name: Build all bundles
+        run: npm run build
+
+  # ── Bundle size budget ─────────────────────────────────────────────────────
+  sdk-bundle-size:
+    name: SDK — browser bundle size budget
+    runs-on: ubuntu-latest
+    needs: sdk-test
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build bundles
+        run: npm run build
+
+      - name: Run size-limit budget check
+        run: npx size-limit --json
+        # The budgets are declared in package.json "size-limit" field:
+        #   - dist/browser/index.global.js  ≤ 120 kB gzipped
+        #   - dist/browser/index.esm.mjs    ≤ 120 kB gzipped
+        #   - dist/index.js                 ≤ 150 kB gzipped
+        # The job fails if any artifact exceeds its budget.
+
+      - name: Upload browser bundle as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-browser-bundle
+          path: |
+            sdk/dist/browser/index.global.js
+            sdk/dist/browser/index.global.js.map
+            sdk/dist/browser/index.esm.mjs
+          retention-days: 14

--- a/sdk/CDN_USAGE.md
+++ b/sdk/CDN_USAGE.md
@@ -1,0 +1,176 @@
+# SwiftRemit SDK — Browser / CDN Usage
+
+This guide covers loading the SwiftRemit SDK directly in a browser without a build tool
+(via CDN), the polyfills it requires, and how to keep bundle size under control when using
+a bundler.
+
+---
+
+## Quick-start: Script tag / CDN
+
+The IIFE build exposes a single global: **`window.SwiftRemitSDK`**.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SwiftRemit CDN example</title>
+</head>
+<body>
+  <!--
+    1. Polyfills — load before the SDK.
+       The Stellar SDK relies on the Node.js `Buffer` global.
+       The easiest drop-in for browsers is the `buffer` package via esm.sh.
+  -->
+  <script type="module">
+    import { Buffer } from "https://esm.sh/buffer@6";
+    window.Buffer = Buffer;   // make it available globally
+  </script>
+
+  <!-- 2. Stellar SDK (peer dependency — must be loaded before SwiftRemitSDK) -->
+  <script src="https://unpkg.com/@stellar/stellar-sdk@13/dist/stellar-sdk.min.js"></script>
+
+  <!-- 3. SwiftRemit SDK -->
+  <script src="https://unpkg.com/@swiftremit/sdk@latest/dist/browser/index.global.js"></script>
+
+  <!-- 4. Your application code -->
+  <script>
+    const { SwiftRemitClient, Networks, RpcUrls, toStroops, fromStroops } = SwiftRemitSDK;
+
+    async function main() {
+      const client = new SwiftRemitClient({
+        contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+        networkPassphrase: Networks.TESTNET,
+        rpcUrl: RpcUrls.TESTNET,
+      });
+
+      // Read-only: fetch the on-chain health status
+      const healthQueryAddress = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+      const health = await client.health(healthQueryAddress);
+      console.log("Contract healthy:", !health.paused);
+      console.log("Total remittances:", health.totalRemittances.toString());
+
+      // Amount conversion helpers
+      console.log("100 USDC in stroops:", toStroops(100).toString()); // 1000000000n
+      console.log("1000000000 stroops in USDC:", fromStroops(1_000_000_000n)); // 100
+    }
+
+    main().catch(console.error);
+  </script>
+</body>
+</html>
+```
+
+---
+
+## Required polyfills
+
+| Polyfill | Why it is needed | CDN / npm |
+|---|---|---|
+| `Buffer` | The Stellar SDK uses Node's `Buffer` for XDR (de)serialisation. Browsers do not have it natively. | `https://esm.sh/buffer@6` or `npm i buffer` |
+| `TextEncoder` / `TextDecoder` | Used internally by the Stellar SDK for UTF-8 conversion. Built-in in all modern browsers (Chrome 38+, Firefox 19+, Safari 10.1+). Polyfill only needed for IE11 / legacy WebKit. | `https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js` |
+| `fetch` | Used for Soroban RPC calls. Built-in in all modern browsers. Polyfill only needed for IE11 / very old mobile browsers. | `https://cdn.jsdelivr.net/npm/whatwg-fetch@3.6.20/fetch.min.js` |
+
+> **Crypto**: The SDK does not perform key-signing in the browser bundle — it only builds
+> and prepares transactions. Signing should be delegated to a wallet (e.g. Freighter,
+> Albedo, WalletConnect) which supplies the `Keypair` externally. If you do sign in-browser,
+> the Stellar SDK uses the Web Crypto API (`window.crypto.subtle`), which is available
+> natively in all modern browsers and requires HTTPS.
+
+---
+
+## ESM bundlers (Vite, webpack, Rollup, esbuild)
+
+Prefer the `"browser"` export condition — bundlers will pick it up automatically from
+`package.json`:
+
+```ts
+// Tree-shakeable: only the symbols you import are included in your final bundle.
+import { SwiftRemitClient, toStroops, Networks, RpcUrls } from "@swiftremit/sdk";
+```
+
+Add the Buffer polyfill in your bundler config if your target environment does not provide
+it:
+
+**Vite (`vite.config.ts`)**
+```ts
+import { defineConfig } from "vite";
+import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
+
+export default defineConfig({
+  optimizeDeps: {
+    esbuildOptions: {
+      plugins: [NodeGlobalsPolyfillPlugin({ buffer: true })],
+    },
+  },
+  resolve: {
+    alias: { buffer: "buffer" },
+  },
+});
+```
+
+**webpack 5 (`webpack.config.js`)**
+```js
+const { ProvidePlugin } = require("webpack");
+
+module.exports = {
+  resolve: {
+    fallback: { buffer: require.resolve("buffer/") },
+  },
+  plugins: [
+    new ProvidePlugin({ Buffer: ["buffer", "Buffer"] }),
+  ],
+};
+```
+
+---
+
+## Bundle size budget
+
+The CI pipeline enforces the following gzipped size budgets (see `"size-limit"` in
+`package.json`):
+
+| Artifact | Budget (gzipped) |
+|---|---|
+| `dist/browser/index.global.js` (IIFE) | 120 kB |
+| `dist/browser/index.esm.mjs` (ESM, bundlers) | 120 kB |
+| `dist/index.js` (Node CJS) | 150 kB |
+
+Run locally after building:
+
+```bash
+npm run build
+npm run size
+```
+
+CI fails automatically if any budget is exceeded (the `size:ci` script is called in the
+`sdk-ci` workflow).
+
+---
+
+## Tree-shaking verification
+
+The ESM browser build (`dist/browser/index.esm.mjs`) is produced with `treeshake: true`
+in tsup. To verify that your bundler successfully tree-shakes unused exports:
+
+```bash
+# Install bundle analyser (example using vite-bundle-visualizer)
+npm i -D vite-bundle-visualizer
+npx vite-bundle-visualizer
+```
+
+A correct tree-shaken build importing only `{ SwiftRemitClient }` should be
+significantly smaller than the full bundle.
+
+---
+
+## React Native
+
+For React Native consumers, use the dedicated subpackage:
+
+```ts
+import { SwiftRemitClient } from "@swiftremit/sdk/react-native";
+```
+
+See [`sdk/react-native/README.md`](sdk/react-native/README.md) for setup instructions.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,10 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "browser": "dist/browser/index.mjs",
+  "browser": "dist/browser/index.global.js",
   "exports": {
     ".": {
-      "browser": "./dist/browser/index.mjs",
+      "browser": "./dist/browser/index.esm.mjs",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
@@ -21,12 +21,15 @@
   },
   "files": [
     "dist",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "CDN_USAGE.md"
   ],
   "scripts": {
     "build": "tsup",
     "test": "vitest run",
     "lint": "tsc --noEmit",
+    "size": "size-limit",
+    "size:ci": "size-limit --json",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",
@@ -34,6 +37,26 @@
     "docs": "typedoc src/index.ts --out docs --plugin typedoc-plugin-markdown",
     "docs:serve": "http-server docs -p 8080 -o"
   },
+  "size-limit": [
+    {
+      "name": "Browser IIFE (gzipped)",
+      "path": "dist/browser/index.global.js",
+      "limit": "120 kB",
+      "gzip": true
+    },
+    {
+      "name": "Browser ESM (gzipped, tree-shakeable)",
+      "path": "dist/browser/index.esm.mjs",
+      "limit": "120 kB",
+      "gzip": true
+    },
+    {
+      "name": "Node CJS (gzipped)",
+      "path": "dist/index.js",
+      "limit": "150 kB",
+      "gzip": true
+    }
+  ],
   "keywords": [
     "stellar",
     "soroban",
@@ -51,8 +74,10 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.10",
+    "@size-limit/preset-small-lib": "^11.0.0",
     "@stellar/stellar-sdk": "^13.0.0",
     "@types/node": "^25.9.1",
+    "size-limit": "^11.0.0",
     "tsup": "^8.0.0",
     "typescript": "^6.0.3",
     "typedoc": "^0.25.1",

--- a/sdk/src/browser.smoke.test.ts
+++ b/sdk/src/browser.smoke.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Browser smoke test — sdk/src/browser.smoke.test.ts
+ *
+ * Verifies that:
+ *  1. The SDK can be imported in a browser-like environment (jsdom / happy-dom).
+ *  2. Key exports are present and have the correct types.
+ *  3. Amount-conversion helpers (toStroops / fromStroops) work correctly.
+ *  4. Input validation helpers throw on bad input (integration with #1160).
+ *  5. SwiftRemitClient can be instantiated without throwing.
+ *
+ * NOTE: This test does NOT make real RPC calls — it verifies the public surface
+ * of the bundle that would be loaded via a CDN <script> tag.  A real end-to-end
+ * read-only call against testnet is covered by the testnet integration workflow.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// Import from the package root so we exercise the same code path that a CDN
+// script-tag consumer would get (the IIFE build re-exports all of index.ts).
+import {
+  SwiftRemitClient,
+  Networks,
+  RpcUrls,
+  USDC_MULTIPLIER,
+  toStroops,
+  fromStroops,
+  validateAmount,
+  validateAddress,
+  estimateStellarFee,
+  SwiftRemitError,
+  ErrorCode,
+} from "./index.js";
+
+// ─── 1. Export presence ───────────────────────────────────────────────────────
+
+describe("browser bundle exports", () => {
+  it("exports SwiftRemitClient as a class", () => {
+    expect(typeof SwiftRemitClient).toBe("function");
+    expect(SwiftRemitClient.prototype).toBeDefined();
+  });
+
+  it("exports Networks with TESTNET and MAINNET passphrases", () => {
+    expect(typeof Networks.TESTNET).toBe("string");
+    expect(typeof Networks.MAINNET).toBe("string");
+    expect(Networks.TESTNET).toContain("Test SDF");
+    expect(Networks.MAINNET).toContain("Public Global");
+  });
+
+  it("exports RpcUrls with TESTNET and MAINNET endpoints", () => {
+    expect(RpcUrls.TESTNET).toMatch(/^https?:\/\//);
+    expect(RpcUrls.MAINNET).toMatch(/^https?:\/\//);
+  });
+
+  it("exports USDC_MULTIPLIER as a bigint", () => {
+    expect(typeof USDC_MULTIPLIER).toBe("bigint");
+    expect(USDC_MULTIPLIER).toBe(10_000_000n);
+  });
+
+  it("exports validation helpers", () => {
+    expect(typeof validateAmount).toBe("function");
+    expect(typeof validateAddress).toBe("function");
+  });
+
+  it("exports estimateStellarFee as a function", () => {
+    expect(typeof estimateStellarFee).toBe("function");
+  });
+});
+
+// ─── 2. Amount conversion ─────────────────────────────────────────────────────
+
+describe("toStroops / fromStroops", () => {
+  it("converts whole USDC amounts correctly", () => {
+    expect(toStroops(1)).toBe(10_000_000n);
+    expect(toStroops(100)).toBe(1_000_000_000n);
+    expect(toStroops(0)).toBe(0n);
+  });
+
+  it("round-trips via fromStroops", () => {
+    const usdc = 42.5;
+    expect(fromStroops(toStroops(usdc))).toBeCloseTo(usdc, 7);
+  });
+
+  it("fromStroops returns a number", () => {
+    expect(typeof fromStroops(10_000_000n)).toBe("number");
+    expect(fromStroops(10_000_000n)).toBe(1);
+  });
+});
+
+// ─── 3. Input validation (#1160 integration) ──────────────────────────────────
+
+describe("validateAmount", () => {
+  it("accepts valid positive integer amounts (as bigint)", () => {
+    expect(() => validateAmount(10_000_000n)).not.toThrow();
+    expect(() => validateAmount(1n)).not.toThrow();
+  });
+
+  it("rejects zero", () => {
+    expect(() => validateAmount(0n)).toThrow(SwiftRemitError);
+    expect(() => validateAmount(0n)).toThrow(/greater than zero/i);
+  });
+
+  it("rejects negative amounts", () => {
+    expect(() => validateAmount(-1n)).toThrow(SwiftRemitError);
+    expect(() => validateAmount(-10_000_000n)).toThrow(SwiftRemitError);
+  });
+
+  it("rejects non-bigint input (e.g. a float passed as number)", () => {
+    // @ts-expect-error intentional wrong type for runtime test
+    expect(() => validateAmount(1.5)).toThrow(SwiftRemitError);
+    // @ts-expect-error intentional wrong type for runtime test
+    expect(() => validateAmount("100")).toThrow(SwiftRemitError);
+  });
+});
+
+describe("validateAddress", () => {
+  const VALID_STELLAR_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  it("accepts a valid Stellar address", () => {
+    expect(() => validateAddress(VALID_STELLAR_ADDRESS)).not.toThrow();
+  });
+
+  it("rejects an empty string", () => {
+    expect(() => validateAddress("")).toThrow(SwiftRemitError);
+  });
+
+  it("rejects a non-G... Stellar address", () => {
+    expect(() => validateAddress("XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4")).toThrow(SwiftRemitError);
+  });
+
+  it("rejects a too-short string", () => {
+    expect(() => validateAddress("GABC")).toThrow(SwiftRemitError);
+  });
+
+  it("rejects a string with invalid characters", () => {
+    expect(() => validateAddress("G" + "0".repeat(55))).toThrow(SwiftRemitError);
+  });
+
+  it("rejects non-string input", () => {
+    // @ts-expect-error intentional wrong type for runtime test
+    expect(() => validateAddress(null)).toThrow(SwiftRemitError);
+    // @ts-expect-error intentional wrong type for runtime test
+    expect(() => validateAddress(12345)).toThrow(SwiftRemitError);
+  });
+});
+
+// ─── 4. SwiftRemitClient instantiation ───────────────────────────────────────
+
+describe("SwiftRemitClient instantiation", () => {
+  it("constructs without throwing for a valid config", () => {
+    expect(
+      () =>
+        new SwiftRemitClient({
+          contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+          networkPassphrase: Networks.TESTNET,
+          rpcUrl: RpcUrls.TESTNET,
+        })
+    ).not.toThrow();
+  });
+
+  it("exposes expected read methods", () => {
+    const client = new SwiftRemitClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+      networkPassphrase: Networks.TESTNET,
+      rpcUrl: RpcUrls.TESTNET,
+    });
+    expect(typeof client.health).toBe("function");
+    expect(typeof client.getRemittance).toBe("function");
+    expect(typeof client.getAccumulatedFees).toBe("function");
+    expect(typeof client.isAgentRegistered).toBe("function");
+  });
+});
+
+// ─── 5. estimateStellarFee ────────────────────────────────────────────────────
+
+describe("estimateStellarFee", () => {
+  it("returns the base fee for 1 operation", () => {
+    expect(estimateStellarFee(1, 100)).toBeCloseTo(0.00001, 10);
+  });
+
+  it("scales linearly with operation count", () => {
+    expect(estimateStellarFee(10, 100)).toBeCloseTo(0.0001, 10);
+  });
+
+  it("throws for operationCount < 1", () => {
+    expect(() => estimateStellarFee(0)).toThrow(RangeError);
+  });
+});
+
+// ─── 6. ErrorCode enum completeness ──────────────────────────────────────────
+
+describe("ErrorCode enum", () => {
+  it("contains InvalidAmount", () => {
+    expect(ErrorCode.InvalidAmount).toBeDefined();
+  });
+
+  it("contains InvalidAddress", () => {
+    expect(ErrorCode.InvalidAddress).toBeDefined();
+  });
+});

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -48,6 +48,8 @@ import {
   bytesNToScVal,
   stringToScVal,
   parseProposal,
+  validateAmount,
+  validateAddress,
 } from "./convert.js";
 
 /** Maximum number of entries allowed in a single batch remittance call. */
@@ -682,6 +684,14 @@ export class SwiftRemitClient {
    * // Sign and submit tx
    */
   async createRemittance(params: CreateRemittanceParams): Promise<Transaction> {
+    // ── Input validation (SR-090 / #1160) ──────────────────────────────────
+    // Validate before building any XDR so callers get a clear error instead of
+    // an opaque transaction-simulation failure or a silently wrong amount.
+    validateAddress(params.sender);
+    validateAddress(params.agent);
+    validateAmount(params.amount);
+    if (params.token) validateAddress(params.token);
+    // ───────────────────────────────────────────────────────────────────────
     return this.prepareTransaction(params.sender, "create_remittance", [
       addressToScVal(params.sender),
       addressToScVal(params.agent),
@@ -777,6 +787,23 @@ export class SwiftRemitClient {
         `Batch size ${entries.length} exceeds MAX_BATCH_SIZE (${MAX_BATCH_SIZE})`
       );
     }
+    // ── Input validation (SR-090 / #1160) ──────────────────────────────────
+    validateAddress(sender);
+    entries.forEach((e, i) => {
+      try {
+        validateAddress(e.agent);
+        validateAmount(e.amount);
+      } catch (err) {
+        if (err instanceof SwiftRemitError) {
+          throw new SwiftRemitError(
+            err.code,
+            `Batch entry [${i}]: ${err.message}`
+          );
+        }
+        throw err;
+      }
+    });
+    // ───────────────────────────────────────────────────────────────────────
     const entriesScVal = xdr.ScVal.scvVec(
       entries.map((e) =>
         xdr.ScVal.scvMap([

--- a/sdk/src/convert.ts
+++ b/sdk/src/convert.ts
@@ -189,9 +189,87 @@ export function parseProposal(val: xdr.ScVal): Proposal {
   };
 }
 
+// ─── Input validation ─────────────────────────────────────────────────────────
+
+/**
+ * Validate a remittance amount before building any transaction.
+ *
+ * Rules:
+ *  - Must be a `bigint` (rejects floats and strings that would silently round).
+ *  - Must be strictly greater than zero (zero amounts are contract-rejected anyway,
+ *    but catching it here gives a cleaner error message).
+ *  - Must not be negative.
+ *
+ * @throws {SwiftRemitError} with `ErrorCode.InvalidAmount` on any violation.
+ */
+export function validateAmount(amount: bigint): void {
+  if (typeof amount !== "bigint") {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAmount,
+      `Amount must be a bigint (e.g. toStroops(100)); received ${typeof amount}. ` +
+        `Passing a floating-point number can silently produce a wrong value.`
+    );
+  }
+  if (amount <= 0n) {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAmount,
+      `Amount must be greater than zero; received ${amount}.`
+    );
+  }
+}
+
+/**
+ * Validate a Stellar/Soroban address before building any transaction.
+ *
+ * Rules:
+ *  - Must be a non-empty string.
+ *  - Must start with "G" (Stellar public-key prefix) or "C" (contract address prefix).
+ *  - Must be exactly 56 characters long (StrKey encoding of a 32-byte key).
+ *  - Must consist only of valid Base-32 characters (A-Z, 2-7).
+ *
+ * We intentionally do NOT call `Address.fromString` here because that throws an
+ * opaque XDR error; we want a clear, actionable message.
+ *
+ * @throws {SwiftRemitError} with `ErrorCode.InvalidAddress` on any violation.
+ */
+export function validateAddress(address: string): void {
+  if (typeof address !== "string" || address.length === 0) {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAddress,
+      `Address must be a non-empty string; received ${JSON.stringify(address)}.`
+    );
+  }
+  // Stellar public key = 56 characters, starts with G.
+  // Contract address  = 56 characters, starts with C.
+  if (address.length !== 56) {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAddress,
+      `Address must be exactly 56 characters long; received ${address.length} characters: "${address}".`
+    );
+  }
+  if (address[0] !== "G" && address[0] !== "C") {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAddress,
+      `Address must start with "G" (account) or "C" (contract); received "${address[0]}".`
+    );
+  }
+  // StrKey alphabet: A-Z and 2-7 (RFC 4648 Base32, uppercase, no padding)
+  if (!/^[A-Z2-7]{56}$/.test(address)) {
+    throw new SwiftRemitError(
+      ErrorCode.InvalidAddress,
+      `Address contains invalid characters. A Stellar StrKey must use only [A-Z2-7]: "${address}".`
+    );
+  }
+}
+
 // ─── Native → ScVal ──────────────────────────────────────────────────────────
 
+/**
+ * Convert a Stellar address string to an ScVal, with pre-validation.
+ * Throws a clear `SwiftRemitError(InvalidAddress)` instead of an opaque XDR error.
+ */
 export function addressToScVal(address: string): xdr.ScVal {
+  validateAddress(address);
   return nativeToScVal(Address.fromString(address), { type: "address" });
 }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -57,6 +57,10 @@ export {
   optionToScVal,
   bytesNToScVal,
   stringToScVal,
+  /** Validate a bigint amount before passing to any transaction-building function. */
+  validateAmount,
+  /** Validate a Stellar address string before passing to any transaction-building function. */
+  validateAddress,
 } from "./convert.js";
 
 /** Stellar network passphrases for convenience. */
@@ -96,9 +100,34 @@ export function estimateStellarFee(operationCount = 1, baseFeeStroops = STELLAR_
   return (baseFeeStroops * operationCount) / XLM_STROOPS;
 }
 
-/** Convert a human-readable USDC amount to stroops. */
+/** Convert a human-readable USDC amount to stroops.
+ *
+ * @param usdc - A non-negative, non-fractional number (e.g. 100 for 100 USDC).
+ *   Passing a float (e.g. 1.999_999_999) will throw — use an integer or round
+ *   explicitly before calling this function.
+ * @throws {RangeError} if `usdc` is negative.
+ * @throws {RangeError} if `usdc` is not a safe integer after scaling
+ *   (i.e. would lose precision via floating-point arithmetic).
+ */
 export function toStroops(usdc: number): bigint {
-  return BigInt(Math.round(usdc * Number(USDC_MULTIPLIER)));
+  if (usdc < 0) {
+    throw new RangeError(`toStroops: usdc must be non-negative; received ${usdc}.`);
+  }
+  const scaled = usdc * Number(USDC_MULTIPLIER);
+  if (!Number.isInteger(scaled)) {
+    throw new RangeError(
+      `toStroops: "${usdc}" USDC does not map to a whole number of stroops ` +
+        `(result: ${scaled}). Use a value with at most 7 decimal places, ` +
+        `or round explicitly: Math.round(${usdc} * 1e7).`
+    );
+  }
+  if (!Number.isSafeInteger(scaled)) {
+    throw new RangeError(
+      `toStroops: "${usdc}" USDC exceeds safe integer range after scaling. ` +
+        `Use a BigInt-based computation for very large amounts.`
+    );
+  }
+  return BigInt(scaled);
 }
 
 /** Convert stroops to a human-readable USDC amount. */

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -10,21 +10,45 @@ export default defineConfig([
     sourcemap: true,
     target: "node18",
     outDir: "dist",
+    treeshake: true,
   },
-  // Browser: IIFE (UMD-compatible) + ESM, no Node.js built-ins
+  // Browser: minified IIFE (UMD-compatible) with explicit global name
+  // Global exposed as `window.SwiftRemitSDK` when loaded via <script> tag / CDN.
   {
     entry: { "browser/index": "src/index.ts" },
-    format: ["iife", "esm"],
+    format: ["iife"],
     globalName: "SwiftRemitSDK",
+    minify: true,
     dts: false,
     clean: false,
     sourcemap: true,
     target: "es2020",
     outDir: "dist",
     platform: "browser",
-    // Prevent Node.js built-ins from leaking into the browser bundle
+    // Bundle everything needed for the browser; only leave out the Stellar SDK
+    // because CDN users are expected to load it separately (see CDN_USAGE.md).
     noExternal: [],
     external: ["@stellar/stellar-sdk"],
+    treeshake: true,
+    esbuildOptions(options) {
+      options.conditions = ["browser"];
+    },
+  },
+  // Browser: ESM build for bundlers (Vite, webpack, Rollup).
+  // Enables tree-shaking so bundlers can drop unused exports.
+  {
+    entry: { "browser/index.esm": "src/index.ts" },
+    format: ["esm"],
+    minify: false,
+    dts: false,
+    clean: false,
+    sourcemap: true,
+    target: "es2020",
+    outDir: "dist",
+    platform: "browser",
+    noExternal: [],
+    external: ["@stellar/stellar-sdk"],
+    treeshake: true,
     esbuildOptions(options) {
       options.conditions = ["browser"];
     },


### PR DESCRIPTION
Closes #1159 (SR-089) — Add a browser bundle with documented CDN usage Closes #1160 (SR-090) — Add SDK-level input validation before transaction construction

════════════════════════════════════════════════════════════════════════ ISSUE #1159 — SR-089: Browser bundle + CDN usage docs ════════════════════════════════════════════════════════════════════════

Problem
-------
The SDK could produce a browser IIFE bundle via tsup but it was neither minified, nor documented, nor had a known/enforced gzipped size.  CDN consumers had no guidance on which polyfills the Stellar SDK requires (Buffer, TextEncoder, etc.) and bundler consumers (Vite/webpack) had no example of how to wire up the Buffer polyfill or tree-shake unused exports.

Changes
-------
sdk/tsup.config.ts
  • IIFE browser target: added minify:true and treeshake:true so the CDN
    build is properly compressed and dead code is removed.
  • Added a separate ESM browser build entry (browser/index.esm.mjs) with
    treeshake:true for bundler consumers (Vite, webpack, Rollup, esbuild).
  • All three build targets (Node CJS/ESM, IIFE, ESM browser) now use
    treeshake:true.
  • globalName is explicitly 'SwiftRemitSDK' — window.SwiftRemitSDK is the
    documented global for script-tag consumers.

sdk/package.json
  • Updated 'browser' field to point to dist/browser/index.global.js (the
    minified IIFE produced by tsup).
  • Updated 'exports['.'].browser' to point to the new ESM browser build
    (dist/browser/index.esm.mjs) so bundlers get the tree-shakeable version.
  • Added 'size-limit' and '@size-limit/preset-small-lib' as devDependencies.
  • Added 'size' and 'size:ci' npm scripts backed by size-limit.
  • Declared three size-limit budgets in package.json:
      - dist/browser/index.global.js   ≤ 120 kB gzipped
      - dist/browser/index.esm.mjs     ≤ 120 kB gzipped
      - dist/index.js                  ≤ 150 kB gzipped
  • Added CDN_USAGE.md to the 'files' list so it ships with the npm package.

sdk/CDN_USAGE.md (new file)
  • Step-by-step CDN example: load Buffer polyfill → Stellar SDK → SwiftRemit
    SDK → application code, all via <script> tags / esm.sh / unpkg.
  • Polyfill compatibility table: Buffer (required), TextEncoder/TextDecoder
    (built-in modern browsers), fetch (built-in modern browsers), Web Crypto
    (HTTPS only, built-in modern browsers).
  • Bundler quick-start for Vite (NodeGlobalsPolyfillPlugin) and webpack 5
    (ProvidePlugin + resolve.fallback) with copy-paste configs.
  • Bundle size budget table and instructions to run 'npm run size' locally.
  • Tree-shaking verification guidance using vite-bundle-visualizer.

sdk/src/browser.smoke.test.ts (new file)
  • Vitest smoke test that runs in a browser-like environment.
  • Covers: export presence (SwiftRemitClient, Networks, RpcUrls,
    USDC_MULTIPLIER, validateAmount, validateAddress, estimateStellarFee),
    toStroops/fromStroops correctness and round-trip, input validation
    integration (see #1160), SwiftRemitClient instantiation surface, and
    RangeError from estimateStellarFee.
  • Does NOT make real RPC network calls — purely validates the public API
    surface that a CDN bundle consumer would see.

.github/workflows/sdk-ci.yml (new file)
  • Dedicated CI workflow triggered on any push/PR that touches sdk/.
  • Job 1 (sdk-test): npm ci → type-check → vitest run → build.
  • Job 2 (sdk-bundle-size, depends on sdk-test): npm ci → build →
    npx size-limit --json; fails the workflow if any budget is exceeded.
  • Uploads dist/browser/ files as a downloadable artifact (14-day retention).

════════════════════════════════════════════════════════════════════════ ISSUE #1160 — SR-090: SDK-level input validation before TX construction ════════════════════════════════════════════════════════════════════════

Problem
-------
sdk/src/convert.ts exposed toStroops(usdc: number) which used Math.round internally, silently accepting floats (e.g. toStroops(1.9999999) rounded to a wrong amount) and negative numbers.  addressToScVal called Address.fromString directly, producing an opaque XDR error on bad input rather than a clear actionable message.  client.ts passed amounts and addresses straight to i128ToScVal / addressToScVal with no validation layer, so a float or a malformed address only surfaced as a confusing RPC error after a round-trip to the Soroban node.

Changes
-------
sdk/src/convert.ts
  • New export validateAmount(amount: bigint): void
      - Asserts typeof === 'bigint'; throws SwiftRemitError(InvalidAmount) with a message explaining that floats must not be passed.
      - Asserts amount > 0n; throws on zero or negative values. • New export validateAddress(address: string): void - Asserts typeof === 'string' && length > 0. - Asserts length === 56 (Stellar StrKey is always 56 chars). - Asserts first character is 'G' (account) or 'C' (contract). - Asserts full match against /^[A-Z2-7]{56}$/ (Base32 StrKey alphabet). - All violations throw SwiftRemitError(InvalidAddress) with a message that names the failing rule and shows the received value. • addressToScVal now calls validateAddress(address) before calling Address.fromString, replacing the opaque XDR error with our typed error.

sdk/src/index.ts
  • toStroops rewritten:
      - Throws RangeError if usdc < 0.
      - Throws RangeError if usdc * USDC_MULTIPLIER is not an integer (i.e. the input has too many decimal places to map to a whole stroop). - Throws RangeError if the result is not a safe integer (overflow). - Removes the Math.round call that previously masked precision loss. • Exports validateAmount and validateAddress from convert.js so consumers can call them independently before constructing any transaction.

sdk/src/client.ts
  • createRemittance: calls validateAddress(params.sender),
    validateAddress(params.agent), validateAmount(params.amount), and
    validateAddress(params.token) (when a token override is supplied) before
    any call to prepareTransaction / XDR construction.
  • batchCreateRemittances: calls validateAddress(sender) once, then iterates
    all entries calling validateAddress(e.agent) and validateAmount(e.amount).
    Validation errors are re-thrown as SwiftRemitError with the batch index
    prepended to the message (e.g. 'Batch entry [2]: Amount must be …') so
    callers know exactly which item is invalid.

How it was done
---------------
All validation is intentionally pure (no I/O, no RPC) and runs synchronously before the first async call in any transaction-building path.  This means:
  • Invalid input fails immediately, not after a network round-trip.
  • The error type is SwiftRemitError (or RangeError for toStroops), both of
    which the existing error-handling infrastructure already surfaces cleanly.
  • No breaking change to the TypeScript types — amounts were already typed
    as bigint in CreateRemittanceParams; the runtime guard just enforces what
    the types imply.