### PR TITLE
feat(mobile): add offline read caching and connectivity-aware UI (SR-094)

### DIFF
--- a/mobile/src/components/OfflineBanner.tsx
+++ b/mobile/src/components/OfflineBanner.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useNetworkStatus } from '../services/offlineCache';
+
+export default function OfflineBanner() {
+  const { isOffline, isReconnecting } = useNetworkStatus();
+
+  if (!isOffline && !isReconnecting) return null;
+
+  return (
+    <View style={[styles.banner, isReconnecting ? styles.reconnecting : styles.offline]}>
+      <Text style={styles.text}>
+        {isReconnecting ? 'Reconnecting…' : "You're offline — showing cached data"}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: { paddingVertical: 8, paddingHorizontal: 16 },
+  offline: { backgroundColor: '#EF4444' },
+  reconnecting: { backgroundColor: '#F59E0B' },
+  text: { color: '#fff', fontWeight: '600', fontSize: 13, textAlign: 'center' },
+});

--- a/mobile/src/screens/KycStatusScreen.tsx
+++ b/mobile/src/screens/KycStatusScreen.tsx
@@ -10,6 +10,8 @@ import {
 } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { kycService } from '../services/api';
+import { readThroughCache } from '../services/offlineCache';
+import OfflineBanner from '../components/OfflineBanner';
 import { KycStatus } from '../types';
 
 const DEFAULT_ANCHOR = 'testanchor.stellar.org';
@@ -46,14 +48,16 @@ export default function KycStatusScreen() {
   const [status, setStatus] = useState<KycStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [cachedAt, setCachedAt] = useState<number | null>(null);
 
   useEffect(() => {
     (async () => {
       try {
         const wallet = await SecureStore.getItemAsync('wallet_address');
         if (!wallet) { setError('Not logged in'); return; }
-        const data = await kycService.getStatus(wallet, DEFAULT_ANCHOR);
-        setStatus(data);
+        const result = await readThroughCache(`kyc:${wallet}`, () => kycService.getStatus(wallet, DEFAULT_ANCHOR));
+        setStatus(result.data);
+        setCachedAt(result.fromCache ? result.cachedAt : null);
       } catch {
         setError('Failed to load KYC status.');
       } finally {
@@ -78,6 +82,13 @@ export default function KycStatusScreen() {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <OfflineBanner />
+      {cachedAt ? (
+        <Text style={styles.staleText}>
+          Showing cached data from {new Date(cachedAt).toLocaleString()}
+        </Text>
+      ) : null}
+
       <View style={[styles.badge, { backgroundColor: `${info.color}22` }]}>
         <Text style={[styles.badgeText, { color: info.color }]}>{info.label}</Text>
       </View>
@@ -153,4 +164,5 @@ const styles = StyleSheet.create({
   btnText: { color: '#fff', fontWeight: '700', fontSize: 16 },
   updated: { color: '#9CA3AF', fontSize: 12, marginTop: 24, textAlign: 'center' },
   errorText: { color: '#EF4444', fontSize: 16 },
+  staleText: { fontSize: 12, color: '#9CA3AF', textAlign: 'center', marginBottom: 12 },
 });

--- a/mobile/src/screens/SendMoneyScreen.tsx
+++ b/mobile/src/screens/SendMoneyScreen.tsx
@@ -12,6 +12,8 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { remittanceService, fxService } from '../services/api';
 import { authenticateWithBiometrics } from '../services/biometrics';
+import { useNetworkStatus } from '../services/offlineCache';
+import OfflineBanner from '../components/OfflineBanner';
 import { SendMoneyFormData, FxRate } from '../types';
 
 const SUPPORTED_CURRENCIES = ['PHP', 'MXN', 'INR', 'NGN', 'GHS', 'KES', 'UGX'];
@@ -21,6 +23,7 @@ export default function SendMoneyScreen() {
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [loading, setLoading] = useState(false);
   const [fxRate, setFxRate] = useState<FxRate | null>(null);
+  const { isOffline } = useNetworkStatus();
 
   const [form, setForm] = useState<SendMoneyFormData>({
     recipientName: '',
@@ -45,6 +48,10 @@ export default function SendMoneyScreen() {
       : '—';
 
   async function handleConfirm() {
+    if (isOffline) {
+      Alert.alert('You\'re offline', 'Connect to the internet to send money.');
+      return;
+    }
     setLoading(true);
     try {
       const confirmed = await authenticateWithBiometrics('Confirm your transfer with biometrics');
@@ -64,6 +71,7 @@ export default function SendMoneyScreen() {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <OfflineBanner />
       {step === 1 && (
         <>
           <Text style={styles.heading}>Who are you sending to?</Text>
@@ -177,14 +185,14 @@ export default function SendMoneyScreen() {
               <Text style={styles.btnOutlineText}>Back</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.btn, styles.btnFlex, loading && styles.btnDisabled]}
-              disabled={loading}
+              style={[styles.btn, styles.btnFlex, (loading || isOffline) && styles.btnDisabled]}
+              disabled={loading || isOffline}
               onPress={handleConfirm}
             >
               {loading ? (
                 <ActivityIndicator color="#fff" />
               ) : (
-                <Text style={styles.btnText}>Confirm & Send</Text>
+                <Text style={styles.btnText}>{isOffline ? 'Offline' : 'Confirm & Send'}</Text>
               )}
             </TouchableOpacity>
           </View>

--- a/mobile/src/screens/TransactionHistoryScreen.tsx
+++ b/mobile/src/screens/TransactionHistoryScreen.tsx
@@ -11,6 +11,8 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import * as SecureStore from 'expo-secure-store';
 import { remittanceService } from '../services/api';
+import { readThroughCache } from '../services/offlineCache';
+import OfflineBanner from '../components/OfflineBanner';
 import { Remittance, RemittanceStatus } from '../types';
 
 const STATUS_COLORS: Record<RemittanceStatus, string> = {
@@ -38,15 +40,17 @@ export default function TransactionHistoryScreen() {
   const [remittances, setRemittances] = useState<Remittance[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [cachedAt, setCachedAt] = useState<number | null>(null);
 
   const load = useCallback(async () => {
     try {
       const wallet = await SecureStore.getItemAsync('wallet_address');
       if (!wallet) return;
-      const data = await remittanceService.getHistory(wallet);
-      setRemittances(data);
+      const result = await readThroughCache(`history:${wallet}`, () => remittanceService.getHistory(wallet));
+      setRemittances(result.data);
+      setCachedAt(result.fromCache ? result.cachedAt : null);
     } catch {
-      // keep stale data on error
+      // no live data and no cache available — keep whatever is on screen
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -71,6 +75,16 @@ export default function TransactionHistoryScreen() {
       data={remittances}
       keyExtractor={(item) => item.remittance_id}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      ListHeaderComponent={
+        <>
+          <OfflineBanner />
+          {cachedAt ? (
+            <Text style={styles.staleText}>
+              Showing cached data from {new Date(cachedAt).toLocaleString()}
+            </Text>
+          ) : null}
+        </>
+      }
       ListEmptyComponent={
         <View style={styles.empty}>
           <Text style={styles.emptyText}>No transfers yet.</Text>
@@ -124,4 +138,5 @@ const styles = StyleSheet.create({
   empty: { flex: 1, alignItems: 'center', paddingTop: 80 },
   emptyText: { fontSize: 18, fontWeight: '600', color: '#374151' },
   emptySubtext: { fontSize: 14, color: '#9CA3AF', marginTop: 8 },
+  staleText: { fontSize: 12, color: '#9CA3AF', textAlign: 'center', paddingVertical: 8 },
 });

--- a/mobile/src/services/offlineCache.ts
+++ b/mobile/src/services/offlineCache.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
+
+const CACHE_PREFIX = 'cache:';
+
+// Reads older than this are still shown, but flagged as stale in the UI.
+const STALE_AFTER_MS = 10 * 60 * 1000;
+
+interface CacheEntry<T> {
+  data: T;
+  cachedAt: number;
+}
+
+export interface ReadThroughResult<T> {
+  data: T;
+  fromCache: boolean;
+  stale: boolean;
+  cachedAt: number | null;
+}
+
+/**
+ * Fetches fresh data and caches it for offline reads. If the fetch fails
+ * (e.g. no connectivity), falls back to the last cached value for that key
+ * and marks the result as stale/from-cache instead of erroring out.
+ * Only ever used for safe, idempotent reads — never for money-moving calls.
+ */
+export async function readThroughCache<T>(key: string, fetcher: () => Promise<T>): Promise<ReadThroughResult<T>> {
+  const storageKey = CACHE_PREFIX + key;
+  try {
+    const data = await fetcher();
+    const entry: CacheEntry<T> = { data, cachedAt: Date.now() };
+    await AsyncStorage.setItem(storageKey, JSON.stringify(entry));
+    return { data, fromCache: false, stale: false, cachedAt: entry.cachedAt };
+  } catch (err) {
+    const raw = await AsyncStorage.getItem(storageKey);
+    if (!raw) throw err;
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    return {
+      data: entry.data,
+      fromCache: true,
+      stale: Date.now() - entry.cachedAt > STALE_AFTER_MS,
+      cachedAt: entry.cachedAt,
+    };
+  }
+}
+
+export function useNetworkStatus(): { isOffline: boolean; isReconnecting: boolean } {
+  const [isOffline, setIsOffline] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const wasOffline = useRef(false);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      const offline = state.isConnected === false || state.isInternetReachable === false;
+      if (wasOffline.current && !offline) setIsReconnecting(true);
+      wasOffline.current = offline;
+      setIsOffline(offline);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!isReconnecting) return;
+    const timeout = setTimeout(() => setIsReconnecting(false), 2000);
+    return () => clearTimeout(timeout);
+  }, [isReconnecting]);
+
+  return { isOffline, isReconnecting };
+}


### PR DESCRIPTION
## Summary
- Added `readThroughCache()` (mobile/src/services/offlineCache.ts): fetches live data and caches it via AsyncStorage for safe, idempotent reads; on fetch failure it transparently falls back to the last cached value, marking it stale rather than erroring the screen.
- Added `useNetworkStatus()` hook (NetInfo-backed) and an `OfflineBanner` component that distinguishes offline / reconnecting / online.
- `TransactionHistoryScreen` and `KycStatusScreen` now read through the cache and show a "Showing cached data from <time>" indicator when serving stale data.
- `SendMoneyScreen` shows the offline banner, disables the "Confirm & Send" button while offline, and `handleConfirm` short-circuits with an alert if offline — the money-moving remittance call is never queued or auto-replayed on reconnect.

Closes #1164

## Validation performed
- Manual review of all touched files against the existing `expo-secure-store`/`axios` service layer and `@react-native-async-storage/async-storage` + `@react-native-community/netinfo`, both already present in `mobile/package.json`, so no new native dependency was introduced.
- No local `node_modules`/lint tooling available in this environment to run `npm run lint`/`tsc` for the mobile package; changes follow the existing file conventions and the package's `strict` TypeScript config.