### PR TITLE
Set testnet placeholder contract/USDC env vars for Vercel build

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -9,7 +9,9 @@
   "env": {
     "VITE_NETWORK": "testnet",
     "VITE_HORIZON_URL": "https://horizon-testnet.stellar.org",
-    "VITE_SOROBAN_RPC_URL": "https://soroban-testnet.stellar.org"
+    "VITE_SOROBAN_RPC_URL": "https://soroban-testnet.stellar.org",
+    "VITE_CONTRACT_ID": "CTESTNETPLACEHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "VITE_USDC_ISSUER": "GTESTNETPLACEHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
   },
   "headers": [
     {


### PR DESCRIPTION
## Summary
PR #1258 merged before this follow-up commit was pushed, so it never landed on `main`. Re-opening it here.

- Fixes the Vercel build failure (`npm install --legacy-peer-deps && npm run build` exiting 1) caused by missing `VITE_CONTRACT_ID`/`VITE_USDC_ISSUER`
- Adds well-formed **placeholder** testnet values to `frontend/vercel.json`'s `env` block so the build passes and the site loads
- These are fake values (not a real deployed contract / issuer) — swap them for real ones once the SwiftRemit contract is deployed to testnet/mainnet. Sending remittances or fetching contract events will error with a clear message until then.

## Test plan
- [x] `npm run build` succeeds locally with these values
- [ ] Vercel redeploy succeeds and the app loads (no more build failure)
- [ ] Replace placeholders with real `VITE_CONTRACT_ID`/`VITE_USDC_ISSUER` once a contract is deployed