### PR TITLE
feat(mobile): secure session handling with token refresh and inactivity timeout (SR-093)

### DIFF
--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,32 +1,96 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import Constants from 'expo-constants';
 import { Remittance, KycStatus, FxRate, SendMoneyFormData } from '../types';
 
 const BASE_URL = Constants.expoConfig?.extra?.apiUrl || 'http://localhost:3000';
 
-const http = axios.create({ baseURL: BASE_URL, timeout: 15000 });
+// Inactivity window after which the session is considered stale and the
+// stored access token must be discarded, forcing re-authentication.
+const SESSION_INACTIVITY_MS = 15 * 60 * 1000;
+
+const SECRET_KEYS = ['auth_token', 'wallet_address', 'last_active'];
+
+const http = axios.create({ baseURL: BASE_URL, timeout: 15000, withCredentials: true });
+
+async function clearAllSecrets(): Promise<void> {
+  await Promise.all(SECRET_KEYS.map((key) => SecureStore.deleteItemAsync(key)));
+}
+
+async function touchActivity(): Promise<void> {
+  await SecureStore.setItemAsync('last_active', String(Date.now()));
+}
+
+async function isSessionExpired(): Promise<boolean> {
+  const lastActive = await SecureStore.getItemAsync('last_active');
+  if (!lastActive) return false;
+  return Date.now() - Number(lastActive) > SESSION_INACTIVITY_MS;
+}
 
 http.interceptors.request.use(async (config) => {
+  if (await isSessionExpired()) {
+    await clearAllSecrets();
+    return Promise.reject(new Error('Session expired due to inactivity'));
+  }
   const token = await SecureStore.getItemAsync('auth_token');
   if (token) config.headers.Authorization = `Bearer ${token}`;
+  await touchActivity();
   return config;
 });
+
+interface RetriableRequestConfig extends AxiosRequestConfig {
+  _retried?: boolean;
+}
+
+http.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (!axios.isAxiosError(error)) return Promise.reject(error);
+    const original = error.config as RetriableRequestConfig | undefined;
+    if (error.response?.status === 401 && original && !original._retried) {
+      original._retried = true;
+      try {
+        const { data } = await axios.post(
+          `${BASE_URL}/api/auth/refresh`,
+          {},
+          { withCredentials: true },
+        );
+        await SecureStore.setItemAsync('auth_token', data.data.access_token);
+        await touchActivity();
+        original.headers = { ...original.headers, Authorization: `Bearer ${data.data.access_token}` };
+        return http(original);
+      } catch (refreshError) {
+        await clearAllSecrets();
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
 
 export const authService = {
   async login(walletAddress: string, signature: string): Promise<{ token: string }> {
     const { data } = await http.post('/api/auth/login', { walletAddress, signature });
     await SecureStore.setItemAsync('auth_token', data.token);
     await SecureStore.setItemAsync('wallet_address', walletAddress);
+    await touchActivity();
     return data;
   },
 
   async logout(): Promise<void> {
-    await SecureStore.deleteItemAsync('auth_token');
-    await SecureStore.deleteItemAsync('wallet_address');
+    try {
+      await http.post('/api/auth/logout');
+    } catch {
+      // best-effort server-side revocation; local secrets are cleared regardless
+    }
+    await clearAllSecrets();
   },
 
   async getStoredWallet(): Promise<string | null> {
+    if (await isSessionExpired()) {
+      await clearAllSecrets();
+      return null;
+    }
     return SecureStore.getItemAsync('wallet_address');
   },
 };


### PR DESCRIPTION
## Summary
- Mobile API client now sends cookies (`withCredentials`) so the backend's existing HttpOnly, rotating refresh-token cookie (`/api/auth/refresh`) can be used to silently mint a new access token on a 401, instead of failing the request. The refresh token itself is never exposed to JS/SecureStore.
- Added an inactivity timeout: the client tracks `last_active` in SecureStore and treats the session as expired after 15 minutes idle, wiping all stored secrets on the next request.
- `authService.logout()` now calls `POST /api/auth/logout` to revoke the session server-side, then unconditionally clears every locally stored secret (`auth_token`, `wallet_address`, `last_active`).

An audit of `mobile/src` found no secrets persisted to `AsyncStorage` — tokens and wallet address were already in `expo-secure-store`, so this PR focuses on the missing refresh/rotation and inactivity-timeout requirements from the issue.

Closes #1163

## Validation performed
- Manual review of `mobile/src/services/api.ts` against the existing `api/src/routes/auth.ts` contract (login/refresh/logout, cookie-based refresh rotation, 15 min access token TTL).
- No local `node_modules`/lint tooling available in this environment to run `npm run lint`/`tsc` for the mobile package; changes were written to satisfy the package's `strict` TypeScript config (explicit `RetriableRequestConfig` type, `axios.isAxiosError` guard).